### PR TITLE
Normalize GitHub blob links and preserve JSON document extensions

### DIFF
--- a/Sources/WikiFSCore/Core/ShareLinkNormalizer.swift
+++ b/Sources/WikiFSCore/Core/ShareLinkNormalizer.swift
@@ -1,7 +1,10 @@
 import Foundation
 
-/// Rewrites recognized file-share "preview" links to their direct-download URL —
-/// PURE, so it is unit-tested value-in/value-out and wired into the real fetch.
+// pattern: Functional Core
+
+/// Rewrites recognized file-share and GitHub "preview" links to their
+/// direct-download URL — PURE, so it is unit-tested value-in/value-out and
+/// wired into the real fetch.
 ///
 /// WHY this exists: file-share hosts hand non-browser clients an HTML *landing
 /// page* (a JS interstitial), not the file, unless you hit the direct-download
@@ -26,9 +29,10 @@ public enum ShareLinkNormalizer {
         let rewrite: @Sendable (URL) -> URL
     }
 
-    /// Provider rules, tried in order. Only Dropbox is implemented today; the
-    /// commented shapes below show how Google Drive / OneDrive slot in.
-    static let rules: [Rule] = [dropbox]
+    /// Provider rules, tried in order. The rewrites preserve the resource path
+    /// and query while changing only a known preview URL into its direct-file
+    /// form.
+    static let rules: [Rule] = [githubBlob, dropbox]
 
     /// Rewrite a recognized share link to its direct-download URL; pass anything
     /// else through unchanged.
@@ -37,6 +41,48 @@ public enum ShareLinkNormalizer {
             return rule.rewrite(url)
         }
         return url
+    }
+
+    // MARK: - GitHub
+
+    /// GitHub's `/blob/` URL is an HTML viewer, even when the path ends in a
+    /// file extension. Rewrite it to the raw-content host so callers receive
+    /// the repository bytes instead of the viewer page.
+    static let githubBlob = Rule(
+        matches: { url in
+            githubBlobPathComponents(for: url) != nil
+        },
+        rewrite: { url in
+            guard let path = githubBlobPathComponents(for: url),
+                  var components = URLComponents(
+                    url: url, resolvingAgainstBaseURL: false)
+            else { return url }
+
+            let rawPath = [path[0], path[1], path[3]]
+                + Array(path.dropFirst(4))
+            components.scheme = "https"
+            components.host = "raw.githubusercontent.com"
+            components.percentEncodedPath = "/"
+                + rawPath.map(String.init).joined(separator: "/")
+            return components.url ?? url
+        })
+
+    /// Return the percent-encoded path segments for a public GitHub blob URL:
+    /// `/owner/repository/blob/ref/file`. Keeping the encoded segments intact
+    /// preserves file names and branch names that contain escaped characters.
+    private static func githubBlobPathComponents(for url: URL) -> [Substring]? {
+        guard let host = url.host?.lowercased(),
+              host == "github.com" || host == "www.github.com",
+              let components = URLComponents(
+                url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+
+        let path = components.percentEncodedPath.split(
+            separator: "/", omittingEmptySubsequences: true)
+        guard path.count >= 5, path[2].lowercased() == "blob" else {
+            return nil
+        }
+        return path
     }
 
     // MARK: - Dropbox

--- a/Sources/WikiFSCore/Sources/FormatMaterializer.swift
+++ b/Sources/WikiFSCore/Sources/FormatMaterializer.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// pattern: Functional Core
+
 /// The format-layer types and dispatcher, separated from origin (where bytes
 /// came from). Given bytes + a content-type hint + a pre-computed filename stem
 /// + an optional extension hint, `FormatMaterializer.dispatch` determines the
@@ -82,6 +84,16 @@ public struct FormatPlan: Sendable, Equatable {
 /// bytes + build provenance, then delegate here for content-type dispatch,
 /// HTML→Markdown conversion, and filename derivation.
 public enum FormatMaterializer {
+
+    /// Return a JSON document extension that should survive generic server
+    /// MIME types. GitHub's raw endpoint reports `.canvas` as `text/plain`,
+    /// while the local source MIME table identifies it as JSON Canvas.
+    private static func jsonDocumentExtension(from extensionHint: String?) -> String? {
+        guard let extensionHint,
+              MimeType.mime(forExtension: extensionHint) == MimeType.json
+        else { return nil }
+        return extensionHint.lowercased()
+    }
 
     /// Dispatch bytes to a `FormatPlan`: content-sniff ambiguous types, convert
     /// HTML→Markdown, store PDF/text/binary verbatim, and derive the filename
@@ -246,6 +258,9 @@ public enum FormatMaterializer {
     /// Extension for a `text/*` response: map the common ones, else fall back to
     /// `extensionHint`, else `txt`.
     static func textExtension(forMIME mime: String, extensionHint: String?) -> String {
+        if let jsonExtension = jsonDocumentExtension(from: extensionHint) {
+            return jsonExtension
+        }
         switch mime {
         case MimeType.markdown, MimeType.markdownX: return "md"
         case "text/plain": return "txt"
@@ -261,6 +276,9 @@ public enum FormatMaterializer {
     /// Extension for a non-text response: from the MIME subtype when recognizable,
     /// else `extensionHint`, else empty (no extension).
     static func binaryExtension(forMIME mime: String?, extensionHint: String?) -> String {
+        if let jsonExtension = jsonDocumentExtension(from: extensionHint) {
+            return jsonExtension
+        }
         if let mime {
             switch mime {
             case MimeType.imageJPEG: return "jpg"

--- a/Tests/WikiFSTests/FormatMaterializerTests.swift
+++ b/Tests/WikiFSTests/FormatMaterializerTests.swift
@@ -121,6 +121,25 @@ struct FormatMaterializerTests {
         #expect(plan.filename == "doc.md")
     }
 
+    @Test func canvasExtensionSurvivesGenericJSONContentType() {
+        let canvas = Data("{\"nodes\":[],\"edges\":[]}".utf8)
+        let plan = FormatMaterializer.dispatch(
+            data: canvas, contentType: "text/plain; charset=utf-8",
+            stem: "sample", extensionHint: "canvas")
+
+        #expect(plan.filename == "sample.canvas")
+        #expect(plan.data == canvas)
+    }
+
+    @Test func canvasExtensionSurvivesApplicationJSONContentType() {
+        let plan = FormatMaterializer.dispatch(
+            data: Data("{\"nodes\":[],\"edges\":[]}".utf8),
+            contentType: "application/json",
+            stem: "sample", extensionHint: "canvas")
+
+        #expect(plan.filename == "sample.canvas")
+    }
+
     // MARK: - Binary verbatim (AC.1)
 
     @Test func imageStoredWithInferredExtension() {

--- a/Tests/WikiFSTests/ShareLinkNormalizerTests.swift
+++ b/Tests/WikiFSTests/ShareLinkNormalizerTests.swift
@@ -32,6 +32,16 @@ struct ShareLinkNormalizerTests {
         #expect(normalized.absoluteString == url.absoluteString)
     }
 
+    @Test func githubBlobURLRewritesToRawContentURL() {
+        let url = URL(string:
+            "https://github.com/obsidianmd/jsoncanvas/blob/main/sample.canvas")!
+
+        #expect(
+            ShareLinkNormalizer.normalize(url).absoluteString
+                == "https://raw.githubusercontent.com/obsidianmd/jsoncanvas/main/sample.canvas"
+        )
+    }
+
     @Test func alreadyDirectDropboxURLUntouched() {
         // A direct-download Dropbox URL doesn't match the share-host rule, so it
         // passes through unchanged (no double rewrite).


### PR DESCRIPTION
## Summary

- Rewrite public GitHub `/blob/` links to `raw.githubusercontent.com` URLs.
- Preserve JSON document extensions, including `.canvas`, when servers return generic MIME types.
- Add tests for GitHub links and canvas files.

## Why

GitHub blob links return an HTML viewer instead of file contents. GitHub raw responses can use `text/plain`, which can cause JSON Canvas files to lose their `.canvas` extension.