### PR TITLE
fix(daemon): retry transport assembly and preserve chat connection

### DIFF
--- a/Sources/WikiDaemonContract/WikiDaemonError.swift
+++ b/Sources/WikiDaemonContract/WikiDaemonError.swift
@@ -12,7 +12,7 @@ public enum WikiDaemonError: Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .connectionFailed:
-            return "Could not connect to the wikid daemon. Is it running? (make install-daemon)"
+            return "Could not connect to the wikid daemon."
         case .unexpectedReply:
             return "The wikid daemon returned an unexpected reply."
         }

--- a/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinator.swift
@@ -30,9 +30,9 @@ extension DaemonWorkloadClient: ChatDaemonCommands {}
 /// the app no longer runs chat in-process; the daemon owns every chat session.
 ///
 /// Injected via the SwiftUI environment (see `ChatDaemonCoordinatorKey`).
-/// When the daemon is unavailable the environment value is `nil` and
-/// `ChatDetailView` renders an unavailable state — there is no local fallback
-/// for chat (the daemon is the single chat owner).
+/// The environment value is `nil` while transport starts or reconnects.
+/// `ChatDetailView` renders a reconnecting state because the daemon is the
+/// single chat owner and the app has no local fallback.
 ///
 /// **Live indicator aggregate:** the coordinator tracks the set of chatIDs the
 /// daemon reports as running (from `chatState` envelopes), even for chats the
@@ -399,12 +399,12 @@ public final class ChatDaemonCoordinator {
 import SwiftUI
 
 private struct ChatDaemonCoordinatorKey: EnvironmentKey {
-    /// `nil` when the daemon is unavailable — chat renders an unavailable state.
+    /// `nil` while the daemon transport starts or reconnects.
     static let defaultValue: ChatDaemonCoordinator? = nil
 }
 
 extension EnvironmentValues {
-    /// The app-wide chat daemon coordinator (nil when the daemon is down).
+    /// The app-wide chat daemon coordinator. It is nil while transport recovers.
     var chatDaemonCoordinator: ChatDaemonCoordinator? {
         get { self[ChatDaemonCoordinatorKey.self] }
         set { self[ChatDaemonCoordinatorKey.self] = newValue }

--- a/Sources/WikiFS/Queue/DaemonTransportAppCoordinator.swift
+++ b/Sources/WikiFS/Queue/DaemonTransportAppCoordinator.swift
@@ -1,4 +1,6 @@
 #if os(macOS)
+// pattern: Imperative Shell
+
 import Foundation
 import WikiCtlCore
 import WikiDaemonContract
@@ -68,6 +70,7 @@ final class DaemonTransportAppCoordinator {
         task?.cancel()
         await task?.value
         connectedCandidateID = nil
+        replaceChatCoordinator(nil)
         await services.stop()
         await bridge.stop()
         observeEvent(.stopped)
@@ -91,6 +94,7 @@ final class DaemonTransportAppCoordinator {
             lifecycle = .stopped
             eventTask = nil
             connectedCandidateID = nil
+            replaceChatCoordinator(nil)
             await bridge.stop()
         case .reconnecting:
             break
@@ -112,16 +116,21 @@ final class DaemonTransportAppCoordinator {
             connection: connection,
             generation: expectedGeneration)
         guard isAdmitted(expectedGeneration) else {
+            replaceChatCoordinator(nil)
             await bridge.remove(id, invalidate: false)
             return
         }
         switch outcome {
         case .connected:
             guard await bridge.markConnected(id) else {
+                replaceChatCoordinator(nil)
                 await services.acknowledge(.init(candidateID: id, outcome: .retry))
                 return
             }
         case .retry, .localFallbackReady:
+            // The coordinator now returns `.connected` after safe queue
+            // relinquishment so chat remains available. Keep the shared
+            // outcome exhaustive for defensive handling of future callers.
             await bridge.remove(id, invalidate: false)
         }
         await services.acknowledge(.init(candidateID: id, outcome: outcome))
@@ -145,6 +154,11 @@ final class DaemonTransportAppCoordinator {
                 return (
                     .init(client: proxy, epoch: epoch),
                     ChatDaemonCoordinator(client: workloadClient, eventSink: eventSink))
+            }
+            let makeChatCoordinator: () -> ChatDaemonCoordinator = {
+                let eventSink = DaemonQueueEventSink()
+                workloadClient.registerEventSink(eventSink)
+                return ChatDaemonCoordinator(client: workloadClient, eventSink: eventSink)
             }
 
             if case .shutdownBlocked = queueController.state {
@@ -170,7 +184,8 @@ final class DaemonTransportAppCoordinator {
                     guard isAdmitted(expectedGeneration) else { return .retry }
                     if fellBack {
                         DebugLog.store("WikiFSApp: daemon relinquished queue ownership — local runtime ready")
-                        return .localFallbackReady
+                        replaceChatCoordinator(makeChatCoordinator())
+                        return .connected
                     }
                     return .retry
                 } catch {
@@ -184,7 +199,9 @@ final class DaemonTransportAppCoordinator {
                         daemon.endpoint,
                         expectedEpoch: expectedEpoch)
                     guard isAdmitted(expectedGeneration) else { return .retry }
-                    if accepted { replaceChatCoordinator(daemon.chatCoordinator) }
+                    if accepted {
+                        replaceChatCoordinator(daemon.chatCoordinator)
+                    }
                     return accepted ? .connected : .retry
                 }
             }
@@ -209,19 +226,22 @@ final class DaemonTransportAppCoordinator {
     }
 
     private func handleInvalidation() async {
-        guard let id = connectedCandidateID else { return }
+        let id = connectedCandidateID
         connectedCandidateID = nil
-        await bridge.remove(id, invalidate: false)
-        DebugLog.store("WikiFSApp: daemon disconnected — queue ownership is unresolved")
+        if let id {
+            await bridge.remove(id, invalidate: false)
+        } else {
+            DebugLog.store("WikiFSApp: daemon disconnected before candidate state was published")
+        }
+        replaceChatCoordinator(nil)
         guard case .daemonActive(let epoch) = queueController.state else {
-            DebugLog.store("WikiFSApp: disconnect had no active daemon ownership epoch")
-            replaceChatCoordinator(nil)
+            DebugLog.store("WikiFSApp: daemon disconnected — local queue ownership remains local")
             return
         }
+        DebugLog.store("WikiFSApp: daemon disconnected — queue ownership is unresolved")
         await queueController.daemonOwnershipBecameUnresolved(
             expectedEpoch: epoch,
             reason: "Daemon connection was invalidated")
-        replaceChatCoordinator(nil)
     }
 
     private func handleInterruption(_ id: DaemonTransportCandidateID) async {

--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -284,19 +284,23 @@ struct WikiDetailView: View {
             // this makes chat→chat behave the same way.
             .id(chatID)
         } else {
-            chatDaemonUnavailable
+            chatDaemonConnecting
         }
     }
 
-    /// Shown when the wikid daemon is unavailable — chat is daemon-hosted
-    /// after Phase C4, so there is no local fallback. The queue/extraction
-    /// surface still works (it has a local fallback), but interactive chat
-    /// requires the daemon.
-    private var chatDaemonUnavailable: some View {
+    /// Shown while the daemon transport is starting or reconnecting. Chat is
+    /// daemon-hosted after Phase C4, so the coordinator is allowed to be nil
+    /// during that short transition but must never present a manual-install
+    /// failure for it.
+    private var chatDaemonConnecting: some View {
         ContentUnavailableView {
-            Label("Chat Unavailable", systemImage: "bubble.left.and.bubble.right.slash")
+            Label("Connecting to Chat", systemImage: "bubble.left.and.bubble.right")
         } description: {
-            Text("Interactive chat requires the wikid daemon. Run “make install-daemon” and relaunch.")
+            VStack(spacing: 8) {
+                Text("The wikid daemon is starting. Chat will connect automatically.")
+                ProgressView()
+                    .controlSize(.small)
+            }
         }
     }
 

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -103,7 +103,8 @@ struct WikiFSApp: App {
     /// App-wide chat daemon coordinator (Phase C4). Owns the per-chat
     /// `RemoteChatSession` registry + wraps the 6 chat XPC commands. `nil`
     /// when the daemon is unavailable — chat surfaces then render an
-    /// unavailable state (no local fallback; the daemon owns chat).
+    /// reconnecting state while transport starts or recovers. Chat has no local
+    /// fallback because the daemon owns chat.
     @State private var chatDaemonCoordinator: ChatDaemonCoordinator?
 
     /// Presentation-only adapter for typed daemon transport events.
@@ -603,6 +604,9 @@ struct WikiFSApp: App {
 
     @MainActor
     private func connectToDaemon() {
+        // Start composition if needed. The owner ignores duplicate calls and
+        // retries assembly while startup remains in progress.
+        Task { await daemonTransportCompositionOwner.start() }
         daemonTransportCoordinator.installChatReplacement { coordinator in
             replaceChatDaemonCoordinator(coordinator)
         }

--- a/Sources/WikiFSEngine/DaemonTransportCompositionOwner.swift
+++ b/Sources/WikiFSEngine/DaemonTransportCompositionOwner.swift
@@ -1,4 +1,6 @@
 #if os(macOS)
+// pattern: Imperative Shell
+
 import Foundation
 import WikiFSCore
 
@@ -12,6 +14,7 @@ extension DaemonTransportRuntimeHandle: DaemonTransportRuntimeOwning {}
 private actor MutableDaemonTransportServices {
     nonisolated let facade: DaemonTransportServices
 
+    private let relay: DaemonTransportServiceRelay
     private var installed: DaemonTransportServices?
     private var startRequested = false
     private var stopped = false
@@ -20,6 +23,7 @@ private actor MutableDaemonTransportServices {
 
     init() {
         let relay = DaemonTransportServiceRelay()
+        self.relay = relay
         facade = relay.facade
         relay.bind(self)
     }
@@ -112,7 +116,7 @@ private actor MutableDaemonTransportServices {
 // swiftlint:disable:next unchecked_sendable
 private final class DaemonTransportServiceRelay: @unchecked Sendable {
     private let lock = NSLock()
-    private var target: MutableDaemonTransportServices?
+    private weak var target: MutableDaemonTransportServices?
 
     lazy var facade = DaemonTransportServices(
         startAdmission: { [weak self] in await self?.readTarget()?.startAdmission() },
@@ -156,13 +160,18 @@ public actor DaemonTransportCompositionOwner {
 
     private let mutableServices: MutableDaemonTransportServices
     private let assemble: AssemblyFactory
+    private let retryInterval: Duration
     private var state: State = .idle
 
-    public init(assemble: @escaping AssemblyFactory) {
+    public init(
+        retryInterval: Duration = .seconds(1),
+        assemble: @escaping AssemblyFactory
+    ) {
         let mutableServices = MutableDaemonTransportServices()
         self.mutableServices = mutableServices
         services = mutableServices.facade
         self.assemble = assemble
+        self.retryInterval = retryInterval
     }
 
     public func start() {
@@ -174,7 +183,7 @@ public actor DaemonTransportCompositionOwner {
         state = .starting(task)
     }
 
-    public func awaitSettled() async {
+    func awaitSettled() async {
         guard case .starting(let task) = state else { return }
         await task.value
     }
@@ -198,24 +207,35 @@ public actor DaemonTransportCompositionOwner {
     }
 
     private func runStartup() async {
-        do {
-            let handle = try await assemble()
-            guard case .starting = state, !Task.isCancelled else {
-                try await handle.dispose()
+        while !Task.isCancelled {
+            do {
+                let handle = try await assemble()
+                guard case .starting = state, !Task.isCancelled else {
+                    try await handle.dispose()
+                    return
+                }
+                await mutableServices.install(handle.services)
+                guard case .starting = state, !Task.isCancelled else {
+                    try await handle.dispose()
+                    return
+                }
+                state = .installed(handle)
                 return
-            }
-            await mutableServices.install(handle.services)
-            guard case .starting = state, !Task.isCancelled else {
-                try await handle.dispose()
+            } catch is CancellationError {
                 return
+            } catch {
+                guard case .starting = state else { return }
+                DebugLog.store(
+                    "Daemon transport assembly failed; retrying in \(retryInterval): \(error)")
+                do {
+                    try await Task.sleep(for: retryInterval)
+                } catch is CancellationError {
+                    return
+                } catch {
+                    DebugLog.store("Daemon transport assembly retry delay failed: \(error)")
+                    return
+                }
             }
-            state = .installed(handle)
-        } catch is CancellationError {
-            return
-        } catch {
-            guard case .starting = state else { return }
-            state = .idle
-            DebugLog.store("Daemon transport assembly failed; local queue remains active: \(error)")
         }
     }
 }

--- a/Tests/WikiFSTests/DaemonTransportBoundaryPolicyTests.swift
+++ b/Tests/WikiFSTests/DaemonTransportBoundaryPolicyTests.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import Foundation
 import Testing
+@testable import WikiDaemonContract
 
 @Suite("Daemon transport boundary policy")
 struct DaemonTransportBoundaryPolicyTests {
@@ -76,6 +77,27 @@ struct DaemonTransportBoundaryPolicyTests {
                 #expect(!source.contains(symbol), "Forbidden \(symbol) in \(path)")
             }
         }
+    }
+
+    @Test("chat nil state is a reconnecting state, not a manual install failure")
+    func chatUnavailableCopyDoesNotRequireManualDaemonInstall() throws {
+        let source = try read(
+            "Sources/WikiFS/Window/WikiDetailView.swift",
+            root: repositoryRoot())
+
+        #expect(!source.contains("make install-daemon"))
+        #expect(source.contains("Chat will connect automatically"))
+        #expect(!WikiDaemonError.connectionFailed.localizedDescription.contains("make install-daemon"))
+    }
+
+    @Test("safe queue relinquishment keeps chat connected")
+    func safeQueueRelinquishmentKeepsChatConnected() throws {
+        let source = try read(
+            "Sources/WikiFS/Queue/DaemonTransportAppCoordinator.swift",
+            root: repositoryRoot())
+
+        #expect(!source.contains("return .localFallbackReady"))
+        #expect(source.contains("replaceChatCoordinator(makeChatCoordinator())"))
     }
 }
 

--- a/Tests/WikiFSTests/DaemonTransportCompositionOwnerTests.swift
+++ b/Tests/WikiFSTests/DaemonTransportCompositionOwnerTests.swift
@@ -1,0 +1,79 @@
+#if os(macOS)
+import Synchronization
+import Testing
+@testable import WikiFSEngine
+
+@Suite("Daemon transport composition owner", .serialized, .timeLimit(.minutes(1)))
+struct DaemonTransportCompositionOwnerTests {
+    @Test("retries assembly failure without another app lifecycle event")
+    func retriesAssemblyFailure() async {
+        let attempts = AssemblyAttempts()
+        let handle = RecordingTransportRuntimeHandle()
+        let owner = DaemonTransportCompositionOwner(
+            retryInterval: .zero
+        ) {
+            let attempt = await attempts.next()
+            if attempt == 1 { throw FirstAssemblyAttemptError() }
+            return handle
+        }
+
+        await owner.services.startAdmission()
+        await owner.start()
+        await owner.awaitSettled()
+
+        #expect(await attempts.count == 2)
+        #expect(await handle.admissionStartCount() == 1)
+        await owner.shutdown()
+        #expect(handle.disposeCount == 1)
+    }
+}
+
+private actor AssemblyAttempts {
+    private var value = 0
+
+    func next() -> Int {
+        value += 1
+        return value
+    }
+
+    var count: Int { value }
+}
+
+private struct FirstAssemblyAttemptError: Error {}
+
+private actor AdmissionStarts {
+    private var value = 0
+
+    func increment() {
+        value += 1
+    }
+
+    var count: Int { value }
+}
+
+private final class RecordingTransportRuntimeHandle: DaemonTransportRuntimeOwning, @unchecked Sendable {
+    let services: DaemonTransportServices
+    private let admissionCounter: AdmissionStarts
+    private let disposeCounter = Mutex(0)
+
+    init() {
+        let starts = AdmissionStarts()
+        self.admissionCounter = starts
+        services = DaemonTransportServices(
+            startAdmission: { await starts.increment() },
+            acknowledge: { _ in },
+            requestManualReconnect: {},
+            events: { AsyncStream { $0.finish() } },
+            availability: { .idle },
+            stop: {})
+    }
+
+    func admissionStartCount() async -> Int { await admissionCounter.count }
+
+    var disposeCount: Int { disposeCounter.withLock { $0 } }
+
+    func dispose() async throws {
+        disposeCounter.withLock { $0 += 1 }
+    }
+}
+#endif

--- a/plans/cordis-daemon-transport-services.md
+++ b/plans/cordis-daemon-transport-services.md
@@ -49,7 +49,7 @@ The runtime allocates a new `DaemonTransportCandidateID` before each attempt. Th
 
 A successful health probe publishes `awaitingAcceptance`. It does not publish `connected`.
 
-The app validates queue ownership and installs the queue endpoint. The app then sends one acknowledgement for the same candidate ID.
+The app checks queue ownership and tries to install the queue endpoint. After safe queue relinquishment, the app keeps the healthy connection for chat while the local queue runs. It then sends one acknowledgement for the same candidate ID.
 
 The acknowledgement outcome is `connected`, `retry`, or `localFallbackReady`.
 
@@ -65,7 +65,7 @@ The bridge returns only a narrow `DaemonTransportConnection` wrapper to the Engi
 
 `DaemonTransportAppCoordinator` resolves the concrete connection only for the current candidate ID.
 
-The coordinator preserves the existing queue ownership transaction. It installs a chat coordinator only after queue activation succeeds.
+The coordinator preserves the queue ownership transaction. It keeps a healthy chat connection when the app returns to its local queue after safe daemon relinquishment.
 
 The coordinator contains no Cordis context, activation context, or service key.
 


### PR DESCRIPTION
## Summary

- Retain the daemon transport relay so the app facade reaches the installed runtime.
- Retry transport assembly after a transient startup failure.
- Clear and recreate chat across reconnect races.
- Show a reconnecting chat state instead of the obsolete manual-install error.

## Root cause

Cordis transport composition created a relay with weak facade captures but did not retain the relay. The facade became a no-op after initialization.

Startup assembly also stopped after its first failure. This left chat without a daemon coordinator until a later app event restarted the connection.

## Test plan

- `make build`
- `make test`
- SwiftLint pre-commit hook: 0 violations

The full test run passed 3,489 tests in 338 suites.
