### PR TITLE
Add Cordis provider catalog discovery

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -74,9 +74,14 @@ struct AgentsSettingsView: View {
     }
 
     let containerDirectory: URL
+    let providerServices: any AgentProviderServices
 
-    init(containerDirectory: URL) {
+    init(
+        containerDirectory: URL,
+        providerServices: any AgentProviderServices
+    ) {
         self.containerDirectory = containerDirectory
+        self.providerServices = providerServices
         let loaded = AgentProvidersConfig.loadOrSeed(from: containerDirectory)
         _config = State(initialValue: loaded)
         _selectedProviderID = State(initialValue: loaded.providers.first?.id)
@@ -131,7 +136,8 @@ struct AgentsSettingsView: View {
             ProviderDetailPane(
                 provider: provider,
                 config: $config,
-                containerDirectory: containerDirectory)
+                containerDirectory: containerDirectory,
+                providerServices: providerServices)
                 // Re-seed the pane's local edit state when the SELECTED provider
                 // changes, but not when the same provider's config mutates (so
                 // inline edits survive a save round-trip).
@@ -367,6 +373,7 @@ private struct ProviderDetailPane: View {
     let provider: AgentProvider
     @Binding var config: AgentProvidersConfig
     let containerDirectory: URL
+    let providerServices: any AgentProviderServices
 
     @State private var label: String
     @State private var commandText: String
@@ -377,6 +384,7 @@ private struct ProviderDetailPane: View {
     @State private var envText: String
     @State private var isAvailable: Bool = false
     @State private var modelRefreshState: ModelRefreshState = .idle
+    @State private var modelRefreshTask: Task<Void, Never>?
 
     /// The probe's lifecycle state. Equatable so SwiftUI skips body re-renders
     /// when the state hasn't changed.
@@ -387,10 +395,16 @@ private struct ProviderDetailPane: View {
         case error(String)
     }
 
-    init(provider: AgentProvider, config: Binding<AgentProvidersConfig>, containerDirectory: URL) {
+    init(
+        provider: AgentProvider,
+        config: Binding<AgentProvidersConfig>,
+        containerDirectory: URL,
+        providerServices: any AgentProviderServices
+    ) {
         self.provider = provider
         self._config = config
         self.containerDirectory = containerDirectory
+        self.providerServices = providerServices
         self._label = State(initialValue: provider.label)
         self._commandText = State(initialValue: provider.command.map(ShellWords.join) ?? "")
         self._envText = State(initialValue: EnvVarText.seed(for: provider))
@@ -406,6 +420,7 @@ private struct ProviderDetailPane: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { refreshAvailability() }
+        .onDisappear { cancelModelRefresh() }
     }
 
     // MARK: - Header
@@ -448,6 +463,7 @@ private struct ProviderDetailPane: View {
                     TextField("Command", text: $commandText, prompt: Text("bun x @agentclientprotocol/claude-agent-acp"))
                         .fontDesign(.monospaced)
                         .onChange(of: commandText) {
+                            cancelModelRefresh()
                             commitProviderConfig()
                             refreshAvailability()
                         }
@@ -538,7 +554,10 @@ private struct ProviderDetailPane: View {
             TextEditor(text: $envText)
                 .font(.system(.body, design: .monospaced))
                 .frame(minHeight: 120)
-                .onChange(of: envText) { commitProviderConfig() }
+                .onChange(of: envText) {
+                    cancelModelRefresh()
+                    commitProviderConfig()
+                }
         } header: {
             Text("Environment")
         } footer: {
@@ -623,39 +642,24 @@ private struct ProviderDetailPane: View {
             modelRefreshState = .error("Executable not found on PATH")
             return
         }
+        cancelModelRefresh()
         modelRefreshState = .loading
         DebugLog.agent("ProviderDetailPane.refreshModels: starting probe provider=\(provider.id)")
         let providerID = provider.id
         let env = EnvVarText.parse(envText)
         let cleanLabel = label.trimmingCharacters(in: .whitespaces)
-        Task {
-            let resolved = await PathPreflight.resolveOnLoginShell(executable: exe)
-            let resolvedWords: [String]
-            switch resolved {
-            case .found(let absolutePath):
-                resolvedWords = [absolutePath] + Array(words.dropFirst())
-                await MainActor.run { isAvailable = true }
-            case .missing(let reason):
-                await MainActor.run {
-                    isAvailable = false
-                    modelRefreshState = .error(reason)
-                }
-                return
-            }
-            let providerForProbe = AgentProvider(
-                id: providerID,
-                label: cleanLabel,
-                command: words.isEmpty ? nil : words,
-                env: env,
-                enabled: true,
-                isDefault: false)
-            let probe = ACPProviderModelProbe(
-                provider: providerForProbe,
-                resolvedCommand: resolvedWords,
-                apiKey: nil)
+        let providerForProbe = AgentProvider(
+            id: providerID,
+            label: cleanLabel,
+            command: words,
+            env: env,
+            enabled: true,
+            isDefault: false)
+        modelRefreshTask = Task {
             let outcome: Result<ACPProviderCatalogObservation, Error>
             do {
-                let observation = try await probe.discoverObservation()
+                let observation = try await providerServices.discoverCatalog(
+                    for: providerForProbe)
                 if ACPProviderModelProbe.shouldThrowNoModels(observation.models) {
                     DebugLog.agent("ProviderDetailPane.refreshModels: probe OK but no models advertised provider=\(providerID)")
                     outcome = .failure(ACPProviderModelProbeError.noModelsAdvertised)
@@ -663,12 +667,19 @@ private struct ProviderDetailPane: View {
                     DebugLog.agent("ProviderDetailPane.refreshModels: probe OK models=\(observation.models.count) provider=\(providerID)")
                     outcome = .success(observation)
                 }
+            } catch is CancellationError {
+                return
             } catch {
                 DebugLog.agent("ProviderDetailPane.refreshModels: probe failed provider=\(providerID): \(error.localizedDescription)")
                 outcome = .failure(error)
             }
-            await MainActor.run {
-                switch outcome {
+            guard !Task.isCancelled,
+                  providerForProbe.command == ShellWords.split(commandText),
+                  providerForProbe.env == EnvVarText.parse(envText),
+                  config.providers.contains(where: { $0.id == providerID })
+            else { return }
+            modelRefreshTask = nil
+            switch outcome {
                 case .success(let observation):
                     modelRefreshState = .ready(observation.models)
                     // Persist models, agent fingerprint, and standard ACP
@@ -685,6 +696,13 @@ private struct ProviderDetailPane: View {
                     modelRefreshState = .error(message)
                 }
             }
+        }
+
+    private func cancelModelRefresh() {
+        modelRefreshTask?.cancel()
+        modelRefreshTask = nil
+        if modelRefreshState == .loading {
+            modelRefreshState = .idle
         }
     }
 }

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -824,7 +824,9 @@ struct WikiFSApp: App {
                 ExtractionSettingsView(containerDirectory: containerDirectory, launcher: settingsLauncher)
                     .tag(SettingsTab.extraction)
                     .tabItem { Label("Extraction", systemImage: "doc.viewfinder") }
-                AgentsSettingsView(containerDirectory: containerDirectory)
+                AgentsSettingsView(
+                    containerDirectory: containerDirectory,
+                    providerServices: agentProviderServices)
                     .tag(SettingsTab.agents)
                     .tabItem { Label("Providers", systemImage: "cpu") }
                 OperationsSettingsView(containerDirectory: containerDirectory)

--- a/Sources/WikiFSEngine/AgentProviderRuntime.swift
+++ b/Sources/WikiFSEngine/AgentProviderRuntime.swift
@@ -97,6 +97,7 @@ public protocol AgentProviderServices: Sendable {
     func preparation(from token: AgentProviderAttemptToken, stage: AgentProviderStage) async throws -> AgentOperationPreparation
     func fallbackPreparation(from token: AgentProviderAttemptToken, stage: AgentProviderStage, fallbackProviderID: ProviderID) async throws -> AgentOperationPreparation
     func prepareSummarization() async throws -> AgentProviderSummaryPreparation
+    func discoverCatalog(for provider: AgentProvider) async throws -> ACPProviderCatalogObservation
     func modelSummary(text: String, preparation: AgentOperationPreparation) async throws -> String?
     func release(_ token: AgentProviderAttemptToken) async
     func readiness() async -> Bool
@@ -183,6 +184,12 @@ public actor MutableAgentProviderServices: AgentProviderPrivateServices {
         try await installed.prepareSummarization()
     }
 
+    public func discoverCatalog(
+        for provider: AgentProvider
+    ) async throws -> ACPProviderCatalogObservation {
+        try await installed.discoverCatalog(for: provider)
+    }
+
     public func modelSummary(
         text: String,
         preparation: AgentOperationPreparation
@@ -236,6 +243,7 @@ public struct UnavailableAgentProviderServices: AgentProviderServices {
     public func preparation(from token: AgentProviderAttemptToken, stage: AgentProviderStage) async throws -> AgentOperationPreparation { throw AgentProviderRuntimeError.unavailable }
     public func fallbackPreparation(from token: AgentProviderAttemptToken, stage: AgentProviderStage, fallbackProviderID: ProviderID) async throws -> AgentOperationPreparation { throw AgentProviderRuntimeError.unavailable }
     public func prepareSummarization() async throws -> AgentProviderSummaryPreparation { throw AgentProviderRuntimeError.unavailable }
+    public func discoverCatalog(for provider: AgentProvider) async throws -> ACPProviderCatalogObservation { throw AgentProviderRuntimeError.unavailable }
     public func modelSummary(text: String, preparation: AgentOperationPreparation) async throws -> String? { throw AgentProviderRuntimeError.unavailable }
     public func release(_ token: AgentProviderAttemptToken) async {}
     public func readiness() async -> Bool { false }
@@ -261,6 +269,11 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
     public typealias CredentialReader = @Sendable (ProviderID) -> String?
     public typealias PermissionPolicyResolver = @Sendable (PermissionOperationKind) -> PermissionPolicy
     public typealias BackendFactory = @Sendable (PermissionPolicy, Duration?, TimeInterval) -> any AgentBackend
+    public typealias CatalogProbe = @Sendable (
+        AgentProvider,
+        [String],
+        String?
+    ) async throws -> ACPProviderCatalogObservation
 
     private struct SpawnRecord: Sendable { let provider: AgentProvider; let model: ModelID?; let hints: [String: String] }
     private struct Snapshot: Sendable { let policy: AgentOperationPolicy; let thinking: String?; let models: AgentOperationModelSelection; let chains: [AgentProviderStage: [SpawnRecord]] }
@@ -271,14 +284,37 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
     private let readCredential: CredentialReader
     private let resolvePermissionPolicy: PermissionPolicyResolver
     private let makeBackend: BackendFactory
+    private let probeCatalog: CatalogProbe
     private var snapshots: [UUID: Snapshot] = [:]
     private var tokens: [UUID: TokenRecord] = [:]
     private var cachedBackends: [String: any AgentBackend] = [:]
     private var disposed = false
 
-    public init(readConfiguration: @escaping ConfigurationReader, resolveCommand: @escaping CommandResolver, readCredential: @escaping CredentialReader, resolvePermissionPolicy: @escaping PermissionPolicyResolver, makeBackend: @escaping BackendFactory = { AgentBackendFactory.makeBackend(policy: $0, budget: $1, turnCeilingTimeout: $2) }) {
-        self.readConfiguration = readConfiguration; self.resolveCommand = resolveCommand; self.readCredential = readCredential
-        self.resolvePermissionPolicy = resolvePermissionPolicy; self.makeBackend = makeBackend
+    public init(
+        readConfiguration: @escaping ConfigurationReader,
+        resolveCommand: @escaping CommandResolver,
+        readCredential: @escaping CredentialReader,
+        resolvePermissionPolicy: @escaping PermissionPolicyResolver,
+        makeBackend: @escaping BackendFactory = {
+            AgentBackendFactory.makeBackend(
+                policy: $0,
+                budget: $1,
+                turnCeilingTimeout: $2)
+        },
+        probeCatalog: @escaping CatalogProbe = { provider, resolvedCommand, apiKey in
+            try await ACPProviderModelProbe(
+                provider: provider,
+                resolvedCommand: resolvedCommand,
+                apiKey: apiKey)
+                .discoverObservation()
+        }
+    ) {
+        self.readConfiguration = readConfiguration
+        self.resolveCommand = resolveCommand
+        self.readCredential = readCredential
+        self.resolvePermissionPolicy = resolvePermissionPolicy
+        self.makeBackend = makeBackend
+        self.probeCatalog = probeCatalog
     }
 
     public func prepareInteractive(
@@ -368,6 +404,21 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
             policyOverride: policy)
         snapshots[snapshotID] = snapshot
         return .model(try makePreparation(snapshotID: snapshotID, stage: .summarizer, providerID: nil))
+    }
+
+    public func discoverCatalog(
+        for provider: AgentProvider
+    ) async throws -> ACPProviderCatalogObservation {
+        try requireAvailable()
+        let commands = await resolveCommand([provider])
+        try requireAvailable()
+        guard let resolvedCommand = commands[provider.id], !resolvedCommand.isEmpty else {
+            throw ACPProviderModelProbeError.notConfigured
+        }
+        return try await probeCatalog(
+            provider,
+            resolvedCommand,
+            readCredential(provider.id))
     }
 
     public func modelSummary(

--- a/Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift
+++ b/Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift
@@ -15,6 +15,7 @@ public struct AgentProviderRuntimeAssembly: Sendable {
         case credentialReader
         case permissionPolicyResolver
         case backendFactory
+        case catalogProbe
         case runtime
         case services
     }
@@ -25,6 +26,7 @@ public struct AgentProviderRuntimeAssembly: Sendable {
         static let credentialReader = ServiceKey<AgentProviderRuntime.CredentialReader>(label: "agent-provider.credential-reader")
         static let permissionPolicyResolver = ServiceKey<AgentProviderRuntime.PermissionPolicyResolver>(label: "agent-provider.permission-policy-resolver")
         static let backendFactory = ServiceKey<AgentProviderRuntime.BackendFactory>(label: "agent-provider.backend-factory")
+        static let catalogProbe = ServiceKey<AgentProviderRuntime.CatalogProbe>(label: "agent-provider.catalog-probe")
         static let runtime = ServiceKey<AgentProviderRuntime>(label: "agent-provider.runtime")
         static let services = ServiceKey<any AgentProviderServices>(label: "agent-provider.services")
     }
@@ -34,6 +36,7 @@ public struct AgentProviderRuntimeAssembly: Sendable {
     public let readCredential: AgentProviderRuntime.CredentialReader
     public let resolvePermissionPolicy: AgentProviderRuntime.PermissionPolicyResolver
     public let makeBackend: AgentProviderRuntime.BackendFactory
+    public let probeCatalog: AgentProviderRuntime.CatalogProbe
 
     public init(
         readConfiguration: @escaping AgentProviderRuntime.ConfigurationReader,
@@ -42,6 +45,13 @@ public struct AgentProviderRuntimeAssembly: Sendable {
         resolvePermissionPolicy: @escaping AgentProviderRuntime.PermissionPolicyResolver,
         makeBackend: @escaping AgentProviderRuntime.BackendFactory = { policy, budget, ceiling in
             AgentBackendFactory.makeBackend(policy: policy, budget: budget, turnCeilingTimeout: ceiling)
+        },
+        probeCatalog: @escaping AgentProviderRuntime.CatalogProbe = { provider, resolvedCommand, apiKey in
+            try await ACPProviderModelProbe(
+                provider: provider,
+                resolvedCommand: resolvedCommand,
+                apiKey: apiKey)
+                .discoverObservation()
         }
     ) {
         self.readConfiguration = readConfiguration
@@ -49,6 +59,7 @@ public struct AgentProviderRuntimeAssembly: Sendable {
         self.readCredential = readCredential
         self.resolvePermissionPolicy = resolvePermissionPolicy
         self.makeBackend = makeBackend
+        self.probeCatalog = probeCatalog
     }
 
     public func assemble() async throws -> AgentProviderRuntimeHandle {
@@ -117,17 +128,22 @@ public struct AgentProviderRuntimeAssembly: Sendable {
             return try ComponentDefinition(label: component.rawValue, provisions: [ServiceDependency(Keys.backendFactory)]) { activation in
                 _ = try await activation.supply(Keys.backendFactory, value: makeBackend)
             }
+        case .catalogProbe:
+            return try ComponentDefinition(label: component.rawValue, provisions: [ServiceDependency(Keys.catalogProbe)]) { activation in
+                _ = try await activation.supply(Keys.catalogProbe, value: probeCatalog)
+            }
         case .runtime:
             return try ComponentDefinition(
                 label: component.rawValue,
-                dependencies: [ServiceDependency(Keys.configurationReader), ServiceDependency(Keys.commandResolver), ServiceDependency(Keys.credentialReader), ServiceDependency(Keys.permissionPolicyResolver), ServiceDependency(Keys.backendFactory)],
+                dependencies: [ServiceDependency(Keys.configurationReader), ServiceDependency(Keys.commandResolver), ServiceDependency(Keys.credentialReader), ServiceDependency(Keys.permissionPolicyResolver), ServiceDependency(Keys.backendFactory), ServiceDependency(Keys.catalogProbe)],
                 provisions: [ServiceDependency(Keys.runtime)]) { activation in
                     let runtime = AgentProviderRuntime(
                         readConfiguration: try await activation.require(Keys.configurationReader),
                         resolveCommand: try await activation.require(Keys.commandResolver),
                         readCredential: try await activation.require(Keys.credentialReader),
                         resolvePermissionPolicy: try await activation.require(Keys.permissionPolicyResolver),
-                        makeBackend: try await activation.require(Keys.backendFactory))
+                        makeBackend: try await activation.require(Keys.backendFactory),
+                        probeCatalog: try await activation.require(Keys.catalogProbe))
                     _ = try await activation.supply(Keys.runtime, value: runtime)
                     _ = try await activation.effect { _ in await runtime.dispose() }
                 }

--- a/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
@@ -6,11 +6,15 @@ struct AgentProviderCompositionBoundaryTests {
     @Test("app queue and wiki sessions receive one stable facade")
     func appQueueAndWikiSessionsReceiveSameFacade() throws {
         let source = try sourceText("Sources/WikiFS/Window/WikiFSApp.swift")
+        let settings = try sourceText("Sources/WikiFS/Settings/AgentsSettingsView.swift")
 
         #expect(source.contains("let providerServices = MutableAgentProviderServices()"))
         #expect(source.contains("providerServices: providerServices"))
         #expect(source.contains("await providerServices.install(handle.services)"))
         #expect(source.contains("agentProviderRuntimeHandle = handle"))
+        #expect(source.contains("providerServices: agentProviderServices"))
+        #expect(settings.contains("providerServices.discoverCatalog("))
+        #expect(!settings.contains("ACPProviderModelProbe("))
         #expect(!source.contains("CordisContext"))
     }
 
@@ -39,6 +43,29 @@ struct AgentProviderCompositionBoundaryTests {
         #expect(controller.contains("runtime.prepareStart("))
         #expect(runtime.contains("providerServices.prepareInteractive("))
         #expect(runtime.contains("preparedInteractiveOperation:"))
+    }
+
+    @Test("only provider assembly constructs the runtime")
+    func onlyProviderAssemblyConstructsRuntime() throws {
+        let root = repositoryRoot()
+        let sourceRoot = root.appendingPathComponent("Sources")
+        let approvedPath = "WikiFSEngine/AgentProviderRuntimeAssembly.swift"
+        let enumerator = try #require(
+            FileManager.default.enumerator(
+                at: sourceRoot,
+                includingPropertiesForKeys: nil))
+        var constructionPaths: [String] = []
+
+        for case let fileURL as URL in enumerator where fileURL.pathExtension == "swift" {
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            guard source.contains("AgentProviderRuntime(") else { continue }
+            constructionPaths.append(
+                fileURL.path.replacingOccurrences(
+                    of: sourceRoot.path + "/",
+                    with: ""))
+        }
+
+        #expect(constructionPaths == [approvedPath])
     }
 
     @Test("provider assembly excludes app and process owners")

--- a/Tests/WikiFSTests/AgentProviderRuntimeAssemblyTests.swift
+++ b/Tests/WikiFSTests/AgentProviderRuntimeAssemblyTests.swift
@@ -46,6 +46,86 @@ struct AgentProviderRuntimeAssemblyTests {
         }
     }
 
+    @Test("catalog discovery resolves command and credential through the runtime")
+    func catalogDiscoveryUsesRuntimeDependencies() async throws {
+        let calls = CatalogProbeCalls()
+        let provider = AgentProvider(
+            id: ProviderID(rawValue: "draft"),
+            label: "Draft",
+            command: ["draft-agent", "--acp"],
+            env: ["MODE": "test"])
+        let expected = ACPProviderCatalogObservation(
+            providerID: provider.id,
+            fingerprint: nil,
+            models: [CachedModelInfo(
+                modelId: ModelID(rawValue: "test-model"),
+                name: "Test Model",
+                description: nil)],
+            currentModelID: ModelID(rawValue: "test-model"),
+            thinkingCapability: nil)
+        let assembly = AgentProviderRuntimeAssembly(
+            readConfiguration: { AgentProvidersConfig(providers: []) },
+            resolveCommand: { providers in
+                #expect(providers == [provider])
+                return [provider.id: ["/resolved/draft-agent", "--acp"]]
+            },
+            readCredential: { providerID in
+                #expect(providerID == provider.id)
+                return "secret"
+            },
+            resolvePermissionPolicy: { _ in .bypass },
+            probeCatalog: { receivedProvider, command, credential in
+                await calls.record(
+                    provider: receivedProvider,
+                    command: command,
+                    credential: credential)
+                return expected
+            })
+        let handle = try await assembly.assemble(
+            registrationOrder: AgentProviderRuntimeAssembly.Component.allCases.shuffled())
+
+        let observation = try await handle.services.discoverCatalog(for: provider)
+
+        #expect(observation == expected)
+        #expect(await calls.provider == provider)
+        #expect(await calls.command == ["/resolved/draft-agent", "--acp"])
+        #expect(await calls.credential == "secret")
+        try await handle.dispose()
+    }
+
+    @Test("catalog discovery rejects a missing resolved command")
+    func catalogDiscoveryRejectsMissingCommand() async throws {
+        let handle = try await AgentProviderRuntimeAssembly(
+            readConfiguration: { AgentProvidersConfig(providers: []) },
+            resolveCommand: { _ in [:] },
+            readCredential: { _ in nil },
+            resolvePermissionPolicy: { _ in .bypass })
+            .assemble()
+        let provider = AgentProvider(
+            id: ProviderID(rawValue: "missing"),
+            label: "Missing",
+            command: ["missing-agent"])
+
+        await #expect(throws: ACPProviderModelProbeError.notConfigured) {
+            try await handle.services.discoverCatalog(for: provider)
+        }
+        try await handle.dispose()
+    }
+
+    @Test("disposed runtime rejects catalog discovery")
+    func disposedRuntimeRejectsCatalogDiscovery() async throws {
+        let handle = try await makeAssembly().assemble()
+        try await handle.dispose()
+
+        await #expect(throws: AgentProviderRuntimeError.unavailable) {
+            try await handle.services.discoverCatalog(
+                for: AgentProvider(
+                    id: ProviderID(rawValue: "test"),
+                    label: "Test",
+                    command: ["/test/provider"]))
+        }
+    }
+
     @Test("assembly source contains only approved headless boundaries")
     func assemblyContainsOnlyApprovedHeadlessBoundaries() throws {
         let source = try String(
@@ -58,6 +138,7 @@ struct AgentProviderRuntimeAssemblyTests {
             "agent-provider.credential-reader",
             "agent-provider.permission-policy-resolver",
             "agent-provider.backend-factory",
+            "agent-provider.catalog-probe",
             "agent-provider.runtime",
             "agent-provider.services",
         ]
@@ -97,6 +178,22 @@ struct AgentProviderRuntimeAssemblyTests {
             readCredential: { _ in nil },
             resolvePermissionPolicy: { _ in .bypass },
             makeBackend: { _, _, _ in FakeAgentBackend() })
+    }
+}
+
+private actor CatalogProbeCalls {
+    private(set) var provider: AgentProvider?
+    private(set) var command: [String]?
+    private(set) var credential: String?
+
+    func record(
+        provider: AgentProvider,
+        command: [String],
+        credential: String?
+    ) {
+        self.provider = provider
+        self.command = command
+        self.credential = credential
     }
 }
 

--- a/plans/cordis-agent-provider-composition.md
+++ b/plans/cordis-agent-provider-composition.md
@@ -18,7 +18,8 @@ The process scope owns these services:
 - operation policy resolution;
 - PATH and credential resolution;
 - private provider spawn records;
-- backend construction and reuse by operation snapshot and provider ID.
+- backend construction and reuse by operation snapshot and provider ID;
+- provider catalog discovery with the same command and credential resolvers.
 
 The queue runtime remains a child composition boundary. `QueueRuntimeAssembly` still owns queue stores, providers, factories, output, and engine lifecycle.
 
@@ -70,6 +71,7 @@ Diagnostics can include provider IDs and operation kinds. Diagnostics cannot inc
 
 The app injects the same facade into these clients:
 
+- the provider settings view;
 - the settings launcher;
 - every `WikiSession` launcher;
 - `AppQueueIngestionProvider`.

--- a/progress/2026-08-19T060000Z-cordis-agent-provider-composition.md
+++ b/progress/2026-08-19T060000Z-cordis-agent-provider-composition.md
@@ -134,3 +134,19 @@ The remaining low findings cover PATH error-message quality, daemon-only behavio
 A follow-up removed the daemon cold-start duplicate configuration read. One process-local preparation now supplies claim attribution and launcher startup. Preflight failure closes the prepared runtime before retry, so a released token cannot become a permanent retry failure.
 
 Follow-up verification passed `make build`, `make test` with 3,421 tests, the 10-test store concurrency gate, bare SwiftPM gates, and 112 focused chat/provider tests. GLM 5.2 reviewed the follow-up, found one medium retry defect, verified its fix, and returned `APPROVE WITH NON-BLOCKING FINDINGS`.
+
+## Provider catalog follow-up
+
+The provider runtime now owns ACP catalog discovery. The Cordis graph registers a typed `agent-provider.catalog-probe` capability.
+
+The runtime resolves the draft provider command and credential through its declared dependencies. It returns only the typed catalog observation.
+
+The provider settings view receives the existing stable facade. It no longer resolves the command or constructs `ACPProviderModelProbe`.
+
+The view still owns draft input, refresh presentation state, and configuration persistence. Cordis does not own SwiftUI or persisted configuration state.
+
+Focused tests cover shuffled registration, dependency routing, missing commands, disposal, the fixed service label, and the removed direct construction path.
+
+Final verification passed `make build`. It also passed `make test` with 3,475 tests in 335 suites.
+
+An independent review found two medium safeguards. The implementation now cancels stale provider refresh tasks and rejects stale completions. A source-policy test also restricts direct `AgentProviderRuntime` construction to the approved assembly file.


### PR DESCRIPTION
## Summary

- Add provider catalog discovery to the stable `AgentProviderServices` facade.
- Register a typed Cordis catalog probe capability.
- Resolve draft provider commands and credentials through declared runtime dependencies.
- Route the provider settings refresh through the stable facade.
- Cancel stale refresh tasks and reject stale completions.
- Add assembly and source-policy tests for the new boundary.

## Ownership boundary

Cordis owns command resolution, credential resolution, and the one-shot ACP probe operation.

SwiftUI still owns draft input, refresh presentation state, and configuration persistence. The Cordis context remains private to the runtime handle.

## Verification

- `make build`
- `make test` — 3,475 tests in 335 suites
- focused provider runtime and boundary suites
- pre-commit SwiftLint — 0 violations in 540 files
- no new bare `try?`

## Review

An independent review found no blocking issues. It identified stale refresh completion and direct-construction guard gaps. This branch fixes both.

## Known limitation

`scripts/validate-skills` is not present in this checkout, so that command could not run. This branch does not change skill definitions.
