### PR TITLE
feat(renderer): expose JSON Canvas sources

### DIFF
--- a/Sources/WikiFS/Renderer/JSONCanvasDocument.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasDocument.swift
@@ -398,11 +398,24 @@ struct JSONCanvasDocument: Sendable, Equatable {
             let internalLink = JSONCanvasInternalLink.file(reference)
             return (internalLink.displayLabel, internalLink)
         case "link":
-            guard let rawURL = wireNode.url,
-                  let reference = JSONCanvasWikiReference(rawValue: rawURL)
+            guard let rawURL = wireNode.url else {
+                throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue)
+            }
+            if let reference = JSONCanvasWikiReference(rawValue: rawURL) {
+                let internalLink = JSONCanvasInternalLink.wiki(reference)
+                return (internalLink.displayLabel, internalLink)
+            }
+            guard rawURL.hasPrefix("[[") == false,
+                  rawURL.hasSuffix("]]") == false
             else { throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue) }
-            let internalLink = JSONCanvasInternalLink.wiki(reference)
-            return (internalLink.displayLabel, internalLink)
+            guard let url = URL(string: rawURL),
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "https" || scheme == "http"
+            else { throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue) }
+            return (rawURL, nil)
+        case "group":
+            let label = wireNode.label?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (label?.isEmpty == false ? label ?? "Group" : "Group", nil)
         default:
             throw JSONCanvasDecodingError.unsupportedNodeType(wireNode.type)
         }
@@ -461,6 +474,7 @@ private struct JSONCanvasWireNode: Decodable {
     let text: String?
     let file: String?
     let url: String?
+    let label: String?
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: JSONCanvasWireKey.self)
@@ -471,8 +485,12 @@ private struct JSONCanvasWireNode: Decodable {
             allowedKeys = ["id", "type", "x", "y", "width", "height", "text"]
         case "file":
             allowedKeys = ["id", "type", "x", "y", "width", "height", "file"]
+        case "group":
+            allowedKeys = ["id", "type", "x", "y", "width", "height", "label", "color", "fontSize"]
+        case "link":
+            allowedKeys = ["id", "type", "x", "y", "width", "height", "url", "color", "fontSize"]
         default:
-            allowedKeys = ["id", "type", "x", "y", "width", "height", "url"]
+            allowedKeys = ["id", "type", "x", "y", "width", "height"]
         }
         try JSONCanvasWireValidation.rejectUnknownKeys(container.allKeys, allowed: allowedKeys)
 
@@ -485,6 +503,7 @@ private struct JSONCanvasWireNode: Decodable {
         text = try container.decodeIfPresent(String.self, forKey: .text)
         file = try container.decodeIfPresent(String.self, forKey: .file)
         url = try container.decodeIfPresent(String.self, forKey: .url)
+        label = try container.decodeIfPresent(String.self, forKey: .label)
     }
 }
 
@@ -497,7 +516,7 @@ private struct JSONCanvasWireEdge: Decodable {
         let container = try decoder.container(keyedBy: JSONCanvasWireKey.self)
         try JSONCanvasWireValidation.rejectUnknownKeys(
             container.allKeys,
-            allowed: ["id", "fromNode", "toNode"]
+            allowed: ["id", "fromNode", "toNode", "label", "fromSide", "toSide", "fromEnd", "toEnd"]
         )
         id = try container.decode(String.self, forKey: .id)
         fromNode = try container.decode(String.self, forKey: .fromNode)
@@ -531,6 +550,7 @@ private struct JSONCanvasWireKey: CodingKey, Hashable {
     static let text = Self("text")
     static let file = Self("file")
     static let url = Self("url")
+    static let label = Self("label")
     static let fromNode = Self("fromNode")
     static let toNode = Self("toNode")
 }

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -161,7 +161,10 @@ struct SourceRendererPresentationPlanner: Sendable {
     }
 
     nonisolated static func standaloneDiagramSource(_ source: SourceSummary) -> Bool {
-        MimeType.isMermaid(source.mimeType) || source.ext.lowercased() == MermaidSourceDetector.mermaidExtension || source.ext.lowercased() == "mermaid"
+        MimeType.isMermaid(source.mimeType)
+            || source.ext.lowercased() == MermaidSourceDetector.mermaidExtension
+            || source.ext.lowercased() == "mermaid"
+            || source.ext.lowercased() == "canvas"
     }
 
     private enum MediaMIMECandidate: Sendable, Equatable {

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -385,6 +385,12 @@ struct SourceDetailView: View {
         return ext == MermaidSourceDetector.mermaidExtension || ext == "mermaid"
     }
 
+    /// JSON Canvas exposes its own spatial outline inside the native renderer.
+    /// Do not show an empty Markdown-heading outline beside it.
+    private var isPureJSONCanvasSource: Bool {
+        file.ext.lowercased() == "canvas"
+    }
+
     /// `true` when the outline sidebar is meaningful for this source: there's
     /// markdown content AND it isn't a pure Mermaid diagram. Gates both the
     /// outline pane and its toggle button so a `.mmd` source never shows a
@@ -393,7 +399,7 @@ struct SourceDetailView: View {
     /// without this guard it leaks from a previous markdown source).
     /// Issue #642.
     private var isOutlineApplicable: Bool {
-        !isPureMermaidSource && isMarkdownEditable
+        !isPureMermaidSource && !isPureJSONCanvasSource && isMarkdownEditable
     }
 
     private var displayName: String {

--- a/Sources/WikiFSTypes/MimeType.swift
+++ b/Sources/WikiFSTypes/MimeType.swift
@@ -46,6 +46,10 @@ public enum MimeType {
     /// `text/x-mermaid` — the `x-` variant some tools emit for Mermaid sources.
     public static let mermaidX = "text/x-mermaid"
 
+    /// `application/json` — JSON Canvas files use JSON as their registered
+    /// media type. The `.canvas` extension remains the format discriminator.
+    public static let json = "application/json"
+
     /// `application/xhtml+xml`.
     public static let xhtml = "application/xhtml+xml"
 
@@ -111,6 +115,7 @@ public enum MimeType {
     public static func mime(forExtension ext: String) -> String? {
         switch ext.lowercased() {
         case "mmd", "mermaid": return mermaid
+        case "canvas": return json
         default: return nil
         }
     }

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -144,6 +144,24 @@ import WikiFSTypes
         #expect(id == .jsonCanvas)
     }
 
+    @Test("JSON Canvas sources use the raw source presentation")
+    func plannerUsesRawPresentationForCanvasSources() throws {
+        let source = SourceSummary(
+            id: .init(rawValue: "source"),
+            filename: "diagram.canvas",
+            ext: "canvas",
+            mimeType: MimeType.json,
+            byteSize: 32,
+            createdAt: .distantPast,
+            updatedAt: .distantPast,
+            version: 1)
+
+        #expect(SourceRendererPresentationPlanner.standaloneDiagramSource(source))
+        #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
+            for: source,
+            currentMarkdown: "{\"nodes\":[],\"edges\":[]}"))
+    }
+
     @Test("JSON Canvas factory returns nil for unavailable and malformed input so the host keeps Source")
     @MainActor
     func jsonCanvasFactoryFailsClosedToHostFallback() throws {

--- a/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
+++ b/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
@@ -116,7 +116,7 @@ struct JSONCanvasRendererTests {
     }
 
     @Test("decoder rejects unavailable malformed oversized and unsupported Canvas input")
-    func decoderRejectsInvalidInput() {
+    func decoderRejectsInvalidInput() throws {
         #expect(throws: JSONCanvasDecodingError.unavailableInput) {
             try JSONCanvasDocument.decode(nil)
         }
@@ -126,9 +126,8 @@ struct JSONCanvasRendererTests {
         #expect(throws: JSONCanvasDecodingError.oversizedInput) {
             try JSONCanvasDocument.decode(Data(repeating: 0, count: JSONCanvasLimits.maximumInputByteCount + 1))
         }
-        #expect(throws: JSONCanvasDecodingError.unsupportedNodeType("group")) {
-            try JSONCanvasDocument.decode(Self.unsupportedGroupCanvas)
-        }
+        let groupedDocument = try #require(try? JSONCanvasDocument.decode(Self.unsupportedGroupCanvas))
+        #expect(groupedDocument.outline.contains { $0.label == "Group" })
         #expect(throws: JSONCanvasDecodingError.malformedDocument) {
             try JSONCanvasDocument.decode(Self.textNodeWithURLCanvas)
         }
@@ -377,7 +376,7 @@ struct JSONCanvasRendererTests {
     private static let unsupportedGroupCanvas = Data("""
     {
       "nodes": [
-        {"id":"link","type":"group","x":0,"y":0,"width":120,"height":60,"url":"https://example.com"}
+        {"id":"group","type":"group","x":0,"y":0,"width":120,"height":60,"label":"Group"}
       ],
       "edges": []
     }
@@ -394,7 +393,6 @@ struct JSONCanvasRendererTests {
         fileLinkCanvas("notes.md?query"),
         fileLinkCanvas("notes.md#fragment"),
         fileLinkCanvas("notes%2Fsecret.md"),
-        wikiLinkCanvas("https://example.com"),
         wikiLinkCanvas("wiki://page?id=01J00000000000000000000000"),
         wikiLinkCanvas("[[page:not-a-ulid]]"),
         wikiLinkCanvas("[[page:01J00000000000000000000000|Alias]]"),

--- a/Tests/WikiFSAppTests/SourcesTests.swift
+++ b/Tests/WikiFSAppTests/SourcesTests.swift
@@ -128,6 +128,13 @@ struct SourcesTests {
         #expect(source.mimeType == MimeType.mermaid)
     }
 
+    @Test func canvasExtensionResolvesToJSONMime() throws {
+        let store = try tempStore()
+        let source = try store.addSource(
+            filename: "diagram.canvas", data: Data("{\"nodes\":[],\"edges\":[]}".utf8))
+        #expect(source.mimeType == MimeType.json)
+    }
+
     @Test func explicitMimeStillWinsOverMmdExtension() throws {
         // The `mimeType:` parameter is the first fallback tried; a caller that
         // says "this is application/custom" must win over the `.mmd` map.

--- a/progress/2026-08-20T072000Z-json-canvas-source-availability.md
+++ b/progress/2026-08-20T072000Z-json-canvas-source-availability.md
@@ -1,0 +1,25 @@
+---
+timestamp: 2026-08-20T072000Z
+title: Make JSON Canvas source content available
+branch: feature/json-canvas-source-renderer
+status: complete
+---
+
+# Make JSON Canvas source content available
+
+## Progress
+
+The existing native JSON Canvas renderer now receives source content from
+`SourceDetailView`. The `.canvas` extension resolves to `application/json`.
+The Source pane shows the raw JSON in a code block. The existing renderer host
+provides the Reader, Rendered, and Split presentations.
+
+The decoder now accepts standard group nodes and HTTP(S) link nodes. It still
+rejects unsafe file references, malformed wiki links, invalid geometry, and
+oversized input.
+
+## Verification
+
+`WIKIFS_APP_TESTS=1 swift test --filter 'WikiFSAppTests.JSONCanvasRendererTests|WikiFSAppTests.BuiltInRendererRegistryTests|WikiFSAppTests.SourcesTests'` passed.
+
+The focused run covered 89 tests with zero failures.


### PR DESCRIPTION
## Summary

- expose `.canvas` files through the existing Source, Rendered, and Split renderer host
- derive `application/json` for `.canvas` imports and show raw JSON in the Source pane
- accept standard JSON Canvas group and HTTP(S) link nodes
- keep the native renderer outline as the navigable canvas outline

## Verification

- `swift build`
- `WIKIFS_APP_TESTS=1 swift test --filter 'WikiFSAppTests.JSONCanvasRendererTests|WikiFSAppTests.BuiltInRendererRegistryTests|WikiFSAppTests.SourcesTests'`
- 89 focused tests passed

Closes #594