### PR TITLE
feat(inspector): remove history from page and source sidebars

### DIFF
--- a/Sources/WikiFS/Detail/DetailInspectorView.swift
+++ b/Sources/WikiFS/Detail/DetailInspectorView.swift
@@ -15,12 +15,12 @@ enum InspectorTab: String, CaseIterable, Codable {
     case outline
     case history
 
-    static let pageAvailableTabs: [InspectorTab] = [.metadata, .outline, .history]
+    static let pageAvailableTabs: [InspectorTab] = [.metadata, .outline]
     static let persistedChatAvailableTabs: [InspectorTab] = [.metadata, .outline]
     static let metadataOnlyAvailableTabs: [InspectorTab] = [.metadata]
 
     static func sourceAvailableTabs(hasOutline: Bool) -> [InspectorTab] {
-        hasOutline ? pageAvailableTabs : [.metadata, .history]
+        hasOutline ? pageAvailableTabs : [.metadata]
     }
 
     static func decodePersisted(_ rawValue: String?) -> InspectorTab {
@@ -55,8 +55,9 @@ enum InspectorTab: String, CaseIterable, Codable {
 // MARK: - DetailInspectorView
 
 /// Xcode-style inspector panel for detail views. Shows an ordered, caller-
-/// supplied set of Metadata, Outline, and History tabs when more than one is
-/// available.
+/// supplied set of Metadata and Outline tabs when more than one is available.
+/// The legacy History case remains renderable for compatibility with callers
+/// that still supply it, but current page and source registrations do not.
 ///
 /// - **Outline tab**: renders the `@ViewBuilder` closure passed by the caller
 ///   (the page's `PageOutlineView` or the source's outline view).
@@ -97,6 +98,18 @@ struct DetailInspectorView<Outline: View>: View {
     /// The width to render: the in-flight drag value if dragging, else the
     /// persisted `outlineWidth`.
     private var effectiveWidth: Double { liveWidth ?? outlineWidth }
+
+    /// Keep the segmented picker selection valid while a persisted legacy tab
+    /// value is being normalized by the owning detail view's task.
+    private var inspectorTabSelection: Binding<InspectorTab> {
+        Binding(
+            get: {
+                InspectorTab.normalizedFallback(
+                    selection: inspectorTab,
+                    availableTabs: availableTabs)
+            },
+            set: { inspectorTab = $0 })
+    }
 
     /// Clamp a proposed inspector width to the allowed range.
     private func clampedWidth(_ width: Double) -> Double {
@@ -141,7 +154,7 @@ struct DetailInspectorView<Outline: View>: View {
 
             VStack(alignment: .leading, spacing: 0) {
                 if availableTabs.count >= 2 {
-                    Picker("Inspector section", selection: $inspectorTab) {
+                    Picker("Inspector section", selection: inspectorTabSelection) {
                         ForEach(availableTabs, id: \.self) { tab in
                             Label(tab.label, systemImage: tab.symbol).tag(tab)
                         }

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -36,8 +36,8 @@ struct PageDetailView: View {
     /// Per-view collapse state for the header. Starts collapsed; persists
     /// across same-type tab switches (SwiftUI keeps the view alive).
     @State private var isHeaderExpanded = false
-    /// Provenance for the inspector's History tab. Loaded via `.task(id:)`
-    /// keyed on `currentPageID` so it re-fires on page navigation.
+    /// Legacy provenance payload retained for compatibility with the shared
+    /// inspector. Current page registrations expose Metadata and Outline.
     @State private var provenanceOrigin: PageOrigin?
     @State private var provenanceHistory: [PageOrigin] = []
     @State private var metadataState: MetadataHydrationState = .idle
@@ -565,8 +565,8 @@ struct PageDetailView: View {
         return MarkdownDocumentIdentity(pageID: pageID, pageVersionID: pageVersionID)
     }
 
-    /// Open the Versions window for the current page (#817). Injected into the
-    /// inspector's `ProvenancePanel` as `onCompareVersions` (page-only). The
+    /// Open the Versions window for the current page (#817). The callback is
+    /// retained for legacy history-compatible inspector registrations. The
     /// `WindowGroup(for: PageVersionCompareContext.self)` dedups by pageID +
     /// wikiID, so re-opening focuses the existing window.
     private func openVersionsWindow() {

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -1052,9 +1052,8 @@ struct SourceDetailView: View {
     /// `body` so the type-checker can resolve each subtree independently.
     ///
     /// Uses the shared `DetailInspectorView` (same as `PageDetailView`) so
-    /// sources get the same tabbed inspector (Outline / History). The outline
-    /// tab renders the source's `PageOutlineView`; the History tab renders
-    /// the shared `ProvenancePanel` with the source's provenance.
+    /// sources get the same tabbed inspector. The outline tab renders the
+    /// source's `PageOutlineView`.
     ///
     /// The explicit `.frame(maxWidth: .infinity, maxHeight: .infinity,
     /// alignment: .topLeading)` on `contentArea` is load-bearing and mirrors

--- a/Tests/WikiFSAppTests/InspectorTabTests.swift
+++ b/Tests/WikiFSAppTests/InspectorTabTests.swift
@@ -3,13 +3,13 @@ import Testing
 @testable import WikiFS
 
 struct InspectorTabTests {
-    @Test func pageTabsStartWithMetadata() {
-        #expect(InspectorTab.pageAvailableTabs == [.metadata, .outline, .history])
+    @Test func pageTabsExcludeHistory() {
+        #expect(InspectorTab.pageAvailableTabs == [.metadata, .outline])
     }
 
-    @Test func sourceTabsStartWithMetadata() {
-        #expect(InspectorTab.sourceAvailableTabs(hasOutline: true) == [.metadata, .outline, .history])
-        #expect(InspectorTab.sourceAvailableTabs(hasOutline: false) == [.metadata, .history])
+    @Test func sourceTabsExcludeHistory() {
+        #expect(InspectorTab.sourceAvailableTabs(hasOutline: true) == [.metadata, .outline])
+        #expect(InspectorTab.sourceAvailableTabs(hasOutline: false) == [.metadata])
     }
 
     @Test func chatTabsStartWithMetadata() {
@@ -35,6 +35,13 @@ struct InspectorTabTests {
 
     @Test func legacyHistoryDecodes() {
         #expect(InspectorTab.decodePersisted("history") == .history)
+    }
+
+    @Test func persistedHistorySelectionFallsBackToMetadataForPagesAndSources() {
+        let persistedSelection = InspectorTab.decodePersisted("history")
+        #expect(InspectorTab.normalizedFallback(selection: persistedSelection, availableTabs: InspectorTab.pageAvailableTabs) == .metadata)
+        #expect(InspectorTab.normalizedFallback(selection: persistedSelection, availableTabs: InspectorTab.sourceAvailableTabs(hasOutline: true)) == .metadata)
+        #expect(InspectorTab.normalizedFallback(selection: persistedSelection, availableTabs: InspectorTab.sourceAvailableTabs(hasOutline: false)) == .metadata)
     }
 
     @Test func unknownValueDecodesAsMetadata() {

--- a/progress/2026-08-20T180948Z-remove-page-source-history-sidebar.md
+++ b/progress/2026-08-20T180948Z-remove-page-source-history-sidebar.md
@@ -1,0 +1,30 @@
+---
+timestamp: 2026-08-20T180948Z
+title: Remove page and source history from the right sidebar
+branch: feature/remove-sidebar-page-source-history
+status: complete
+---
+
+# Remove page and source history from the right sidebar
+
+## Progress
+
+Page and source detail views now expose only Metadata and Outline in the right sidebar.
+Sources without an outline expose Metadata only. Legacy History selections fall back to Metadata.
+
+## Verification
+
+The focused app test run passed 15 tests:
+
+```text
+WIKIFS_APP_TESTS=1 swift test --filter InspectorTabTests
+```
+
+The required build and test gates passed:
+
+```text
+make build
+make test
+```
+
+`make test` passed 3,486 tests in 337 suites. `git diff --check` passed.


### PR DESCRIPTION
## Summary

- Remove History from page and source right-sidebar tab lists.
- Show Metadata only when a source has no outline.
- Keep persisted History values compatible by falling back to Metadata.

## Test plan

- [x] `WIKIFS_APP_TESTS=1 swift test --filter InspectorTabTests`
- [x] `make build`
- [x] `make test` — 3,486 tests in 337 suites
- [x] `git diff --check`
