### PR TITLE
fix(renderer): make embedded Excalidraw diagrams visible

### DIFF
--- a/RendererPackages/Excalidraw/manifest.json
+++ b/RendererPackages/Excalidraw/manifest.json
@@ -1,12 +1,12 @@
 {
   "revision": 1,
   "packageID": "org.selfdrivingwiki.excalidraw-readonly",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "descriptors": [
     {
       "reference": {
         "packageID": "org.selfdrivingwiki.excalidraw-readonly",
-        "version": "1.0.0",
+        "version": "1.0.1",
         "registrationID": "excalidraw"
       },
       "displayName": "Excalidraw",
@@ -56,7 +56,7 @@
         },
         {
           "path": "viewer.js",
-          "digest": "9a05ed23438ce8bbf7edbf9d5350c9cec8480a6686c99dc9e1b47579f33bd69b"
+          "digest": "67cebc707a02e1dd769f1af90a27eb2c4f37bfb13c0913c265d15e1a701b0571"
         }
       ],
       "capabilities": [
@@ -98,7 +98,7 @@
     },
     {
       "path": "viewer.js",
-      "digest": "9a05ed23438ce8bbf7edbf9d5350c9cec8480a6686c99dc9e1b47579f33bd69b"
+      "digest": "67cebc707a02e1dd769f1af90a27eb2c4f37bfb13c0913c265d15e1a701b0571"
     }
   ]
 }

--- a/RendererPackages/Excalidraw/viewer.js
+++ b/RendererPackages/Excalidraw/viewer.js
@@ -24,6 +24,33 @@
     viewer.replaceChildren(Object.assign(document.createElement("p"), { className: "message", textContent: text }));
   }
 
+  // A drawing carries its own canvas colour, and its element colours were
+  // chosen against it. Excalidraw's default `#ffffff` with near-black strokes
+  // disappears on a dark system canvas, so the declared background is applied
+  // and the system colour keywords underneath it (`Canvas`, `CanvasText`) are
+  // resolved for that background rather than for the viewer's appearance.
+  const hexColorPattern = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+  function documentBackground(appState) {
+    const value = appState && appState.viewBackgroundColor;
+    return typeof value === "string" && hexColorPattern.test(value) ? value : null;
+  }
+
+  function isLightBackground(hex) {
+    const digits = hex.slice(1);
+    const expanded = digits.length === 3 ? digits.replace(/./g, (d) => d + d) : digits;
+    const channel = (offset) => parseInt(expanded.slice(offset, offset + 2), 16) / 255;
+    // Rec. 601 luma is enough to pick a light or dark colour scheme.
+    return 0.299 * channel(0) + 0.587 * channel(2) + 0.114 * channel(4) > 0.5;
+  }
+
+  function applyDocumentBackground(appState) {
+    const color = documentBackground(appState);
+    if (color === null) return;
+    viewer.style.backgroundColor = color;
+    viewer.style.setProperty("color-scheme", isLightBackground(color) ? "light" : "dark");
+  }
+
   function bounds(elements) {
     const active = elements.filter((element) => element && element.isDeleted !== true && Number.isFinite(element.x) && Number.isFinite(element.y));
     if (active.length === 0) return { x: 0, y: 0, width: 1, height: 1 };
@@ -75,6 +102,7 @@
       showMessage("This drawing is not a supported Excalidraw document.");
       return;
     }
+    applyDocumentBackground(documentValue.appState);
     const svg = makeSVG("svg", { class: "scene", role: "img", "aria-label": "Read-only Excalidraw drawing" });
     const scene = makeSVG("g");
     documentValue.elements.map(renderElement).filter(Boolean).forEach((node) => scene.append(node));

--- a/Sources/WikiFS/Reader/ExcalidrawStaticPreview.swift
+++ b/Sources/WikiFS/Reader/ExcalidrawStaticPreview.swift
@@ -1,0 +1,228 @@
+import Foundation
+import WikiFSMarkdown
+
+// pattern: Functional Core — bytes in, markup out, no host state.
+
+/// A bounded, host-generated SVG preview of an Excalidraw drawing.
+///
+/// The reader's renderer card is a static surface: it may not run the package's
+/// JavaScript, so the card draws the drawing itself. This covers the same
+/// element subset the bundled viewer does, which is enough to recognise a
+/// diagram at a glance; the Interact control still opens the real renderer for
+/// panning, zooming, and links.
+///
+/// Pure and nonisolated by construction — Markdown conversion runs off the main
+/// actor, so this takes bytes and returns markup with no store and no actor.
+///
+/// Two rules keep author-controlled JSON safe in reader HTML: every colour must
+/// match a strict hex form before it reaches an attribute, and an element's
+/// `link` is deliberately dropped. The interactive viewer wraps a linked shape
+/// in an `<a>`; the reader must never take an `href` from a fence.
+enum ExcalidrawStaticPreview {
+    /// Enough to draw a real diagram, few enough that a pathological document
+    /// cannot bloat the page. Input is already bounded to 48 KB upstream.
+    static let maximumElementCount = 400
+
+    /// Excalidraw's own default canvas. A drawing's colours were chosen against
+    /// its canvas, so the preview always paints one — near-black strokes on the
+    /// reader's dark background would otherwise be invisible.
+    static let defaultBackground = "#ffffff"
+    static let defaultStroke = "#1e1e1e"
+
+    static let padding = 12.0
+    static let defaultFontSize = 16.0
+    static let defaultStrokeWidth = 2.0
+    static let cornerRadius = 8.0
+
+    /// Returns the SVG for a valid drawing, or nil when the bytes are not a
+    /// drawing this can render. A nil result leaves the card intact and silent
+    /// rather than claiming a preview it cannot produce.
+    static func svg(from bytes: Data) -> String? {
+        // A fence whose JSON does not parse is an ordinary authoring state, not
+        // a host failure: the card still renders and Interact still opens the
+        // renderer, which reports the real problem. Conversion re-runs on every
+        // render, so logging here would repeat for every keystroke.
+        // swiftlint:disable:next silent_try_optional
+        guard let root = try? JSONSerialization.jsonObject(with: bytes) as? [String: Any],
+              root["type"] as? String == "excalidraw",
+              let rawElements = root["elements"] as? [[String: Any]]
+        else { return nil }
+
+        let elements = rawElements
+            .filter { $0["isDeleted"] as? Bool != true }
+            .prefix(maximumElementCount)
+        let shapes = elements.compactMap(shape(for:))
+        guard shapes.isEmpty == false, let box = bounds(of: elements) else { return nil }
+
+        let originX = box.minX - padding
+        let originY = box.minY - padding
+        let width = box.width + padding * 2
+        let height = box.height + padding * 2
+        let canvas = tag("rect", [
+            ("x", number(originX)), ("y", number(originY)),
+            ("width", number(width)), ("height", number(height)),
+            ("fill", color(root["appState"] as? [String: Any]) ?? defaultBackground),
+        ])
+        let viewBox = [originX, originY, width, height].map(number).joined(separator: " ")
+        return tag(
+            "svg",
+            [
+                ("viewBox", viewBox),
+                ("role", "img"),
+                ("aria-label", "Preview of an Excalidraw drawing"),
+                ("preserveAspectRatio", "xMidYMid meet"),
+            ],
+            content: canvas + shapes.joined())
+    }
+
+    // MARK: Geometry
+
+    private struct Box {
+        var minX: Double
+        var minY: Double
+        var width: Double
+        var height: Double
+    }
+
+    private static func bounds(of elements: some Sequence<[String: Any]>) -> Box? {
+        var minX = Double.infinity, minY = Double.infinity
+        var maxX = -Double.infinity, maxY = -Double.infinity
+        for element in elements {
+            guard let x = numeric(element["x"]), let y = numeric(element["y"]) else { continue }
+            minX = min(minX, x)
+            minY = min(minY, y)
+            maxX = max(maxX, x + (numeric(element["width"]) ?? 0))
+            maxY = max(maxY, y + (numeric(element["height"]) ?? 0))
+        }
+        guard minX.isFinite, minY.isFinite, maxX.isFinite, maxY.isFinite else { return nil }
+        // A single point or a flat connector still needs a drawable box.
+        return Box(minX: minX, minY: minY, width: max(1, maxX - minX), height: max(1, maxY - minY))
+    }
+
+    // MARK: Elements
+
+    private static func shape(for element: [String: Any]) -> String? {
+        guard let x = numeric(element["x"]), let y = numeric(element["y"]) else { return nil }
+        let width = max(0, numeric(element["width"]) ?? 0)
+        let height = max(0, numeric(element["height"]) ?? 0)
+        let stroke = color(element["strokeColor"]) ?? defaultStroke
+        let strokeWidth = number(numeric(element["strokeWidth"]) ?? defaultStrokeWidth)
+        let outline = [
+            ("fill", color(element["backgroundColor"]) ?? "none"),
+            ("stroke", stroke),
+            ("stroke-width", strokeWidth),
+        ] + opacity(element)
+
+        switch element["type"] as? String {
+        case "rectangle":
+            let radius = element["roundness"] is [String: Any] ? cornerRadius : 0
+            return tag("rect", [
+                ("x", number(x)), ("y", number(y)),
+                ("width", number(width)), ("height", number(height)),
+                ("rx", number(radius)),
+            ] + outline)
+        case "ellipse":
+            return tag("ellipse", [
+                ("cx", number(x + width / 2)), ("cy", number(y + height / 2)),
+                ("rx", number(width / 2)), ("ry", number(height / 2)),
+            ] + outline)
+        case "diamond":
+            let corners = [
+                (x + width / 2, y), (x + width, y + height / 2),
+                (x + width / 2, y + height), (x, y + height / 2),
+            ]
+            return tag("polygon", [("points", points(corners))] + outline)
+        case "line", "arrow", "freedraw":
+            guard let plotted = polyline(of: element, originX: x, originY: y) else { return nil }
+            return tag("polyline", [
+                ("points", points(plotted)), ("fill", "none"),
+                ("stroke", stroke), ("stroke-width", strokeWidth),
+            ] + opacity(element))
+        case "text":
+            guard let text = element["text"] as? String, text.isEmpty == false else { return nil }
+            return tag(
+                "text",
+                [
+                    ("x", number(x)), ("y", number(y)), ("fill", stroke),
+                    ("font-size", number(numeric(element["fontSize"]) ?? defaultFontSize)),
+                    ("dominant-baseline", "hanging"),
+                    ("font-family", "-apple-system, BlinkMacSystemFont, sans-serif"),
+                ] + opacity(element),
+                content: HTMLEntities.escapeHTML(text))
+        default:
+            return nil
+        }
+    }
+
+    /// Connector points are stored relative to the element's origin.
+    private static func polyline(
+        of element: [String: Any],
+        originX: Double,
+        originY: Double
+    ) -> [(Double, Double)]? {
+        guard let raw = element["points"] as? [[Any]] else { return nil }
+        let plotted = raw.compactMap { pair -> (Double, Double)? in
+            guard pair.count >= 2, let dx = numeric(pair[0]), let dy = numeric(pair[1])
+            else { return nil }
+            return (originX + dx, originY + dy)
+        }
+        return plotted.count >= 2 ? plotted : nil
+    }
+
+    private static func opacity(_ element: [String: Any]) -> [(String, String)] {
+        // Excalidraw stores opacity as a percentage.
+        guard let value = numeric(element["opacity"]), value >= 0, value < 100 else { return [] }
+        return [("opacity", number(value / 100))]
+    }
+
+    private static func points(_ values: [(Double, Double)]) -> String {
+        values.map { "\(number($0.0)),\(number($0.1))" }.joined(separator: " ")
+    }
+
+    // MARK: Markup
+
+    /// Attribute values come from validated numbers, fixed keywords, and
+    /// hex colours only, so they need no further escaping; element text is
+    /// escaped by the caller.
+    private static func tag(
+        _ name: String,
+        _ attributes: [(String, String)],
+        content: String? = nil
+    ) -> String {
+        let rendered = attributes.map { "\($0.0)=\"\($0.1)\"" }.joined(separator: " ")
+        guard let content else { return "<\(name) \(rendered)/>" }
+        return "<\(name) \(rendered)>\(content)</\(name)>"
+    }
+
+    // MARK: Scalars
+
+    /// Only `#rgb` and `#rrggbb` reach an attribute. Anything else — including
+    /// Excalidraw's `"transparent"` — is treated as absent by the caller.
+    private static func color(_ value: Any?) -> String? {
+        guard let text = value as? String, text.hasPrefix("#") else { return nil }
+        let digits = text.dropFirst()
+        guard digits.count == 3 || digits.count == 6,
+              digits.allSatisfy(\.isHexDigit)
+        else { return nil }
+        return text
+    }
+
+    private static func color(_ appState: [String: Any]?) -> String? {
+        color(appState?["viewBackgroundColor"])
+    }
+
+    private static func numeric(_ value: Any?) -> Double? {
+        if let value = value as? Double { return value.isFinite ? value : nil }
+        if let value = value as? Int { return Double(value) }
+        return nil
+    }
+
+    private static func number(_ value: Double) -> String {
+        guard value.isFinite else { return "0" }
+        let rounded = (value * 100).rounded() / 100
+        guard rounded != rounded.rounded(), abs(rounded) < 1e9 else {
+            return String(Int(rounded.rounded()))
+        }
+        return String(rounded)
+    }
+}

--- a/Sources/WikiFS/Reader/MarkdownHTMLRenderer.swift
+++ b/Sources/WikiFS/Reader/MarkdownHTMLRenderer.swift
@@ -319,7 +319,15 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
         }()
         let placeholderID = escapeAttribute(plan.placeholderID)
         let summary = escape(plan.semanticContent)
-        let fallback = escape(plan.fallbackReason?.rawValue ?? "static preview")
+        // The card used to print the literal "static preview" whenever nothing
+        // had failed, promising a preview it never drew, and the raw enum case
+        // name when something had. Draw the real thing, and say why when there
+        // is nothing to draw.
+        let previewHTML = Self.previewHTML(for: plan)
+        let fallbackNoticeHTML: String = {
+            guard let reason = plan.fallbackReason else { return "" }
+            return #"<p class="sdw-renderer-card__fallback">\#(escape(Self.fallbackNotice(for: reason)))</p>"#
+        }()
         let control = escape(plan.activationMetadata?.controlLabel ?? "Open")
         let aria = escapeAttribute(plan.activationMetadata?.accessibilityLabel ?? "renderer preview")
         let mimeType: String? = {
@@ -383,10 +391,43 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
         <section class="sdw-renderer-card" id="\(placeholderID)" role="group" aria-label="\(aria)" data-renderer-reference="\(escapeAttribute(refValue))"\(inputAttribute)>
           <header class="sdw-renderer-card__header">\(title)</header>
           <p class="sdw-renderer-card__summary">\(summary)</p>
-          <p class="sdw-renderer-card__fallback">\(fallback)</p>
+          \(previewHTML)\(fallbackNoticeHTML)
           \(actionHTML)
         </section>
         """
+    }
+
+    /// The card's own drawing of the content, for the renderers that can be
+    /// drawn without running their package. Absent for everything else, which
+    /// leaves the card as its name, summary, and control.
+    private static func previewHTML(for plan: RendererEmbedPlan) -> String {
+        guard plan.fallbackReason == nil,
+              let input = plan.input,
+              case .inlineArtifact(let artifact) = input,
+              artifact.fenceKind == .excalidraw,
+              let svg = ExcalidrawStaticPreview.svg(from: artifact.bytes)
+        else { return "" }
+        return #"<div class="sdw-renderer-card__preview">\#(svg)</div>"#
+    }
+
+    /// A reader-facing sentence for a fence the renderer would not take.
+    /// `.oversizedInput` returns the original fenced code instead of a card and
+    /// never reaches this.
+    private static func fallbackNotice(for reason: MarkdownFenceFallbackReason) -> String {
+        switch reason {
+        case .emptyInfoString:
+            return "This block does not name a renderer."
+        case .malformedInfoString:
+            return "This block's renderer name could not be read."
+        case .unsupportedAlias:
+            return "No approved renderer draws this kind of block."
+        case .packageAliasDisallowed:
+            return "The renderer for this block is not available here."
+        case .missingDocumentIdentity:
+            return "This block is not tied to a saved version yet, so it cannot open."
+        case .oversizedInput:
+            return "This block is too large to draw."
+        }
     }
 
     private func rendererEmbedPlan(for block: MarkdownFencedBlock, alias: MarkdownRichFenceAlias) -> RendererEmbedPlan? {

--- a/Sources/WikiFS/Reader/MarkdownHTMLRenderer.swift
+++ b/Sources/WikiFS/Reader/MarkdownHTMLRenderer.swift
@@ -515,11 +515,13 @@ struct MarkdownHTMLRenderer: MarkupVisitor {
             else { preconditionFailure("approved jsoncanvas renderer reference must remain valid") }
             return RendererReference(packageID: packageID, version: version, registrationID: registrationID)
         case .excalidraw:
-            guard let packageID = RendererPackageID(rawValue: "org.selfdrivingwiki.excalidraw-readonly"),
-                  let version = RendererPackageVersion(rawValue: "1.0.0"),
-                  let registrationID = RendererRegistrationID(rawValue: "excalidraw")
-            else { preconditionFailure("approved excalidraw renderer reference must remain valid") }
-            return RendererReference(packageID: packageID, version: version, registrationID: registrationID)
+            // Read from the bundled-package constants rather than repeating the
+            // literals: a card whose version drifts from the installed package
+            // resolves to no descriptor and presents nothing.
+            return RendererReference(
+                packageID: BundledRendererPackages.excalidrawPackageID,
+                version: BundledRendererPackages.excalidrawVersion,
+                registrationID: BundledRendererPackages.excalidrawRegistrationID)
         }
     }
 

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -548,6 +548,15 @@ struct WikiReaderView: View {
           .sdw-renderer-card__fallback {
             margin: 0.1em 0 0; font-size: 0.8em; color: var(--muted);
           }
+          /* The card's own drawing of the content. The SVG carries a viewBox,
+             so width alone scales it; the height cap keeps a tall diagram from
+             taking over the page — the renderer pane is where it gets room. */
+          .sdw-renderer-card__preview {
+            margin: 0.6em 0 0; border-radius: 6px; overflow: hidden;
+          }
+          .sdw-renderer-card__preview svg {
+            display: block; width: 100%; height: auto; max-height: 320px;
+          }
           /* The action is an `<a>` and the collapse control a `<button>`; both
              are drawn as the same bordered control so the card reads as one
              affordance either side of activation. */

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -527,6 +527,38 @@ struct WikiReaderView: View {
           .sdw-code-operator { color: var(--code-operator); }
           .sdw-code-punctuation { color: var(--code-punctuation); }
           .sdw-code-constant { color: var(--code-constant); }
+          /* Rich-fence renderer cards. `MarkdownHTMLRenderer.rendererCardHTML`
+             emits a `<section class="sdw-renderer-card">` for every approved
+             fence (mermaid stays on its own `.mermaid` path). The card is the
+             static, in-flow surface; its action either mounts a native inline
+             attachment over this rect or opens the full renderer. Styled to
+             match `details.sdw-transclusion` above — same border, fill, and
+             radius — so both embed surfaces read as one family. Without these
+             rules the card degrades to unstyled stacked text. */
+          section.sdw-renderer-card {
+            margin: 0.6em 0; padding: 0.7em 0.9em; border-radius: 8px;
+            background: var(--code-bg); border: 1px solid var(--border);
+          }
+          .sdw-renderer-card__header {
+            font-weight: 600; font-size: 0.95em; color: var(--text);
+          }
+          .sdw-renderer-card__summary {
+            margin: 0.15em 0 0; font-size: 0.9em; color: var(--muted);
+          }
+          .sdw-renderer-card__fallback {
+            margin: 0.1em 0 0; font-size: 0.8em; color: var(--muted);
+          }
+          /* The action is an `<a>` and the collapse control a `<button>`; both
+             are drawn as the same bordered control so the card reads as one
+             affordance either side of activation. */
+          .sdw-renderer-card__action, .sdw-renderer-card__collapse {
+            display: inline-block; margin: 0.7em 0.4em 0 0;
+            padding: 0.2em 0.7em; border: 1px solid var(--border);
+            border-radius: 6px; background: none; font: inherit;
+            font-size: 0.9em; text-decoration: none; cursor: pointer;
+          }
+          .sdw-renderer-card__action { color: -webkit-link; }
+          .sdw-renderer-card__collapse { color: var(--muted); }
           hr { border: none; border-top: 1px solid var(--border); margin: 1.5em 0; }
           table { border-collapse: collapse; margin: 0 0 1em; }
           th, td { border: 1px solid var(--border); padding: 6px 10px; text-align: left; vertical-align: top; }
@@ -681,7 +713,9 @@ final class WikiReaderWebView: WKWebView {
         Object.keys(known).forEach(function(id){if(!current[id])window.webkit.messageHandlers.rendererAttachmentGeometry.postMessage({kind:'removed',generation:g,placeholderID:id});}); known=current; }
       window.__sdwRendererAttachmentReport=function(g){window.__sdwRendererAttachmentGeneration=g;window.__sdwRendererAttachmentRevision=(window.__sdwRendererAttachmentRevision||0)+1;report();};
       window.__sdwRendererAttachmentReserve=function(id,height){var e=document.getElementById(id); if(!e||!Number.isFinite(height))return; e.style.minHeight=height+'px'; window.__sdwRendererAttachmentRevision=(window.__sdwRendererAttachmentRevision||0)+1; report();};
-      document.addEventListener('click',function(event){var control=event.target.closest('.sdw-renderer-card__action,.sdw-renderer-card__collapse');if(!control)return;var card=control.closest('.sdw-renderer-card[id]');if(!card)return;event.preventDefault();var collapse=control.classList.contains('sdw-renderer-card__collapse');window.webkit.messageHandlers.rendererAttachmentAction.postMessage({action:collapse?'collapse':'activate',placeholderID:card.id});if(!collapse&&!card.querySelector('.sdw-renderer-card__collapse')){var b=document.createElement('button');b.className='sdw-renderer-card__collapse';b.type='button';b.textContent='Collapse';b.setAttribute('aria-label','Collapse interactive renderer');card.appendChild(b);}});
+      window.__sdwRendererAttachmentPresentCollapse=function(id){var card=document.getElementById(id); if(!card||card.querySelector('.sdw-renderer-card__collapse'))return; var b=document.createElement('button');b.className='sdw-renderer-card__collapse';b.type='button';b.textContent='Collapse';b.setAttribute('aria-label','Collapse interactive renderer');card.appendChild(b);};
+      window.__sdwRendererAttachmentDismissCollapse=function(id){var card=document.getElementById(id); if(!card)return; var b=card.querySelector('.sdw-renderer-card__collapse'); if(b)b.remove();};
+      document.addEventListener('click',function(event){var control=event.target.closest('.sdw-renderer-card__action,.sdw-renderer-card__collapse');if(!control)return;var card=control.closest('.sdw-renderer-card[id]');if(!card)return;event.preventDefault();var collapse=control.classList.contains('sdw-renderer-card__collapse');window.webkit.messageHandlers.rendererAttachmentAction.postMessage({action:collapse?'collapse':'activate',placeholderID:card.id});});
       addEventListener('scroll',report,{passive:true}); addEventListener('resize',report); new MutationObserver(report).observe(document.documentElement,{childList:true,subtree:true,attributes:true});
     })();
     """
@@ -1658,44 +1692,72 @@ internal struct WikiReaderRep: NSViewRepresentable {
             if removedMountedChild { attachmentContainer?.collapseAttachment() }
         }
 
+        /// Activate the card's control. Only a renderer with a **native** inline
+        /// attachment (JSON Canvas today) mounts a child over the card rect;
+        /// every other approved renderer — including the bundled Excalidraw web
+        /// package — is presented in the full renderer through
+        /// `onRendererActivation`. Mounting a contentless child instead would
+        /// paint an empty focus-bordered rectangle over the card and show the
+        /// reader nothing, which is exactly what this path used to do.
         func activateAttachment(_ placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentActivationResult {
             guard let attachmentCoordinator, let attachmentContainer else { return .rejected }
-            switch nativeAttachmentContent(for: placeholderID) {
+            // No registered context means there is nothing authorized to show —
+            // neither natively nor in the full renderer.
+            guard let context = webView?.rendererActivationAdmission?.attachmentContext(for: placeholderID) else {
+                failAttachment(placeholderID)
+                return .rejected
+            }
+            switch nativeAttachmentContent(for: context, placeholderID: placeholderID) {
             case .failed:
                 failAttachment(placeholderID)
                 return .rejected
+            case .unsupported:
+                // Deliberately does NOT call `attachmentCoordinator.activate`:
+                // the full renderer is a sheet the coordinator never hears
+                // close, so a record left `.active` could never be re-activated.
+                return presentInFullRenderer(context)
             case .canvas(let content):
                 let result = attachmentCoordinator.activate(placeholderID)
-                if result == .activate {
+                switch result {
+                case .activate:
                     attachmentContainer.activateAttachment(
                         named: placeholderID,
                         content: content,
                         onExit: { [weak self] in self?.collapseAttachment(placeholderID) })
+                    setCollapseControl(true, for: placeholderID)
+                case .showInFullRenderer:
+                    // The single active-attachment budget is already spent.
+                    return presentInFullRenderer(context)
+                case .rejected:
+                    break
                 }
                 return result
-            case .fallback:
-                break
             }
-            let result = attachmentCoordinator.activate(placeholderID)
-            if result == .activate {
-                attachmentContainer.activateAttachment(
-                    named: placeholderID,
-                    onExit: { [weak self] in self?.collapseAttachment(placeholderID) })
-            }
-            return result
+        }
+
+        /// Hand the exact authorized reference + input to the app-layer renderer
+        /// presentation. Returns `.rejected` when no presenter is wired (the
+        /// agent-transcript and preview readers pass none).
+        private func presentInFullRenderer(_ context: RendererEmbedActivationContext) -> RendererAttachmentActivationResult {
+            guard let present = webView?.onRendererActivation else { return .rejected }
+            present(context.rendererReference, context.input)
+            return .showInFullRenderer
         }
 
         private enum NativeAttachmentContent {
-            case fallback
+            /// The renderer has no native inline attachment factory.
+            case unsupported
             case canvas(AnyView)
             case failed
         }
 
-        private func nativeAttachmentContent(for placeholderID: RendererAttachmentPlaceholderID) -> NativeAttachmentContent {
-            guard let context = webView?.rendererActivationAdmission?.attachmentContext(for: placeholderID),
-                  context.rendererReference == BuiltInRendererReference.reference(for: .jsonCanvas),
+        private func nativeAttachmentContent(
+            for context: RendererEmbedActivationContext,
+            placeholderID: RendererAttachmentPlaceholderID
+        ) -> NativeAttachmentContent {
+            guard context.rendererReference == BuiltInRendererReference.reference(for: .jsonCanvas),
                   case .inlineArtifact(let artifact) = context.input
-            else { return .fallback }
+            else { return .unsupported }
             do {
                 let factory = NativeJSONCanvasAttachmentFactory.fencedOnly()
                 return .canvas(try factory.makeView(for: .fenced(artifact)))
@@ -1703,6 +1765,18 @@ internal struct WikiReaderRep: NSViewRepresentable {
                 DebugLog.reader("native JSON Canvas attachment failed for \(placeholderID.rawValue): \(error)")
                 return .failed
             }
+        }
+
+        /// Add or remove the card's Collapse control. The document script no
+        /// longer appends it optimistically on click — only a mounted native
+        /// attachment has anything to collapse.
+        private func setCollapseControl(_ present: Bool, for placeholderID: RendererAttachmentPlaceholderID) {
+            guard let webView else { return }
+            let identifier = WikiReaderRep.jsString(placeholderID.rawValue)
+            let function = present
+                ? "window.__sdwRendererAttachmentPresentCollapse"
+                : "window.__sdwRendererAttachmentDismissCollapse"
+            webView.evaluateJavaScript("\(function) && \(function)(\(identifier));")
         }
 
         func attachmentState(for placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentState {
@@ -1719,10 +1793,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
             else { return }
             attachmentCoordinator.collapse(placeholderID)
             attachmentContainer.collapseAttachment()
+            setCollapseControl(false, for: placeholderID)
         }
 
         func failAttachment(_ placeholderID: RendererAttachmentPlaceholderID) {
             attachmentCoordinator?.fail(placeholderID)
+            setCollapseControl(false, for: placeholderID)
             guard attachmentContainer?.ownsMountedAttachment(named: placeholderID) == true else { return }
             attachmentContainer?.collapseAttachment()
         }

--- a/Sources/WikiFS/Renderer/BundledRendererPackages.swift
+++ b/Sources/WikiFS/Renderer/BundledRendererPackages.swift
@@ -14,7 +14,10 @@ enum BundledRendererPackages {
     }()
 
     static let excalidrawVersion: RendererPackageVersion = {
-        do { return try RendererPackageVersion(validating: "1.0.0") }
+        // Bumped with the package bytes: an installed version pins its exact
+        // hash, so a changed asset at the same version fails closed and the
+        // machine keeps the old package.
+        do { return try RendererPackageVersion(validating: "1.0.1") }
         catch { preconditionFailure("Invalid bundled Excalidraw version: \(error)") }
     }()
 

--- a/Sources/WikiFS/Renderer/WikiAppWebView.swift
+++ b/Sources/WikiFS/Renderer/WikiAppWebView.swift
@@ -118,15 +118,25 @@ struct WikiAppWebViewRepresentable: NSViewRepresentable {
             }
             identity = nextIdentity
             self.session = session
-            if let hostedView = session.hostedView {
-                hostedView.frame = container.bounds
-                hostedView.autoresizingMask = [.width, .height]
-                container.addSubview(hostedView)
-            }
-            schedule { [weak self, weak session] in
+            // A session that already owns its view (a test double, or one
+            // restarted in place) can attach now.
+            attach(session.hostedView, to: container)
+            schedule { [weak self, weak session, weak container] in
                 guard let self, let session, self.session === session else { return }
                 session.start()
+                // The live session builds its WebView inside `start()`, so its
+                // `hostedView` was nil above. Attach here or the renderer loads
+                // into a detached zero-sized view and never appears.
+                guard let container else { return }
+                attach(session.hostedView, to: container)
             }
+        }
+
+        private func attach(_ hostedView: NSView?, to container: NSView) {
+            guard let hostedView, hostedView.superview !== container else { return }
+            hostedView.frame = container.bounds
+            hostedView.autoresizingMask = [.width, .height]
+            container.addSubview(hostedView)
         }
 
         func teardown(from container: NSView) {

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -445,14 +445,23 @@ struct ContentView: View {
 
 }
 
-struct RendererActivationPresentation: Identifiable, Equatable {
+/// The window key for one activated renderer. `WindowGroup(for:)` dedups by
+/// `==`, so activating the same content twice focuses the open window instead
+/// of stacking a second one.
+///
+/// `id` covers the renderer and the exact bytes but not the block that carried
+/// them, so the same drawing embedded on two pages deliberately shares one
+/// window: the windows would be identical.
+struct RendererActivationPresentation: Identifiable, Codable, Hashable {
     let reference: RendererReference
     let input: RendererBridgeInput
+    let wikiID: WikiID
     let id: String
 
-    init(reference: RendererReference, input: RendererBridgeInput) {
+    init(reference: RendererReference, input: RendererBridgeInput, wikiID: WikiID) {
         self.reference = reference
         self.input = input
+        self.wikiID = wikiID
         let encodedInput: String
         switch input {
         case .inlineArtifact(let artifact):
@@ -469,25 +478,61 @@ struct RendererActivationPresentation: Identifiable, Equatable {
             encodedInput
         ].joined(separator: "|")
     }
+
+    /// `RendererBridgeInput` is `Equatable` but not `Hashable`, and widening a
+    /// Core contract to key a window would be the wrong trade — `id` already
+    /// encodes the renderer and its exact bytes.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id && lhs.wikiID == rhs.wikiID
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(wikiID)
+    }
 }
 
-struct RendererActivationPresentationSheet: View {
+/// Resolves the activating wiki's store for the renderer window through the
+/// shared `SessionManager`, mirroring `PageVersionCompareWindow`. A restored
+/// window whose wiki is not open lands on the unavailable state rather than
+/// holding a stale store.
+struct RendererActivationWindow: View {
+    let sessionManager: SessionManager
+    let installedRendererHost: InstalledRendererHost
+    let context: RendererActivationPresentation?
+
+    var body: some View {
+        if let context, let session = sessionManager.sessions[context.wikiID] {
+            RendererActivationView(
+                store: session.store,
+                installedRendererHost: installedRendererHost,
+                request: context)
+        } else {
+            ContentUnavailableView {
+                Label("Renderer Unavailable", systemImage: "rectangle.slash")
+            } description: {
+                Text("Open the wiki that holds this content, then activate the renderer again.")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+/// One activated renderer, hosted as the content of a value-driven
+/// `WindowGroup` — a real, resizable, non-modal window (see `WikiFSApp`). The
+/// window's own traffic lights close it, so there is no in-content Close
+/// control; Escape closes it too, the habit a reader brings from Quick Look.
+struct RendererActivationView: View {
     @Environment(\.dismiss) private var dismiss
     @Bindable var store: WikiStoreModel
     let installedRendererHost: InstalledRendererHost
     let request: RendererActivationPresentation
 
     var body: some View {
-        NavigationStack {
-            rendererContent
-                .navigationTitle(title)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Close") { dismiss() }
-                    }
-                }
-        }
-        .frame(minWidth: 520, minHeight: 420)
+        rendererContent
+            .frame(minWidth: 520, minHeight: 420)
+            .navigationTitle(title)
+            .onExitCommand { dismiss() }
     }
 
     @ViewBuilder

--- a/Sources/WikiFS/Window/RootView.swift
+++ b/Sources/WikiFS/Window/RootView.swift
@@ -24,7 +24,7 @@ struct RootView: View {
     @Bindable var registry: WikiRegistryClient
     let fileProvider: FileProviderFacade
     let installedRendererHost: InstalledRendererHost
-    @State private var activeRendererPresentation: RendererActivationPresentation?
+    @Environment(\.openWindow) private var openWindow
 
     var body: some View {
         ContentView(
@@ -40,12 +40,6 @@ struct RootView: View {
             onRendererActivation: presentRendererActivation
         )
         .id(session.wikiID)
-        .sheet(item: $activeRendererPresentation) { request in
-            RendererActivationPresentationSheet(
-                store: session.store,
-                installedRendererHost: installedRendererHost,
-                request: request)
-        }
         // Consume a deferred cross-window `wiki://` navigation (set on the
         // session by `SessionManager.applyOrStashWikiLink` when a link was
         // clicked in the Activity window while THIS wiki's window was closed).
@@ -57,11 +51,16 @@ struct RootView: View {
         .onAppear { consumePendingWikiLink() }
     }
 
+    /// Open the activated renderer in its own window rather than a sheet, so a
+    /// diagram can be resized and left open beside the page it came from.
+    /// `WindowGroup(for:)` dedups by `==`, so activating the same content again
+    /// focuses the window already showing it.
     @MainActor
     private func presentRendererActivation(reference: RendererReference, input: RendererBridgeInput) {
-        activeRendererPresentation = RendererActivationPresentation(
+        openWindow(value: RendererActivationPresentation(
             reference: reference,
-            input: input)
+            input: input,
+            wikiID: session.wikiID))
     }
 
     /// Deliver the stashed `wiki://` link (if any) to the app-layer router

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -776,6 +776,21 @@ struct WikiFSApp: App {
         .defaultSize(width: 1080, height: 740)
         .windowResizability(.contentMinSize)
 
+        // Renderers: a real, resizable, non-modal window per activated
+        // renderer + wiki, opened via `openWindow(value:)` from `RootView`
+        // when a reader card's control fires. Mirrors the two compare groups
+        // above. The group title is generic because every renderer arrives
+        // here — the content sets the window's own title.
+        WindowGroup("Renderer", for: RendererActivationPresentation.self) { $context in
+            RendererActivationWindow(
+                sessionManager: sessionManager,
+                installedRendererHost: installedRendererHost,
+                context: context)
+                .preferredColorScheme(appearanceColorScheme)
+        }
+        .defaultSize(width: 900, height: 640)
+        .windowResizability(.contentMinSize)
+
         // Queue Activity windows: one per `QueueKind` (Ingestion + Extraction),
         // opened via `openWindow(value:)` / `openWindowBridge.openQueueWindow`.
         // `WindowGroup(for:)` deduplicates by `==`, so re-opening a queue's

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -408,6 +408,92 @@ struct MarkdownHTMLRendererTests {
         #expect(!mermaid.contains("sdw-renderer-card"))
     }
 
+    @Test("an Excalidraw card draws the drawing instead of promising a preview")
+    func excalidrawCardDrawsItsOwnPreview() throws {
+        let projection = RendererEmbedProjection(
+            sourceEmbeds: [:],
+            richFenceAliases: Set(MarkdownRichFenceAlias.allCases))
+        let document = MarkdownDocumentIdentity(
+            pageID: .init(rawValue: "01HTESTPAGE000000000000001"),
+            pageVersionID: .init(rawValue: "01HTESTPV00000000000000001"))
+        let options = MarkdownRenderOptions(
+            codeHighlighting: .disabled,
+            rendererEmbedProjection: projection,
+            documentIdentity: document,
+            rendererActivationAdmission: RendererEmbedActivationAdmission(
+                pageID: document.pageID,
+                pageVersionID: document.pageVersionID,
+                capability: .init(rawValue: "capability"),
+                generation: 1))
+
+        let drawing = """
+        ```excalidraw
+        {"type":"excalidraw","version":2,"elements":[\
+        {"id":"a","type":"rectangle","x":80,"y":120,"width":220,"height":100,\
+        "strokeColor":"#1e1e1e","backgroundColor":"#dbeafe","roundness":{"type":3}},\
+        {"id":"b","type":"text","x":130,"y":155,"width":120,"height":30,\
+        "strokeColor":"#1e1e1e","text":"Client"}],\
+        "appState":{"viewBackgroundColor":"#ffffff"}}
+        ```
+        """
+        let card = MarkdownHTMLRenderer.render(drawing, options: options)
+        #expect(card.contains(#"class="sdw-renderer-card__preview""#))
+        #expect(card.contains("<svg "))
+        #expect(card.contains("<rect "))
+        #expect(card.contains(">Client</text>"))
+        #expect(card.contains(##"fill="#dbeafe""##))
+        // The drawing's own canvas, so its near-black strokes stay legible on
+        // the reader's dark background.
+        #expect(card.contains(##"fill="#ffffff""##))
+        // The label the card used to print in place of a drawing.
+        #expect(!card.contains("static preview"))
+
+        // A fence the preview cannot read leaves a card with no preview and no
+        // claim that there is one.
+        let unreadable = MarkdownHTMLRenderer.render(
+            "```excalidraw\n{\"type\":\"excalidraw\",\"version\":2,\"elements\":[]}\n```",
+            options: options)
+        #expect(unreadable.contains("sdw-renderer-card"))
+        #expect(!unreadable.contains("sdw-renderer-card__preview"))
+        #expect(!unreadable.contains("static preview"))
+        #expect(unreadable.contains("Interact"))
+    }
+
+    @Test("preview markup escapes drawing text and drops author colours and links")
+    func previewMarkupIsSafeForReaderHTML() throws {
+        let hostile = Data("""
+        {"type":"excalidraw","version":2,"elements":[\
+        {"id":"a","type":"text","x":0,"y":0,"width":10,"height":10,\
+        "text":"</text><script>alert('x')</script>","link":"javascript:alert(1)"},\
+        {"id":"b","type":"rectangle","x":0,"y":0,"width":10,"height":10,\
+        "strokeColor":"red; content: url(x)","backgroundColor":"transparent"}],\
+        "appState":{"viewBackgroundColor":"url(evil)"}}
+        """.utf8)
+        let svg = try #require(ExcalidrawStaticPreview.svg(from: hostile))
+
+        #expect(!svg.contains("<script>"))
+        #expect(svg.contains("&lt;/text&gt;&lt;script&gt;"))
+        // An element link never becomes an href in the reader document.
+        #expect(!svg.contains("javascript:"))
+        #expect(!svg.contains("<a "))
+        // Colours that are not plain hex fall back to the safe defaults.
+        #expect(!svg.contains("content: url"))
+        #expect(!svg.contains("url(evil)"))
+        #expect(svg.contains(##"stroke="#1e1e1e""##))
+        #expect(svg.contains(#"fill="none""#))
+        #expect(svg.contains(##"fill="#ffffff""##))
+    }
+
+    @Test("preview returns nothing for input it cannot draw")
+    func previewDeclinesUnreadableInput() {
+        #expect(ExcalidrawStaticPreview.svg(from: Data("not json".utf8)) == nil)
+        #expect(ExcalidrawStaticPreview.svg(from: Data(#"{"type":"mermaid","elements":[]}"#.utf8)) == nil)
+        #expect(ExcalidrawStaticPreview.svg(from: Data(#"{"type":"excalidraw","version":2}"#.utf8)) == nil)
+        // Every element deleted leaves nothing to draw.
+        let deleted = #"{"type":"excalidraw","version":2,"elements":[{"id":"a","type":"rectangle","x":0,"y":0,"width":4,"height":4,"isDeleted":true}]}"#
+        #expect(ExcalidrawStaticPreview.svg(from: Data(deleted.utf8)) == nil)
+    }
+
     @Test("oversized rich fences fall back to escaped code without renderer metadata")
     func oversizedRichFencesUseEscapedFallbackWithoutRendererMetadata() {
         let projection = RendererEmbedProjection(

--- a/Tests/WikiFSAppTests/Phase6RendererHostedValidationTests.swift
+++ b/Tests/WikiFSAppTests/Phase6RendererHostedValidationTests.swift
@@ -271,6 +271,19 @@ struct Phase6RendererHostedValidationTests {
             expectedValue: "scene-rendered",
             in: webView,
             description: "unassisted Excalidraw scene")
+
+        // The session creates its WKWebView inside `start()`, so a host that
+        // reads `hostedView` before that runs attaches nothing and the
+        // renderer draws off-screen. Evaluating JavaScript against the session
+        // succeeds either way, so only the view hierarchy proves it is visible.
+        #expect(webView.window === window)
+        let attachedContainer = try #require(webView.superview)
+
+        host.view.frame = NSRect(x: 0, y: 0, width: 720, height: 480)
+        host.view.layoutSubtreeIfNeeded()
+        #expect(attachedContainer.bounds.width > 0)
+        #expect(attachedContainer.bounds.height > 0)
+        #expect(webView.frame == attachedContainer.bounds)
     }
 
     private static func prepareApplication() {

--- a/Tests/WikiFSAppTests/Phase6RendererHostedValidationTests.swift
+++ b/Tests/WikiFSAppTests/Phase6RendererHostedValidationTests.swift
@@ -168,6 +168,111 @@ struct Phase6RendererHostedValidationTests {
         }
     }
 
+    /// The viewer must render from its OWN startup request. The test above
+    /// re-posts `input.read` from the page after the session reports ready,
+    /// which hides whether the package's document-load request is ever
+    /// answered -- and that unassisted request is the only one production
+    /// makes.
+    @Test("Excalidraw renders from the package's own startup input request")
+    func excalidrawRendersWithoutAReplayedBridgeRequest() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
+        Self.prepareApplication()
+
+        let fixture = try ExcalidrawHostedFixture()
+        defer { fixture.remove() }
+        let package = try fixture.validator.validate(directory: fixture.packageDirectory)
+        let descriptor = try #require(package.manifest.descriptors.only)
+        let entryPoint = try #require(descriptor.webEntryPoint)
+        let provider = try ValidatedRendererPackageResourceProvider(
+            packageID: descriptor.reference.packageID,
+            version: descriptor.reference.version,
+            expectedPackageHash: package.packageHash,
+            installedRoot: package.stagedRoot,
+            validatedPackage: package)
+        let entryURL = RendererPackageScheme.url(
+            packageID: descriptor.reference.packageID,
+            version: descriptor.reference.version,
+            path: entryPoint.path)
+        let reservation = RendererPackageReservation(
+            packageID: descriptor.reference.packageID,
+            version: descriptor.reference.version)
+        // An inline artifact, not a source version: a fenced ```excalidraw
+        // block on a page is the only input the reader's cards produce.
+        let store = try GRDBWikiStore()
+        let documentIdentity = MarkdownDocumentIdentity(
+            pageID: PageID(rawValue: "01JHOSTEDEXCALIDRAWPAGE00001"),
+            pageVersionID: PageVersionID(rawValue: "01JHOSTEDEXCALIDRAWVERSION01"))
+        let block = try MarkdownFencedBlock(
+            documentIdentity: documentIdentity,
+            parserOrdinal: 0,
+            rawInfoString: "excalidraw",
+            bytes: Self.excalidrawInput)
+        let artifact = try RendererEmbeddedContent.InlineArtifact(
+            pageID: documentIdentity.pageID,
+            pageVersionID: documentIdentity.pageVersionID,
+            blockID: try #require(block.blockID),
+            fenceKind: .excalidraw,
+            mimeType: try .init(validating: "application/json"),
+            bytes: Self.excalidrawInput)
+        let reader = RendererAuthorizedInputReader(
+            store: store,
+            authorizedInput: .inlineArtifact(artifact))
+        let identity = InstalledRendererWebViewIdentity(
+            rendererReference: descriptor.reference,
+            entryURL: entryURL)
+        var session: WikiAppWebViewSession?
+        let view = WikiAppWebView(
+            identity: identity,
+            makeSession: { _, reportFailure in
+                let value = WikiAppWebViewSession(
+                    entryURL: entryURL,
+                    resourceProvider: provider,
+                    installedPackage: reservation,
+                    lifecycleFailureHandler: reportFailure,
+                    bridgeFactory: { sessionID in
+                        RendererContentWorldBroker(
+                            sessionID: sessionID,
+                            capability: .init(rawValue: UUID().uuidString),
+                            inputReader: reader,
+                            expectedOrigin: entryURL)
+                    },
+                    externalActivationPolicy: .enabled)
+                session = value
+                return value
+            },
+            onFailure: { failure in
+                Issue.record("Hosted Excalidraw session failed: \(failure.kind)")
+            })
+        let host = NSHostingController(rootView: AnyView(view))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 480),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false)
+        window.contentViewController = host
+        window.orderFront(nil)
+        defer {
+            host.rootView = AnyView(EmptyView())
+            session?.close()
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+
+        try await Self.waitFor(description: "hosted Excalidraw session") { session != nil }
+        let liveSession = try #require(session)
+        try await Self.waitForReady(liveSession, description: "hosted Excalidraw package session")
+        let webView = try #require(liveSession.webView)
+
+        // No replayed envelope: whatever the page posted on its own must have
+        // been answered.
+        _ = try await Self.waitForJavaScriptString(
+            "document.querySelector('svg.scene') ? 'scene-rendered' : 'pending'",
+            expectedValue: "scene-rendered",
+            in: webView,
+            description: "unassisted Excalidraw scene")
+    }
+
     private static func prepareApplication() {
         let application = NSApplication.shared
         application.setActivationPolicy(.accessory)

--- a/Tests/WikiFSAppTests/RendererActivationPresentationTests.swift
+++ b/Tests/WikiFSAppTests/RendererActivationPresentationTests.swift
@@ -1,0 +1,67 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+import WikiFSCore
+import WikiFSTypes
+
+/// `WindowGroup(for:)` keys a renderer window by this value, so its
+/// hand-written `Equatable`/`Hashable` decides whether activating a renderer
+/// focuses the open window or stacks another one.
+@Suite("Renderer activation window key")
+struct RendererActivationPresentationTests {
+    @Test("the same content in the same wiki is one window")
+    func identicalContentSharesAWindow() throws {
+        let first = try Self.presentation()
+        let second = try Self.presentation()
+
+        #expect(first == second)
+        #expect(first.hashValue == second.hashValue)
+        #expect(Set([first, second]).count == 1)
+    }
+
+    @Test("different content or a different wiki is a different window")
+    func differingContentOrWikiSeparatesWindows() throws {
+        let base = try Self.presentation()
+
+        #expect(try base != Self.presentation(bytes: Self.otherBytes))
+        #expect(try base != Self.presentation(wikiID: WikiID(rawValue: "01JWIKI0000000000000000002")))
+        #expect(try base != Self.presentation(registrationID: "json-canvas"))
+        #expect(try Set([base, Self.presentation(bytes: Self.otherBytes)]).count == 2)
+    }
+
+    // MARK: Fixtures
+
+    private static let bytes = Data(#"{"type":"excalidraw","version":2,"elements":[]}"#.utf8)
+    private static let otherBytes = Data(#"{"type":"excalidraw","version":2,"elements":[],"files":{}}"#.utf8)
+
+    private static func presentation(
+        bytes: Data = bytes,
+        wikiID: WikiID = WikiID(rawValue: "01JWIKI0000000000000000001"),
+        registrationID: String = "excalidraw"
+    ) throws -> RendererActivationPresentation {
+        let identity = MarkdownDocumentIdentity(
+            pageID: PageID(rawValue: "01JWINDOWPAGE0000000000001"),
+            pageVersionID: PageVersionID(rawValue: "01JWINDOWVERSION000000001"))
+        let block = try MarkdownFencedBlock(
+            documentIdentity: identity,
+            parserOrdinal: 0,
+            rawInfoString: "excalidraw",
+            bytes: bytes)
+        let artifact = try RendererEmbeddedContent.InlineArtifact(
+            pageID: identity.pageID,
+            pageVersionID: identity.pageVersionID,
+            blockID: try #require(block.blockID),
+            fenceKind: .excalidraw,
+            mimeType: try .init(validating: "application/json"),
+            bytes: bytes)
+        return RendererActivationPresentation(
+            reference: RendererReference(
+                packageID: try #require(RendererPackageID(rawValue: "org.selfdrivingwiki.excalidraw-readonly")),
+                version: try #require(RendererPackageVersion(rawValue: "1.0.1")),
+                registrationID: try #require(RendererRegistrationID(rawValue: registrationID))),
+            input: .inlineArtifact(artifact),
+            wikiID: wikiID)
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
@@ -47,9 +47,10 @@ struct RendererAttachmentCoordinatorTests {
         let coordinator = WikiReaderRep.Coordinator()
         coordinator.webView = webView
         coordinator.attachmentContainer = container
-        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        Self.startLifecycleLoad(coordinator, webView: webView)
         let generation = try #require(coordinator.attachmentGeneration)
         let placeholder = try RendererAttachmentPlaceholderID(validating: "escape-synchronized-canvas")
+        try Self.admitJSONCanvasPlaceholder(placeholder, coordinator: coordinator, webView: webView)
         coordinator.handleAttachmentGeometry(.init(
             generation: generation,
             placeholderID: placeholder,
@@ -81,11 +82,12 @@ struct RendererAttachmentCoordinatorTests {
         window.contentView = container; window.makeKeyAndOrderFront(nil)
         defer { container.teardown(); window.orderOut(nil) }
         let coordinator = WikiReaderRep.Coordinator(); coordinator.webView = webView; coordinator.attachmentContainer = container; webView.coordinator = coordinator; webView.navigationDelegate = coordinator
-        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        Self.startLifecycleLoad(coordinator, webView: webView)
         try await Self.waitUntil("reader document") { webView.isLoading == false }
         try await Self.waitForReporter(in: webView)
         let placeholder = try RendererAttachmentPlaceholderID(validating: "dom-removal-canvas")
         let generation = try #require(coordinator.attachmentGeneration)
+        try Self.admitJSONCanvasPlaceholder(placeholder, coordinator: coordinator, webView: webView)
         try await Self.runJS("var e=document.createElement('section');e.id='dom-removal-canvas';e.className='sdw-renderer-card';e.style.cssText='width:160px;height:96px';document.body.appendChild(e);window.__sdwRendererAttachmentReport(\(generation));", in: webView)
         try await Self.waitUntil("placeholder admission") { coordinator.attachmentState(for: placeholder) == .card }
         #expect(coordinator.activateAttachment(placeholder) == .activate)
@@ -111,10 +113,12 @@ struct RendererAttachmentCoordinatorTests {
         let coordinator = WikiReaderRep.Coordinator()
         coordinator.webView = webView
         coordinator.attachmentContainer = container
-        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        Self.startLifecycleLoad(coordinator, webView: webView)
         let generation = try #require(coordinator.attachmentGeneration)
         let active = try RendererAttachmentPlaceholderID(validating: "active-canvas")
         let inactive = try RendererAttachmentPlaceholderID(validating: "inactive-canvas")
+        try Self.admitJSONCanvasPlaceholder(active, coordinator: coordinator, webView: webView)
+        try Self.admitJSONCanvasPlaceholder(inactive, coordinator: coordinator, webView: webView, parserOrdinal: 1)
         let geometry = { (placeholderID: RendererAttachmentPlaceholderID) in
             RendererAttachmentGeometryMessage(
                 generation: generation,
@@ -151,10 +155,12 @@ struct RendererAttachmentCoordinatorTests {
         let coordinator = WikiReaderRep.Coordinator()
         coordinator.webView = webView
         coordinator.attachmentContainer = container
-        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        Self.startLifecycleLoad(coordinator, webView: webView)
         let generation = try #require(coordinator.attachmentGeneration)
         let active = try RendererAttachmentPlaceholderID(validating: "active-ownership-canvas")
         let inactive = try RendererAttachmentPlaceholderID(validating: "inactive-ownership-canvas")
+        try Self.admitJSONCanvasPlaceholder(active, coordinator: coordinator, webView: webView)
+        try Self.admitJSONCanvasPlaceholder(inactive, coordinator: coordinator, webView: webView, parserOrdinal: 1)
         let geometry = { (placeholderID: RendererAttachmentPlaceholderID) in
             RendererAttachmentGeometryMessage(
                 generation: generation,
@@ -233,10 +239,11 @@ struct RendererAttachmentCoordinatorTests {
         window.contentView = container; window.makeKeyAndOrderFront(nil)
         defer { container.teardown(); window.orderOut(nil) }
         let coordinator = WikiReaderRep.Coordinator(); coordinator.webView = webView; coordinator.attachmentContainer = container; webView.navigationDelegate = coordinator
-        coordinator.startLoad(markdown: "# First", documentIdentity: nil, isLoading: .constant(true))
+        Self.startLifecycleLoad(coordinator, webView: webView, markdown: "# First")
         try await Self.waitUntil("first document") { webView.isLoading == false }
         let placeholder = try RendererAttachmentPlaceholderID(validating: "generation-canvas")
         let firstGeneration = try #require(coordinator.attachmentGeneration)
+        try Self.admitJSONCanvasPlaceholder(placeholder, coordinator: coordinator, webView: webView)
         coordinator.handleAttachmentGeometry(.init(generation: firstGeneration, placeholderID: placeholder, cssRect: .init(x: 20, y: 20, width: 160, height: 96), visible: true, revision: 1))
         #expect(coordinator.activateAttachment(placeholder) == .activate)
         #expect(coordinator.attachmentState(for: placeholder) == .active)
@@ -264,10 +271,12 @@ struct RendererAttachmentCoordinatorTests {
         coordinator.webView = webView
         coordinator.attachmentContainer = container
         webView.navigationDelegate = coordinator
-        coordinator.startLoad(markdown: "# Reader", documentIdentity: nil, isLoading: .constant(true))
+        Self.startLifecycleLoad(coordinator, webView: webView)
         try await Self.waitUntil("initial reader navigation") { webView.isLoading == false }
         let placeholder = try RendererAttachmentPlaceholderID(validating: "reload-canvas")
-        coordinator.handleAttachmentGeometry(.init(generation: 1, placeholderID: placeholder, cssRect: .init(x: 20, y: 20, width: 160, height: 96), visible: true, revision: 1))
+        let generation = try #require(coordinator.attachmentGeneration)
+        try Self.admitJSONCanvasPlaceholder(placeholder, coordinator: coordinator, webView: webView)
+        coordinator.handleAttachmentGeometry(.init(generation: generation, placeholderID: placeholder, cssRect: .init(x: 20, y: 20, width: 160, height: 96), visible: true, revision: 1))
         #expect(coordinator.activateAttachment(placeholder) == .activate)
         #expect(coordinator.attachmentState(for: placeholder) == .active)
         #expect(container.subviews.flatMap(\.subviews).contains { $0.accessibilityIdentifier() == "renderer-attachment-reload-canvas" })
@@ -415,6 +424,105 @@ struct RendererAttachmentCoordinatorTests {
         #expect(Self.containsHostingView(in: child))
         #expect(window.firstResponder === child)
     }
+    @Test("an admitted package fence opens the full renderer instead of an empty attachment")
+    @MainActor
+    func admittedPackageFencePresentsFullRenderer() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        Self.startLifecycleLoad(coordinator, webView: webView)
+        var presented: [RendererReference] = []
+        webView.onRendererActivation = { reference, _ in presented.append(reference) }
+
+        let generation = try #require(coordinator.attachmentGeneration)
+        let admission = try #require(webView.rendererActivationAdmission)
+        let identity = Self.lifecycleIdentity
+        let bytes = Data(#"{"type":"excalidraw","version":2,"elements":[],"appState":{},"files":{}}"#.utf8)
+        let block = try MarkdownFencedBlock(
+            documentIdentity: identity,
+            parserOrdinal: 0,
+            rawInfoString: "excalidraw",
+            bytes: bytes)
+        let artifact = try RendererEmbeddedContent.InlineArtifact(
+            pageID: identity.pageID,
+            pageVersionID: identity.pageVersionID,
+            blockID: try #require(block.blockID),
+            fenceKind: .excalidraw,
+            mimeType: try .init(validating: "application/json"),
+            bytes: bytes)
+        let reference = RendererReference(
+            packageID: BundledRendererPackages.excalidrawPackageID,
+            version: BundledRendererPackages.excalidrawVersion,
+            registrationID: BundledRendererPackages.excalidrawRegistrationID)
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "admitted-excalidraw")
+        admission.register(context: .init(
+            pageID: identity.pageID,
+            pageVersionID: identity.pageVersionID,
+            blockID: artifact.blockID,
+            rendererReference: reference,
+            input: .inlineArtifact(artifact),
+            capability: admission.capability,
+            generation: generation), attachmentPlaceholderID: placeholder)
+        coordinator.handleAttachmentGeometry(.init(
+            generation: generation,
+            placeholderID: placeholder,
+            cssRect: .init(x: 40, y: 80, width: 240, height: 160),
+            visible: true,
+            revision: 1))
+
+        #expect(coordinator.activateAttachment(placeholder) == .showInFullRenderer)
+        #expect(presented == [reference])
+        // No native child: a contentless mount would paint an empty bordered
+        // rectangle over the card and show the reader nothing.
+        #expect(container.subviews.flatMap(\.subviews).contains {
+            $0.accessibilityIdentifier() == "renderer-attachment-admitted-excalidraw"
+        } == false)
+        // The record stays on `.card` so the control keeps working — the full
+        // renderer is a sheet whose dismissal the coordinator never observes.
+        #expect(coordinator.attachmentState(for: placeholder) == .card)
+        #expect(coordinator.activateAttachment(placeholder) == .showInFullRenderer)
+        #expect(presented.count == 2)
+    }
+
+    @Test("an unadmitted placeholder fails closed instead of mounting an empty attachment")
+    @MainActor
+    func unadmittedPlaceholderFailsClosed() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let coordinator = WikiReaderRep.Coordinator()
+        coordinator.webView = webView
+        coordinator.attachmentContainer = container
+        Self.startLifecycleLoad(coordinator, webView: webView)
+        let generation = try #require(coordinator.attachmentGeneration)
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "unadmitted-canvas")
+        coordinator.handleAttachmentGeometry(.init(
+            generation: generation,
+            placeholderID: placeholder,
+            cssRect: .init(x: 20, y: 20, width: 160, height: 96),
+            visible: true,
+            revision: 1))
+
+        #expect(coordinator.activateAttachment(placeholder) == .rejected)
+        #expect(coordinator.attachmentState(for: placeholder) == .failed)
+        #expect(container.subviews.flatMap(\.subviews).contains {
+            $0.accessibilityIdentifier() == "renderer-attachment-unadmitted-canvas"
+        } == false)
+    }
+
     @Test("geometry bridge accepts only a complete finite typed payload")
     func geometryBridgeDecodesTrustedShape() throws {
         let message = try #require(RendererAttachmentGeometryMessage(body: [
@@ -507,6 +615,63 @@ struct RendererAttachmentCoordinatorTests {
     private static let jsonCanvasBytes = Data("""
     {"nodes":[{"id":"first","type":"text","x":0,"y":0,"width":80,"height":40,"text":"First"}],"edges":[]}
     """.utf8)
+
+    private static let lifecycleIdentity = MarkdownDocumentIdentity(
+        pageID: PageID(rawValue: "01JATTACHMENTPAGE000000000001"),
+        pageVersionID: PageVersionID(rawValue: "01JATTACHMENTPAGEVERSION00001"))
+
+    /// Prepare a Coordinator whose activations resolve to a real admission.
+    /// `startLoad` only mints one when the reader has both a document identity
+    /// and a renderer presenter, so a lifecycle test that skips either can
+    /// never reach the native attachment path.
+    @MainActor
+    private static func startLifecycleLoad(
+        _ coordinator: WikiReaderRep.Coordinator,
+        webView: WikiReaderWebView,
+        markdown: String = "# Reader"
+    ) {
+        webView.onRendererActivation = { _, _ in }
+        coordinator.startLoad(
+            markdown: markdown,
+            documentIdentity: lifecycleIdentity,
+            isLoading: .constant(true))
+    }
+
+    /// Admit `placeholderID` as a JSON Canvas fence — the one renderer with a
+    /// native inline attachment. Activation mounts the factory's SwiftUI view,
+    /// so these lifecycle tests exercise the same path production takes rather
+    /// than an unadmitted placeholder. `parserOrdinal` keeps sibling
+    /// placeholders on distinct block identities.
+    @MainActor
+    private static func admitJSONCanvasPlaceholder(
+        _ placeholderID: RendererAttachmentPlaceholderID,
+        coordinator: WikiReaderRep.Coordinator,
+        webView: WikiReaderWebView,
+        parserOrdinal: Int = 0
+    ) throws {
+        let generation = try #require(coordinator.attachmentGeneration)
+        let admission = try #require(webView.rendererActivationAdmission)
+        let block = try MarkdownFencedBlock(
+            documentIdentity: lifecycleIdentity,
+            parserOrdinal: parserOrdinal,
+            rawInfoString: "jsoncanvas",
+            bytes: jsonCanvasBytes)
+        let artifact = try RendererEmbeddedContent.InlineArtifact(
+            pageID: lifecycleIdentity.pageID,
+            pageVersionID: lifecycleIdentity.pageVersionID,
+            blockID: try #require(block.blockID),
+            fenceKind: .jsoncanvas,
+            mimeType: try .init(validating: "application/json"),
+            bytes: jsonCanvasBytes)
+        admission.register(context: .init(
+            pageID: lifecycleIdentity.pageID,
+            pageVersionID: lifecycleIdentity.pageVersionID,
+            blockID: artifact.blockID,
+            rendererReference: BuiltInRendererReference.reference(for: .jsonCanvas),
+            input: .inlineArtifact(artifact),
+            capability: admission.capability,
+            generation: generation), attachmentPlaceholderID: placeholderID)
+    }
 
     private static func attachmentCoordinatorSource() throws -> String {
         let root = URL(fileURLWithPath: #filePath)

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -753,7 +753,12 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
           if (existing) { existing.remove(); }
           var style = document.createElement('style');
           style.id = \(Self.javaScriptString(styleID));
-          style.textContent = \(Self.javaScriptString("\(selector) { background: \(Self.sentinelColor) !important; border-radius: 0 !important; } \(selector) * { visibility: hidden !important; }"));
+          // The sentinel measures the painted area against the card's
+          // border-box rect, so the card's decoration is flattened without
+          // resizing it: a radius would round the painted corners away, and a
+          // border would paint its own colour over the sentinel fill and inset
+          // the measured area. Recolouring the border keeps the box identical.
+          style.textContent = \(Self.javaScriptString("\(selector) { background: \(Self.sentinelColor) !important; border-radius: 0 !important; border-color: \(Self.sentinelColor) !important; } \(selector) * { visibility: hidden !important; }"));
           document.head.appendChild(style);
           return 'styled';
         })()

--- a/docs/skills/renderer-package-maintainer/references/current-package-guide.md
+++ b/docs/skills/renderer-package-maintainer/references/current-package-guide.md
@@ -1,6 +1,6 @@
 ## Renderer packages
 
-Self Driving Wiki includes and manages the read-only Excalidraw renderer automatically. The app validates the bundled directory and installs it in the machine renderer store. The package ID is `org.selfdrivingwiki.excalidraw-readonly`. The version is `1.0.0`. The registration ID is `excalidraw`.
+Self Driving Wiki includes and manages the read-only Excalidraw renderer automatically. The app validates the bundled directory and installs it in the machine renderer store. The package ID is `org.selfdrivingwiki.excalidraw-readonly`. The version is `1.0.1`. The registration ID is `excalidraw`.
 
 ### Scope and availability
 


### PR DESCRIPTION
An embedded ```excalidraw fence on a page showed four lines of bare text and an Interact link that opened an empty box. Five defects sat between the fence and the diagram; each one alone hid the next.

## What was wrong

**1. Renderer cards had no CSS.** `MarkdownHTMLRenderer` emits a `<section class="sdw-renderer-card">` for every approved fence, but no rule for that class has ever existed in the reader's stylesheet. The card degraded to stacked bare text. It now matches the `details.sdw-transclusion` treatment beside it.

**2. Activation mounted an empty attachment.** #1106 added native inline attachments and routed every card action click through a document script that calls `preventDefault()`. Only JSON Canvas has a native attachment factory; every other renderer fell through to a `content: nil` child, which paints an empty focus-bordered rectangle over the card. The pre-#1106 route to the full renderer became unreachable at the same time. A renderer with no native factory now goes to that presenter and returns `.showInFullRenderer`, leaving the record on `.card` so the control keeps working. An unadmitted placeholder fails closed. The Collapse control moves from the document script, which appended it on every click, to the activation result.

**3. The package WebView was never attached.** `WikiAppWebViewSession` builds its WKWebView inside `start()`, but the SwiftUI host read `session.hostedView` synchronously right after `makeSession` — before the deferred `start()` ran. It was always nil for a live session, nothing was added to the container, and `updateNSView` early-returns on an unchanged identity, so it was never retried. Every package renderer loaded its document into a detached, zero-sized WebView.

**4. The drawing was invisible in dark mode.** A drawing's element colours are chosen against the canvas colour it declares. Excalidraw's default `#ffffff` with near-black strokes vanished on a dark system canvas: labels rendered, every box and arrow did not. The viewer now applies a declared `viewBackgroundColor` and resolves the system colour keywords beneath it for that background.

**5. The card promised a preview it never drew.** The fallback slot printed the literal `static preview` whenever nothing had failed, and the raw enum case name (`missingDocumentIdentity`) when something had. The card now draws the drawing: `ExcalidrawStaticPreview` is a pure bytes-in, markup-out port of the element subset the bundled viewer covers, emitting one bounded SVG with a viewBox so width alone scales it. The reader stays a static surface — this is host-generated markup, not the package's JavaScript. Author-controlled JSON reaches reader HTML, so text is escaped, every colour must match `#rgb` or `#rrggbb` before it lands in an attribute, and an element's `link` is dropped: the interactive viewer wraps a linked shape in an `<a>`, and the reader must never take an href from a fence. Elements are capped at 400 and the rendered height at 320px. Input the preview cannot read leaves the card with no preview and no claim that there is one; a refused fence now reads as a sentence rather than an identifier.

## The viewer is now a window

Activating a renderer put it in a fixed-size modal sheet, so a diagram could not be made bigger, could not be left open beside the page it came from, and closed only through an in-content button. It now opens as a value-driven `WindowGroup`, the shape the Compare Extractions and Compare Versions windows already use: real traffic lights, drag-to-resize, Cmd-W, and Escape — including with focus inside the drawing, since the package's keydown handler returns without `preventDefault` for keys it does not use, so `cancelOperation:` reaches the host.

The window key carries the activating wiki so the content resolves its store through the shared `SessionManager`, and `WindowGroup(for:)` dedups by `==`, so activating the same content again focuses the window already showing it. The key hand-writes `==`/`hash` over its identity string: `RendererBridgeInput` is Equatable but not Hashable, and widening a Core contract to key a window would be the wrong trade. That identity covers the renderer and the exact bytes but not the block that carried them, so the same drawing embedded on two pages deliberately shares one window.

Two consequences worth naming: `WindowGroup(for:)` contexts persist across relaunch, so up to 48KB of artifact bytes ride in state restoration, and a restored window whose wiki is not open lands on the unavailable state. Both match the accepted Compare Versions behaviour.

## Package version

The bundled package moves to 1.0.1 with new digests. An installed version pins its exact hash, so changed bytes at the same version fail closed and the machine keeps the old package. The reader's Excalidraw reference now reads the bundled-package constants instead of repeating the literals, which is what let a version drift go unnoticed.

## Why the tests missed all of this

- The attachment lifecycle tests activated placeholders with no admission context, so they depended on the empty mount they were meant to catch. They now admit a real JSON Canvas fence.
- The hosted package tests drive `session.webView` through `evaluateJavaScript`, which works on a detached view, and the host lifecycle double exposes its `hostedView` at init — the one assumption the live session breaks.
- The Phase 6 hosted check re-posts `input.read` from the page after the session reports ready, so it cannot tell whether the viewer's own document-load request is answered. That unassisted request is the only one production makes.

New coverage: the package-renderer and unadmitted activation paths, and a hosted case that waits for `svg.scene` from the package's own startup request over an inline artifact, asserting the WebView reaches the window and tracks its container. The preview is covered for markup, escaping, colour and link rejection, and the inputs it declines.

The alignment spike harness paints the card with a sentinel colour and compares painted pixels against its border-box rect, so it already squared the corners; the card's new border needed the same flattening.

## Verification

Confirmed in the running app: the card draws the diagram inline on the drawing's own canvas — three labelled, filled boxes and their connectors. Interact opens a real window titled Excalidraw showing the same drawing; it resizes by dragging (900×640 → 1115×750), Escape closes it with focus inside the drawing, and a second Interact focuses the open window rather than stacking another.

- `WIKIFS_APP_TESTS=1 swift test --filter "Renderer|Excalidraw|JSONCanvas|MarkdownHTMLRenderer|WikiAppWebView|Transclusion|WikiReader"` — 527 tests in 76 suites passed
- `swiftlint --strict` — 0 violations across 540 files

## Not included

Interactivity in the page. The card's drawing is static markup; panning, zooming, and links still need the Interact control, which is what `plans/markdown-renderer-embeds.md` asks for — it forbids running the package's JavaScript in the reader document, not a preview. An interactive inline attachment would need an Excalidraw equivalent of `NativeJSONCanvasAttachmentFactory` and remains a separate design change.

Fit-to-window in the viewer. The package opens a drawing at 1:1 with a fixed offset, so a small diagram sits in the top-left of a large window until it is panned or zoomed. That is the package's existing behaviour, unchanged here.

Observed gap, not fixed here: a card with a fallback reason other than `.oversizedInput` drops the original fenced code, which contradicts "does not hide, rewrite, or discard the underlying Markdown" in the same document. `.oversizedInput` preserves it correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

