### PR TITLE
fix(renderer): supersede prior active versions

### DIFF
--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -119,7 +119,7 @@ final class RendererSettingsModel {
 
     private func rebuildRows() {
         rows = (host.machineIndex?.records ?? [])
-            .filter { $0.state != .removed }
+            .filter { $0.state == .validated }
             .sorted()
             .map { record in
                 let descriptor = record.validatedDescriptors.first

--- a/Sources/WikiFSCore/Core/RendererMachineIndexCore.swift
+++ b/Sources/WikiFSCore/Core/RendererMachineIndexCore.swift
@@ -5,8 +5,8 @@ import Foundation
 /// Versioned, machine-only package index. SQLite stores this value authoritatively;
 /// `derived/index.json` is a regenerated projection of the same validated value.
 public struct RendererMachineIndex: Codable, Equatable, Sendable {
-    /// Version 3 adds persisted installed-renderer failure accounting.
-    public static let currentSchemaVersion = 3
+    /// Version 4 makes one package version authoritative for each logical renderer.
+    public static let currentSchemaVersion = 4
 
     public let schemaVersion: Int
     public let generation: UInt64
@@ -55,16 +55,51 @@ public struct RendererMachineIndex: Codable, Equatable, Sendable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
-        guard schemaVersion == 2 || schemaVersion == Self.currentSchemaVersion else {
+        guard schemaVersion == 2 || schemaVersion == 3 || schemaVersion == Self.currentSchemaVersion else {
             throw RendererMachineIndexStoreError.unsupportedSchemaVersion
         }
+        let decodedRecords = try container.decode([RendererPackageInstallRecord].self, forKey: .records)
         try self.init(
             schemaVersion: Self.currentSchemaVersion,
             generation: container.decode(UInt64.self, forKey: .generation),
-            records: container.decode([RendererPackageInstallRecord].self, forKey: .records),
+            records: schemaVersion < Self.currentSchemaVersion
+                ? Self.migratingLegacyActiveVersions(decodedRecords)
+                : decodedRecords,
             safeModeIsEnabled: container.decode(Bool.self, forKey: .safeModeIsEnabled),
             installedRendererFailures: try container.decodeIfPresent([RendererInstalledRendererFailure].self, forKey: .installedRendererFailures) ?? []
         )
+    }
+
+    private static func migratingLegacyActiveVersions(
+        _ records: [RendererPackageInstallRecord]
+    ) throws -> [RendererPackageInstallRecord] {
+        var claimedLogicalReferences: Set<LogicalRendererReference> = []
+        var supersededReservations: Set<RendererPackageReservation> = []
+        for record in records.sorted(by: >) where record.state == .validated {
+            let logicalReferences = Set(record.validatedDescriptors.map(\.logicalReference))
+            if claimedLogicalReferences.isDisjoint(with: logicalReferences) {
+                claimedLogicalReferences.formUnion(logicalReferences)
+            } else {
+                supersededReservations.insert(.init(packageID: record.packageID, version: record.version))
+            }
+        }
+        return try records.map { record in
+            let reservation = RendererPackageReservation(packageID: record.packageID, version: record.version)
+            guard supersededReservations.contains(reservation) else {
+                guard record.state == .validated, record.rollbackCandidate == nil else { return record }
+                let logicalReferences = Set(record.validatedDescriptors.map(\.logicalReference))
+                let rollbackVersion = records
+                    .filter { candidate in
+                        supersededReservations.contains(.init(packageID: candidate.packageID, version: candidate.version)) &&
+                        candidate.validatedDescriptors.contains { logicalReferences.contains($0.logicalReference) }
+                    }
+                    .map(\.version)
+                    .max()
+                guard let rollbackVersion else { return record }
+                return try record.replacing(state: .validated, updatedAt: record.updatedAt, rollbackCandidate: rollbackVersion)
+            }
+            return try record.replacing(state: .superseded, updatedAt: record.updatedAt)
+        }
     }
 
     public func validate() throws {
@@ -72,6 +107,7 @@ public struct RendererMachineIndex: Codable, Equatable, Sendable {
             throw RendererMachineIndexStoreError.unsupportedSchemaVersion
         }
         var reservations: [RendererPackageReservation: RendererSHA256Digest] = [:]
+        var activeLogicalReferences: Set<LogicalRendererReference> = []
         for record in records {
             let key = RendererPackageReservation(packageID: record.packageID, version: record.version)
             if let existingHash = reservations[key], existingHash != record.expectedPackageHash {
@@ -81,6 +117,12 @@ public struct RendererMachineIndex: Codable, Equatable, Sendable {
                 throw RendererMachineIndexStoreError.duplicatePackageVersion
             }
             reservations[key] = record.expectedPackageHash
+            guard record.state == .validated else { continue }
+            for descriptor in record.validatedDescriptors {
+                guard activeLogicalReferences.insert(descriptor.logicalReference).inserted else {
+                    throw RendererMachineIndexStoreError.duplicateLogicalRenderer
+                }
+            }
         }
     }
 
@@ -103,6 +145,26 @@ public struct RendererMachineIndex: Codable, Equatable, Sendable {
     }
 }
 
+private extension RendererPackageInstallRecord {
+    func replacing(
+        state: RendererPackageInstallState,
+        updatedAt: RFC3339Timestamp,
+        rollbackCandidate: RendererPackageVersion? = nil
+    ) throws -> Self {
+        try Self(
+            packageID: packageID,
+            version: version,
+            expectedPackageHash: expectedPackageHash,
+            state: state,
+            reservedAt: reservedAt,
+            updatedAt: updatedAt,
+            diagnostic: diagnostic,
+            rollbackCandidate: rollbackCandidate ?? self.rollbackCandidate,
+            isSafeModeSuppressed: isSafeModeSuppressed,
+            validatedDescriptors: validatedDescriptors)
+    }
+}
+
 public struct RendererPackageReservation: Hashable, Sendable {
     public let packageID: RendererPackageID
     public let version: RendererPackageVersion
@@ -120,6 +182,7 @@ public enum RendererMachineIndexStoreError: Error, Equatable, Sendable {
     case staleGeneration
     case conflictingExpectedHash
     case duplicatePackageVersion
+    case duplicateLogicalRenderer
     case invalidPackagePath
     case corruptIndex
     case sqliteFailure

--- a/Sources/WikiFSCore/Core/RendererMachineIndexStore.swift
+++ b/Sources/WikiFSCore/Core/RendererMachineIndexStore.swift
@@ -320,6 +320,28 @@ public actor RendererMachineIndexStore {
                         if let existing, existing.expectedPackageHash != revalidated.packageHash {
                             throw RendererMachineIndexStoreError.conflictingExpectedHash
                         }
+                        let incomingLogicalReferences = Set(revalidated.manifest.descriptors.map(\.logicalReference))
+                        let activeRecord = records.first { candidate in
+                            candidate.state == .validated &&
+                            candidate.validatedDescriptors.contains { incomingLogicalReferences.contains($0.logicalReference) }
+                        }
+                        records = try records.map { candidate in
+                            guard candidate.state == .validated,
+                                  candidate.validatedDescriptors.contains(where: {
+                                      incomingLogicalReferences.contains($0.logicalReference)
+                                  }) else { return candidate }
+                            return try RendererPackageInstallRecord(
+                                packageID: candidate.packageID,
+                                version: candidate.version,
+                                expectedPackageHash: candidate.expectedPackageHash,
+                                state: .superseded,
+                                reservedAt: candidate.reservedAt,
+                                updatedAt: timestamp,
+                                diagnostic: candidate.diagnostic,
+                                rollbackCandidate: candidate.rollbackCandidate,
+                                isSafeModeSuppressed: candidate.isSafeModeSuppressed,
+                                validatedDescriptors: candidate.validatedDescriptors)
+                        }
                         let record = try RendererPackageInstallRecord(
                             packageID: revalidated.manifest.packageID,
                             version: revalidated.manifest.version,
@@ -327,6 +349,7 @@ public actor RendererMachineIndexStore {
                             state: .validated,
                             reservedAt: existing?.reservedAt ?? timestamp,
                             updatedAt: timestamp,
+                            rollbackCandidate: activeRecord?.version,
                             isSafeModeSuppressed: existing?.isSafeModeSuppressed ?? false,
                             validatedDescriptors: revalidated.manifest.descriptors
                         )
@@ -747,7 +770,7 @@ private struct RendererMachineIndexSQLiteStorage: Sendable {
               sqlite3_column_type(statement, 2) == SQLITE_BLOB
         else { throw RendererMachineIndexStoreError.corruptIndex }
         let schemaVersion = Int(sqlite3_column_int64(statement, 0))
-        guard schemaVersion == 2 || schemaVersion == RendererMachineIndex.currentSchemaVersion else {
+        guard schemaVersion == 2 || schemaVersion == 3 || schemaVersion == RendererMachineIndex.currentSchemaVersion else {
             throw RendererMachineIndexStoreError.unsupportedSchemaVersion
         }
         let rawGeneration = sqlite3_column_int64(statement, 1)
@@ -766,8 +789,8 @@ private struct RendererMachineIndexSQLiteStorage: Sendable {
         return .init(index: index, requiresMigration: schemaVersion != RendererMachineIndex.currentSchemaVersion)
     }
 
-    /// Rewrites a proven v2 JSON shape as v3 without changing generation,
-    /// descriptors, or safe mode. The savepoint leaves the v2 authority intact
+    /// Rewrites a proven legacy JSON shape using the current index invariants.
+    /// The savepoint leaves the prior authority intact
     /// if the derived projection cannot be replaced.
     private func migrate(database: OpaquePointer, index: RendererMachineIndex) throws {
         try execute(database, sql: "SAVEPOINT renderer_machine_index_schema_migration")

--- a/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
+++ b/Sources/WikiFSTypes/Renderer/RendererPhase3Types.swift
@@ -32,6 +32,7 @@ public struct RendererMachineScopeID: RawRepresentable, Codable, Hashable, Senda
 public enum RendererPackageInstallState: String, Codable, CaseIterable, Hashable, Sendable {
     case unvalidated
     case validated
+    case superseded
     case quarantined
     case removed
 }
@@ -85,10 +86,10 @@ public struct RendererPackageInstallRecord: Codable, Hashable, Sendable, Compara
         else {
             throw RendererValidationError.invalidIdentifier(kind: "renderer package install record", value: "inconsistent validated descriptors")
         }
-        guard state != .validated || descriptors.isEmpty == false else {
-            throw RendererValidationError.invalidIdentifier(kind: "renderer package install record", value: "validated record missing descriptors")
+        guard (state != .validated && state != .superseded) || descriptors.isEmpty == false else {
+            throw RendererValidationError.invalidIdentifier(kind: "renderer package install record", value: "available record missing descriptors")
         }
-        guard state == .validated || descriptors.isEmpty else {
+        guard state == .validated || state == .superseded || descriptors.isEmpty else {
             throw RendererValidationError.invalidIdentifier(kind: "renderer package install record", value: "unavailable record has descriptors")
         }
         self.packageID = packageID

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -39,7 +39,7 @@ struct RendererSettingsManagementViewTests {
         #expect(!source.contains("Application Support"))
         #expect(!source.contains("App Group"))
         #expect(source.contains("Source data and wiki preferences were preserved"))
-        #expect(source.contains(".filter { $0.state != .removed }"))
+        #expect(source.contains(".filter { $0.state == .validated }"))
         #expect(source.contains(".task(id: wikiID)"))
         #expect(source.contains("model.updateWiki(wiki)"))
         #expect(source.contains("rendererSourcePreference(for: source.id)"))

--- a/Tests/WikiFSTests/RendererPackageActivationTests.swift
+++ b/Tests/WikiFSTests/RendererPackageActivationTests.swift
@@ -26,6 +26,73 @@ struct RendererPackageActivationTests {
         #expect(FileManager.default.fileExists(atPath: package.stagedRoot.path) == false)
     }
 
+    @Test("the machine index rejects two active versions of one logical renderer")
+    func machineIndexRejectsDuplicateActiveLogicalRenderer() throws {
+        let packageID = try RendererPackageID(validating: "org.example.logical")
+        let firstVersion = try RendererPackageVersion(validating: "1.0.0")
+        let secondVersion = try RendererPackageVersion(validating: "1.0.1")
+        let firstManifest = try Fixture.makeManifest(
+            packageID: packageID,
+            version: firstVersion,
+            contents: Data("first renderer".utf8))
+        let secondManifest = try Fixture.makeManifest(
+            packageID: packageID,
+            version: secondVersion,
+            contents: Data("second renderer".utf8))
+        let timestamp = try RFC3339Timestamp(validating: "2026-08-05T12:00:00+00:00")
+        let firstRecord = try RendererPackageInstallRecord(
+            packageID: packageID,
+            version: firstVersion,
+            expectedPackageHash: try firstManifest.packageHash(),
+            state: .validated,
+            reservedAt: timestamp,
+            updatedAt: timestamp,
+            validatedDescriptors: firstManifest.descriptors)
+        let secondRecord = try RendererPackageInstallRecord(
+            packageID: packageID,
+            version: secondVersion,
+            expectedPackageHash: try secondManifest.packageHash(),
+            state: .validated,
+            reservedAt: timestamp,
+            updatedAt: timestamp,
+            validatedDescriptors: secondManifest.descriptors)
+
+        #expect(throws: RendererMachineIndexStoreError.duplicateLogicalRenderer) {
+            _ = try RendererMachineIndex(records: [firstRecord, secondRecord])
+        }
+    }
+
+    @Test("consecutive activation supersedes the prior logical renderer version")
+    func consecutiveActivationProjectsOnlyNewestVersionAndRetainsRollbackData() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let store = RendererMachineIndexStore(layout: fixture.layout)
+        _ = try await store.read()
+
+        let firstPackage = try fixture.validate()
+        let first = try await store.activate(firstPackage, expectedGeneration: 0, clock: fixture.clock)
+        let firstVersion = fixture.version
+
+        let secondVersion = try fixture.rewrite(
+            versionRaw: "1.0.1",
+            contents: Data("<html>new renderer</html>".utf8))
+        let secondPackage = try fixture.validate()
+        let second = try await store.activate(
+            secondPackage,
+            expectedGeneration: first.generation,
+            clock: fixture.clock)
+
+        #expect(second.records.map(\.version) == [firstVersion, secondVersion])
+        #expect(second.records.contains { $0.version == firstVersion && $0.state == .superseded })
+        #expect(second.records.contains {
+            $0.version == secondVersion && $0.state == .validated && $0.rollbackCandidate == firstVersion
+        })
+        #expect(second.availableDescriptorProjection.map(\.reference) == [secondPackage.manifest.descriptors[0].reference])
+        #expect(FileManager.default.fileExists(atPath: fixture.layout.packageURL(
+            packageID: fixture.packageID,
+            version: firstVersion).path))
+    }
+
     @Test func revalidationFailureCleansStagingAndDoesNotActivate() async throws {
         let fixture = try Fixture()
         defer { fixture.remove() }
@@ -323,10 +390,48 @@ struct RendererPackageActivationTests {
         {"schemaVersion":1,"generation":0,"records":[],"safeModeIsEnabled":false}
         """.utf8)
 
-        #expect(RendererMachineIndex.currentSchemaVersion == 3)
+        #expect(RendererMachineIndex.currentSchemaVersion == 4)
         #expect(throws: RendererMachineIndexStoreError.unsupportedSchemaVersion) {
             _ = try JSONDecoder().decode(RendererMachineIndex.self, from: legacy)
         }
+    }
+
+    @Test("schema v3 duplicate active versions migrate to one active renderer")
+    func schemaV3DuplicateActiveVersionsMigrateToNewestVersion() throws {
+        let packageID = try RendererPackageID(validating: "org.example.legacy")
+        let firstVersion = try RendererPackageVersion(validating: "1.0.0")
+        let secondVersion = try RendererPackageVersion(validating: "1.0.1")
+        let timestamp = try RFC3339Timestamp(validating: "2026-08-05T12:00:00+00:00")
+        let records = try [firstVersion, secondVersion].map { version in
+            let manifest = try Fixture.makeManifest(
+                packageID: packageID,
+                version: version,
+                contents: Data(version.rawValue.utf8))
+            return try RendererPackageInstallRecord(
+                packageID: packageID,
+                version: version,
+                expectedPackageHash: try manifest.packageHash(),
+                state: .validated,
+                reservedAt: timestamp,
+                updatedAt: timestamp,
+                validatedDescriptors: manifest.descriptors)
+        }
+        let legacy = LegacyRendererMachineIndex(
+            schemaVersion: 3,
+            generation: 7,
+            records: records,
+            safeModeIsEnabled: false,
+            installedRendererFailures: [])
+
+        let migrated = try JSONDecoder().decode(
+            RendererMachineIndex.self,
+            from: JSONEncoder().encode(legacy))
+
+        #expect(RendererMachineIndex.currentSchemaVersion == 4)
+        #expect(migrated.generation == 7)
+        #expect(migrated.records.map(\.state) == [.superseded, .validated])
+        #expect(migrated.records.last?.rollbackCandidate == firstVersion)
+        #expect(migrated.availableDescriptorProjection.map(\.reference.version) == [secondVersion])
     }
 
     private final class Fixture {
@@ -358,7 +463,15 @@ struct RendererPackageActivationTests {
             try manifest.canonicalJSON().write(to: source.appendingPathComponent("manifest.json"))
         }
 
-        private static func makeManifest(packageID: RendererPackageID, version: RendererPackageVersion, contents: Data) throws -> RendererManifest {
+        func rewrite(versionRaw: String, contents: Data) throws -> RendererPackageVersion {
+            let version = try RendererPackageVersion(validating: versionRaw)
+            try contents.write(to: source.appendingPathComponent("index.html"))
+            manifest = try Self.makeManifest(packageID: packageID, version: version, contents: contents)
+            try manifest.canonicalJSON().write(to: source.appendingPathComponent("manifest.json"))
+            return version
+        }
+
+        static func makeManifest(packageID: RendererPackageID, version: RendererPackageVersion, contents: Data) throws -> RendererManifest {
             let asset = RendererAsset(path: try RendererRelativePath(validating: "index.html"), digest: RendererSHA256.digest(contents))
             let descriptor = try RendererDescriptor(
                 reference: .init(packageID: packageID, version: version, registrationID: try RendererRegistrationID(validating: "viewer")),
@@ -380,6 +493,14 @@ struct RendererPackageActivationTests {
             catch { Issue.record("Fixture cleanup failed: \(error)") }
         }
     }
+}
+
+private struct LegacyRendererMachineIndex: Encodable {
+    let schemaVersion: Int
+    let generation: UInt64
+    let records: [RendererPackageInstallRecord]
+    let safeModeIsEnabled: Bool
+    let installedRendererFailures: [RendererInstalledRendererFailure]
 }
 
 private struct FixedClock: RendererEventClock {


### PR DESCRIPTION
## Summary

- Keep one active package version for each logical renderer.
- Retain the replaced package as a superseded rollback candidate.
- Migrate existing version 3 indexes to the newest compatible package version.
- Show only active renderer versions in Settings.

## Test plan

- [x] `make build`
- [x] `make test` (3,474 tests)
- [x] `WIKIFS_APP_TESTS=1 swift test --filter RendererSettingsManagementViewTests`
- [x] `swift test --filter RendererPackageActivationTests`
- [x] `swift test --filter RendererFailureWindowTests`
- [x] `git diff --check`
