### PR TITLE
fix(json-canvas): support native canvas content

### DIFF
--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -493,7 +493,8 @@ struct PageDetailView: View {
                         inlineAttachmentResolver: RendererInlineAttachmentResolverFactory.make(
                             store: store.internalStore,
                             installedRendererFactory: installedRendererFactory,
-                            installedRendererFactoryInputs: installedRendererFactoryInputs),
+                            installedRendererFactoryInputs: installedRendererFactoryInputs,
+                            onJSONCanvasHostAction: JSONCanvasHostActionRouter.handler(for: store)),
                         findText: findText, findVersion: findVersion,
                         findOccurrence: findOccurrence)
             .frame(maxWidth: .infinity)

--- a/Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift
+++ b/Sources/WikiFS/Reader/RendererAttachmentCoordinator.swift
@@ -1,6 +1,7 @@
 #if os(macOS)
 import CoreGraphics
 import Foundation
+import WikiFSTypes
 
 // pattern: Functional Core — bounded attachment state and geometry are deterministic values.
 
@@ -12,6 +13,13 @@ enum RendererAttachmentHostPolicy {
     static let minimumReservedHeight = 96.0
     static let maximumReservedHeight = 1_200.0
     static let maximumActiveAttachments = 1
+    static let jsonCanvasReservedHeight = 480.0
+
+    static func preferredReservedHeight(for renderer: RendererReference?) -> CGFloat {
+        renderer == BuiltInRendererReference.reference(for: .jsonCanvas)
+            ? jsonCanvasReservedHeight
+            : minimumReservedHeight
+    }
 }
 
 struct RendererAttachmentPlaceholderID: Hashable, Sendable, Equatable {

--- a/Sources/WikiFS/Reader/WikiReaderContainerView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderContainerView.swift
@@ -31,8 +31,8 @@ final class WikiReaderContainerView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         if attachmentOverlay.attachmentClipRect.contains(point), let attachmentChild {
-            let childPoint = attachmentChild.convert(point, from: self)
-            if let hitView = attachmentChild.hitTest(childPoint) {
+            let overlayPoint = attachmentOverlay.convert(point, from: self)
+            if let hitView = attachmentChild.hitTest(overlayPoint) {
                 return hitView
             }
         }
@@ -241,13 +241,13 @@ private final class RendererAttachmentNativeChildView: NSView {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
-        guard bounds.contains(point) else { return nil }
-        let toolbarPoint = toolbar.convert(point, from: self)
-        if let toolbarHit = toolbar.hitTest(toolbarPoint) {
+        let localPoint = convert(point, from: superview)
+        guard bounds.contains(localPoint) else { return nil }
+        if let toolbarHit = toolbar.hitTest(localPoint) {
             return toolbarHit
         }
         guard let hostedContent else { return self }
-        return hostedContent.hitTest(hostedContent.convert(point, from: self)) ?? self
+        return hostedContent.hitTest(localPoint) ?? self
     }
 
     @objc private func openInWindow() {

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1681,13 +1681,19 @@ internal struct WikiReaderRep: NSViewRepresentable {
         }
 
         func handleAttachmentGeometry(_ message: RendererAttachmentGeometryMessage) {
-            guard let attachmentCoordinator, attachmentCoordinator.ingest(message),
+            guard let attachmentCoordinator else { return }
+            let isFirstAcceptedGeometry = attachmentCoordinator.state(for: message.placeholderID) == .unresolved
+            guard attachmentCoordinator.ingest(message),
                   let webView, let attachmentContainer else { return }
-            if message.revision == 1 {
+            if isFirstAcceptedGeometry {
+                let renderer = webView.rendererActivationAdmission?
+                    .attachmentContext(for: message.placeholderID)?
+                    .rendererReference
                 let reservedHeight = attachmentCoordinator.reserveHeight(
-                    RendererAttachmentHostPolicy.minimumReservedHeight, for: message.placeholderID)
+                    RendererAttachmentHostPolicy.preferredReservedHeight(for: renderer),
+                    for: message.placeholderID)
                 let identifier = WikiReaderRep.jsString(message.placeholderID.rawValue)
-                webView.evaluateJavaScript("window.__sdwRendererAttachmentReserve && window.__sdwRendererAttachmentReserve(\(identifier), \(reservedHeight));")
+                webView.evaluateJavaScript("window.__sdwRendererAttachmentReserve && window.__sdwRendererAttachmentReserve(\"\(identifier)\", \(reservedHeight));")
             }
             updateAttachmentViewport(for: message.placeholderID, in: webView, container: attachmentContainer)
             automaticallyMountAttachmentIfPossible(
@@ -1799,6 +1805,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
             let result = attachmentCoordinator.activate(placeholderID)
             guard result == .activate else { return result }
             if let webView {
+                let reservedHeight = attachmentCoordinator.reserveHeight(
+                    RendererAttachmentHostPolicy.preferredReservedHeight(for: context.rendererReference),
+                    for: placeholderID)
+                let identifier = WikiReaderRep.jsString(placeholderID.rawValue)
+                webView.evaluateJavaScript(
+                    "window.__sdwRendererAttachmentReserve && window.__sdwRendererAttachmentReserve(\"\(identifier)\", \(reservedHeight));")
                 updateAttachmentViewport(for: placeholderID, in: webView, container: attachmentContainer)
             }
             attachmentContainer.activateAttachment(
@@ -1854,7 +1866,7 @@ internal struct WikiReaderRep: NSViewRepresentable {
             let function = present
                 ? "window.__sdwRendererAttachmentPresentCollapse"
                 : "window.__sdwRendererAttachmentDismissCollapse"
-            webView.evaluateJavaScript("\(function) && \(function)(\(identifier));")
+            webView.evaluateJavaScript("\(function) && \(function)(\"\(identifier)\");")
         }
 
         func attachmentState(for placeholderID: RendererAttachmentPlaceholderID) -> RendererAttachmentState {

--- a/Sources/WikiFS/Renderer/BuiltInRendererFactoryMap.swift
+++ b/Sources/WikiFS/Renderer/BuiltInRendererFactoryMap.swift
@@ -100,7 +100,9 @@ enum BuiltInRendererFactoryMap {
     private static func makeJSONCanvas(_ inputs: BuiltInRendererFactoryInputs) -> AnyView? {
         do {
             let document = try JSONCanvasDocument.decode(inputs.sourceBytes)
-            return AnyView(JSONCanvasRendererView(document: document))
+            return AnyView(JSONCanvasRendererView(
+                document: document,
+                onHostAction: JSONCanvasHostActionRouter.handler(for: inputs.store)))
         } catch {
             DebugLog.tabs("BuiltInRendererFactoryMap: JSON Canvas decode failed: \(error)")
             return nil

--- a/Sources/WikiFS/Renderer/JSONCanvasDocument.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasDocument.swift
@@ -27,9 +27,60 @@ enum JSONCanvasDecodingError: Error, Equatable {
     case duplicateEdgeID(String)
     case unsupportedNodeType(String)
     case invalidGeometry(String)
+    case invalidColor(String)
     case textTooLarge(String)
     case unknownEdgeEndpoint(String)
     case invalidInternalLink(String)
+}
+
+enum JSONCanvasColor: Sendable, Equatable {
+    enum Preset: String, Sendable {
+        case red = "1"
+        case orange = "2"
+        case yellow = "3"
+        case green = "4"
+        case cyan = "5"
+        case purple = "6"
+    }
+
+    case preset(Preset)
+    case hex(red: UInt8, green: UInt8, blue: UInt8)
+
+    init(validating rawValue: String) throws {
+        if let preset = Preset(rawValue: rawValue) {
+            self = .preset(preset)
+            return
+        }
+        guard rawValue.hasPrefix("#") else {
+            throw JSONCanvasDecodingError.invalidColor(rawValue)
+        }
+        let digits = String(rawValue.dropFirst())
+        let expanded: String
+        switch digits.count {
+        case 3:
+            expanded = digits.reduce(into: "") { result, digit in
+                result.append(digit)
+                result.append(digit)
+            }
+        case 6:
+            expanded = digits
+        default:
+            throw JSONCanvasDecodingError.invalidColor(rawValue)
+        }
+        guard let value = UInt32(expanded, radix: 16) else {
+            throw JSONCanvasDecodingError.invalidColor(rawValue)
+        }
+        self = .hex(
+            red: UInt8((value >> 16) & 0xff),
+            green: UInt8((value >> 8) & 0xff),
+            blue: UInt8(value & 0xff))
+    }
+}
+
+enum JSONCanvasBackgroundStyle: String, Sendable, Equatable {
+    case cover
+    case ratio
+    case `repeat`
 }
 
 struct JSONCanvasNodeID: Hashable, Sendable, Comparable, Identifiable {
@@ -76,28 +127,53 @@ struct JSONCanvasRect: Sendable, Equatable {
 
 struct JSONCanvasInternalFileReference: RawRepresentable, Hashable, Sendable {
     let path: RendererRelativePath
+    let subpath: JSONCanvasSubpath?
 
     var rawValue: String { path.rawValue }
 
     init?(rawValue: String) {
-        guard rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
-              rawValue.count <= JSONCanvasLimits.maximumIdentifierLength,
-              rawValue.unicodeScalars.allSatisfy({ scalar in
-                  scalar.properties.isWhitespace == false &&
-                      scalar.properties.generalCategory != .control
+        self.init(path: rawValue, subpath: nil)
+    }
+
+    init?(path rawPath: String, subpath rawSubpath: String?) {
+        guard rawPath == rawPath.trimmingCharacters(in: .whitespacesAndNewlines),
+              rawPath.count <= JSONCanvasLimits.maximumIdentifierLength,
+              rawPath.unicodeScalars.allSatisfy({ scalar in
+                  scalar.properties.generalCategory != .control
               }),
-              rawValue.contains(":") == false,
-              rawValue.contains("@") == false,
-              rawValue.contains("?") == false,
-              rawValue.contains("#") == false,
-              rawValue.contains("%") == false,
-              let path = RendererRelativePath(rawValue: rawValue)
+              rawPath.contains(":") == false,
+              rawPath.contains("@") == false,
+              rawPath.contains("?") == false,
+              rawPath.contains("#") == false,
+              rawPath.contains("%") == false,
+              let path = RendererRelativePath(rawValue: rawPath)
         else { return nil }
+        let subpath: JSONCanvasSubpath?
+        if let rawSubpath {
+            guard let validatedSubpath = JSONCanvasSubpath(rawValue: rawSubpath) else { return nil }
+            subpath = validatedSubpath
+        } else {
+            subpath = nil
+        }
         self.path = path
+        self.subpath = subpath
     }
 
     var displayLabel: String {
         path.rawValue.split(separator: "/").last.map(String.init) ?? path.rawValue
+    }
+}
+
+struct JSONCanvasSubpath: RawRepresentable, Hashable, Sendable {
+    let rawValue: String
+
+    init?(rawValue: String) {
+        guard rawValue.hasPrefix("#"),
+              rawValue == rawValue.trimmingCharacters(in: .whitespacesAndNewlines),
+              rawValue.count <= JSONCanvasLimits.maximumTextLength,
+              rawValue.unicodeScalars.allSatisfy({ $0.properties.generalCategory != .control })
+        else { return nil }
+        self.rawValue = rawValue
     }
 }
 
@@ -151,6 +227,7 @@ enum JSONCanvasInternalLink: Hashable, Sendable {
 enum JSONCanvasHostAction: Hashable, Sendable {
     case openFile(JSONCanvasInternalFileReference)
     case openWiki(JSONCanvasWikiReference)
+    case openExternal(URL)
 
     init(internalLink: JSONCanvasInternalLink) {
         switch internalLink {
@@ -176,13 +253,19 @@ struct JSONCanvasNode: Sendable, Equatable, Identifiable {
     let id: JSONCanvasNodeID
     let frame: JSONCanvasRect
     let text: String
+    let color: JSONCanvasColor?
+    let background: JSONCanvasInternalFileReference?
+    let backgroundStyle: JSONCanvasBackgroundStyle?
     let internalLink: JSONCanvasInternalLink?
+    let externalURL: URL?
 }
 
 struct JSONCanvasEdge: Sendable, Equatable, Identifiable {
     let id: String
     let fromNodeID: JSONCanvasNodeID
     let toNodeID: JSONCanvasNodeID
+    let color: JSONCanvasColor?
+    let label: String?
 }
 
 struct JSONCanvasOutlineEntry: Sendable, Equatable, Identifiable {
@@ -197,7 +280,11 @@ struct JSONCanvasRenderProjection: Sendable, Equatable {
         let id: JSONCanvasNodeID
         let frame: JSONCanvasRect
         let text: String
+        let color: JSONCanvasColor?
+        let background: JSONCanvasInternalFileReference?
+        let backgroundStyle: JSONCanvasBackgroundStyle?
         let internalLink: JSONCanvasInternalLink?
+        let externalURL: URL?
     }
 
     struct Edge: Sendable, Equatable, Identifiable {
@@ -206,6 +293,8 @@ struct JSONCanvasRenderProjection: Sendable, Equatable {
         let end: JSONCanvasPoint
         let sourceFrame: JSONCanvasRect
         let destinationFrame: JSONCanvasRect
+        let color: JSONCanvasColor?
+        let label: String?
     }
 
     let nodes: [Node]
@@ -314,11 +403,26 @@ struct JSONCanvasDocument: Sendable, Equatable {
                 throw JSONCanvasDecodingError.textTooLarge(nodeID.rawValue)
             }
             let frame = try Self.validatedFrame(for: wireNode, nodeID: nodeID)
+            let color: JSONCanvasColor?
+            if let rawColor = wireNode.color {
+                do {
+                    color = try JSONCanvasColor(validating: rawColor)
+                } catch {
+                    throw JSONCanvasDecodingError.invalidColor(nodeID.rawValue)
+                }
+            } else {
+                color = nil
+            }
+            let background = try Self.validatedBackground(for: wireNode, nodeID: nodeID)
             decodedNodes.append(.init(
                 id: nodeID,
                 frame: frame,
                 text: content.text,
-                internalLink: content.internalLink))
+                color: color,
+                background: background.reference,
+                backgroundStyle: background.style,
+                internalLink: content.internalLink,
+                externalURL: content.externalURL))
         }
 
         var knownEdgeIDs: Set<String> = []
@@ -337,18 +441,41 @@ struct JSONCanvasDocument: Sendable, Equatable {
             guard knownNodeIDs.contains(toNodeID) else {
                 throw JSONCanvasDecodingError.unknownEdgeEndpoint(toNodeID.rawValue)
             }
-            decodedEdges.append(.init(id: wireEdge.id, fromNodeID: fromNodeID, toNodeID: toNodeID))
+            let color: JSONCanvasColor?
+            if let rawColor = wireEdge.color {
+                do {
+                    color = try JSONCanvasColor(validating: rawColor)
+                } catch {
+                    throw JSONCanvasDecodingError.invalidColor(wireEdge.id)
+                }
+            } else {
+                color = nil
+            }
+            if let label = wireEdge.label,
+               label.count > JSONCanvasLimits.maximumTextLength {
+                throw JSONCanvasDecodingError.textTooLarge(wireEdge.id)
+            }
+            decodedEdges.append(.init(
+                id: wireEdge.id,
+                fromNodeID: fromNodeID,
+                toNodeID: toNodeID,
+                color: color,
+                label: wireEdge.label))
         }
 
         nodes = decodedNodes
         edges = decodedEdges
         let nodesByID = Dictionary(uniqueKeysWithValues: decodedNodes.map { ($0.id, $0) })
-        let renderNodes = decodedNodes.sorted(by: Self.outlineOrder).map {
+        let renderNodes = decodedNodes.map {
             JSONCanvasRenderProjection.Node(
                 id: $0.id,
                 frame: $0.frame,
                 text: $0.text,
-                internalLink: $0.internalLink)
+                color: $0.color,
+                background: $0.background,
+                backgroundStyle: $0.backgroundStyle,
+                internalLink: $0.internalLink,
+                externalURL: $0.externalURL)
         }
         var renderEdges: [JSONCanvasRenderProjection.Edge] = []
         renderEdges.reserveCapacity(decodedEdges.count)
@@ -364,10 +491,12 @@ struct JSONCanvasDocument: Sendable, Equatable {
                 start: source.frame.center,
                 end: destination.frame.center,
                 sourceFrame: source.frame,
-                destinationFrame: destination.frame))
+                destinationFrame: destination.frame,
+                color: edge.color,
+                label: edge.label))
         }
         renderProjection = .init(nodes: renderNodes, edges: renderEdges)
-        outline = renderNodes.map { node in
+        outline = decodedNodes.sorted(by: Self.outlineOrder).map { node in
             .init(nodeID: node.id, label: Self.outlineLabel(for: node.text))
         }
     }
@@ -377,33 +506,35 @@ struct JSONCanvasDocument: Sendable, Equatable {
     }
 
     func hostAction(for nodeID: JSONCanvasNodeID) -> JSONCanvasHostAction? {
-        guard let internalLink = nodes.first(where: { $0.id == nodeID })?.internalLink else { return nil }
-        return .init(internalLink: internalLink)
+        guard let node = nodes.first(where: { $0.id == nodeID }) else { return nil }
+        if let internalLink = node.internalLink { return .init(internalLink: internalLink) }
+        guard let url = node.externalURL else { return nil }
+        return .openExternal(url)
     }
 
     private static func validatedContent(
         for wireNode: JSONCanvasWireNode,
         nodeID: JSONCanvasNodeID
-    ) throws -> (text: String, internalLink: JSONCanvasInternalLink?) {
+    ) throws -> (text: String, internalLink: JSONCanvasInternalLink?, externalURL: URL?) {
         switch wireNode.type {
         case "text":
             guard let text = wireNode.text else {
                 throw JSONCanvasDecodingError.malformedDocument
             }
-            return (text, nil)
+            return (text, nil, nil)
         case "file":
             guard let rawFile = wireNode.file,
-                  let reference = JSONCanvasInternalFileReference(rawValue: rawFile)
+                  let reference = JSONCanvasInternalFileReference(path: rawFile, subpath: wireNode.subpath)
             else { throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue) }
             let internalLink = JSONCanvasInternalLink.file(reference)
-            return (internalLink.displayLabel, internalLink)
+            return (internalLink.displayLabel, internalLink, nil)
         case "link":
             guard let rawURL = wireNode.url else {
                 throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue)
             }
             if let reference = JSONCanvasWikiReference(rawValue: rawURL) {
                 let internalLink = JSONCanvasInternalLink.wiki(reference)
-                return (internalLink.displayLabel, internalLink)
+                return (internalLink.displayLabel, internalLink, nil)
             }
             guard rawURL.hasPrefix("[[") == false,
                   rawURL.hasSuffix("]]") == false
@@ -412,10 +543,10 @@ struct JSONCanvasDocument: Sendable, Equatable {
                   let scheme = url.scheme?.lowercased(),
                   scheme == "https" || scheme == "http"
             else { throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue) }
-            return (rawURL, nil)
+            return (rawURL, nil, url)
         case "group":
             let label = wireNode.label?.trimmingCharacters(in: .whitespacesAndNewlines)
-            return (label?.isEmpty == false ? label ?? "Group" : "Group", nil)
+            return (label?.isEmpty == false ? label ?? "Group" : "Group", nil, nil)
         default:
             throw JSONCanvasDecodingError.unsupportedNodeType(wireNode.type)
         }
@@ -435,6 +566,29 @@ struct JSONCanvasDocument: Sendable, Equatable {
               wireNode.height <= JSONCanvasLimits.maximumCoordinateMagnitude
         else { throw JSONCanvasDecodingError.invalidGeometry(nodeID.rawValue) }
         return .init(origin: .init(x: wireNode.x, y: wireNode.y), width: wireNode.width, height: wireNode.height)
+    }
+
+    private static func validatedBackground(
+        for wireNode: JSONCanvasWireNode,
+        nodeID: JSONCanvasNodeID
+    ) throws -> (reference: JSONCanvasInternalFileReference?, style: JSONCanvasBackgroundStyle?) {
+        guard wireNode.type == "group" else { return (nil, nil) }
+        guard let rawBackground = wireNode.background else {
+            guard wireNode.backgroundStyle == nil else {
+                throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue)
+            }
+            return (nil, nil)
+        }
+        guard let reference = JSONCanvasInternalFileReference(rawValue: rawBackground) else {
+            throw JSONCanvasDecodingError.invalidInternalLink(nodeID.rawValue)
+        }
+        guard let rawStyle = wireNode.backgroundStyle else {
+            return (reference, .cover)
+        }
+        guard let style = JSONCanvasBackgroundStyle(rawValue: rawStyle) else {
+            throw JSONCanvasDecodingError.malformedDocument
+        }
+        return (reference, style)
     }
 
     private static func outlineOrder(_ lhs: JSONCanvasNode, _ rhs: JSONCanvasNode) -> Bool {
@@ -475,6 +629,10 @@ private struct JSONCanvasWireNode: Decodable {
     let file: String?
     let url: String?
     let label: String?
+    let color: String?
+    let subpath: String?
+    let background: String?
+    let backgroundStyle: String?
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: JSONCanvasWireKey.self)
@@ -482,11 +640,11 @@ private struct JSONCanvasWireNode: Decodable {
         let allowedKeys: [String]
         switch type {
         case "text":
-            allowedKeys = ["id", "type", "x", "y", "width", "height", "text"]
+            allowedKeys = ["id", "type", "x", "y", "width", "height", "text", "color"]
         case "file":
-            allowedKeys = ["id", "type", "x", "y", "width", "height", "file"]
+            allowedKeys = ["id", "type", "x", "y", "width", "height", "file", "subpath", "color"]
         case "group":
-            allowedKeys = ["id", "type", "x", "y", "width", "height", "label", "color", "fontSize"]
+            allowedKeys = ["id", "type", "x", "y", "width", "height", "label", "color", "fontSize", "background", "backgroundStyle"]
         case "link":
             allowedKeys = ["id", "type", "x", "y", "width", "height", "url", "color", "fontSize"]
         default:
@@ -504,6 +662,10 @@ private struct JSONCanvasWireNode: Decodable {
         file = try container.decodeIfPresent(String.self, forKey: .file)
         url = try container.decodeIfPresent(String.self, forKey: .url)
         label = try container.decodeIfPresent(String.self, forKey: .label)
+        color = try container.decodeIfPresent(String.self, forKey: .color)
+        subpath = try container.decodeIfPresent(String.self, forKey: .subpath)
+        background = try container.decodeIfPresent(String.self, forKey: .background)
+        backgroundStyle = try container.decodeIfPresent(String.self, forKey: .backgroundStyle)
     }
 }
 
@@ -511,16 +673,20 @@ private struct JSONCanvasWireEdge: Decodable {
     let id: String
     let fromNode: String
     let toNode: String
+    let color: String?
+    let label: String?
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: JSONCanvasWireKey.self)
         try JSONCanvasWireValidation.rejectUnknownKeys(
             container.allKeys,
-            allowed: ["id", "fromNode", "toNode", "label", "fromSide", "toSide", "fromEnd", "toEnd"]
+            allowed: ["id", "fromNode", "toNode", "label", "color", "fromSide", "toSide", "fromEnd", "toEnd"]
         )
         id = try container.decode(String.self, forKey: .id)
         fromNode = try container.decode(String.self, forKey: .fromNode)
         toNode = try container.decode(String.self, forKey: .toNode)
+        color = try container.decodeIfPresent(String.self, forKey: .color)
+        label = try container.decodeIfPresent(String.self, forKey: .label)
     }
 }
 
@@ -551,6 +717,10 @@ private struct JSONCanvasWireKey: CodingKey, Hashable {
     static let file = Self("file")
     static let url = Self("url")
     static let label = Self("label")
+    static let color = Self("color")
+    static let subpath = Self("subpath")
+    static let background = Self("background")
+    static let backgroundStyle = Self("backgroundStyle")
     static let fromNode = Self("fromNode")
     static let toNode = Self("toNode")
 }

--- a/Sources/WikiFS/Renderer/JSONCanvasRendererView.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasRendererView.swift
@@ -1,5 +1,7 @@
 #if os(macOS)
+import AppKit
 import SwiftUI
+import WikiFSCore
 
 // pattern: Mixed (unavoidable)
 // Reason: This native surface binds SwiftUI gesture state to the functional
@@ -14,6 +16,59 @@ struct JSONCanvasInteractionSnapshot: Equatable {
         selectedNodeID = viewport.selectedNodeID
         scale = viewport.scale
         translation = viewport.translation
+    }
+}
+
+enum JSONCanvasNavigationTarget: Equatable, Sendable {
+    case namedContent(title: String, anchor: String?)
+    case page(PageID)
+    case source(SourceID)
+    case external(URL)
+}
+
+@MainActor
+enum JSONCanvasHostActionRouter {
+    nonisolated static func target(for action: JSONCanvasHostAction) -> JSONCanvasNavigationTarget {
+        switch action {
+        case .openFile(let reference):
+            let filename = reference.path.rawValue.split(separator: "/").last.map(String.init)
+                ?? reference.path.rawValue
+            let title = (filename as NSString).deletingPathExtension
+            return .namedContent(
+                title: title,
+                anchor: reference.subpath.map { String($0.rawValue.dropFirst()) })
+        case .openWiki(.page(let pageID)):
+            return .page(pageID)
+        case .openWiki(.source(let sourceID)):
+            return .source(sourceID)
+        case .openExternal(let url):
+            return .external(url)
+        }
+    }
+
+    static func handler(for store: WikiStoreModel) -> (JSONCanvasHostAction) -> Void {
+        { action in route(action, store: store) }
+    }
+
+    static func route(
+        _ action: JSONCanvasHostAction,
+        store: WikiStoreModel,
+        openExternal: (URL) -> Bool = { NSWorkspace.shared.open($0) }
+    ) {
+        switch target(for: action) {
+        case .namedContent(let title, let anchor):
+            if store.selectPage(byTitle: title, anchor: anchor) == false {
+                _ = store.selectSource(byDisplayName: title, anchor: anchor)
+            }
+        case .page(let pageID):
+            _ = store.selectPage(byID: pageID)
+        case .source(let sourceID):
+            _ = store.selectSource(byID: sourceID)
+        case .external(let url):
+            if openExternal(url) == false {
+                DebugLog.reader("JSON Canvas could not open external URL: \(url.absoluteString)")
+            }
+        }
     }
 }
 
@@ -33,6 +88,7 @@ struct JSONCanvasRendererView: View {
     @State private var dragStart: JSONCanvasPoint?
     @State private var dragInitialTranslation = JSONCanvasPoint.zero
     @State private var magnificationBaseline = 1.0
+    @State private var fittedSurface = false
     @FocusState private var focusedSurface: FocusSurface?
 
     init(
@@ -96,7 +152,7 @@ struct JSONCanvasRendererView: View {
     }
 
     private var canvas: some View {
-        GeometryReader { _ in
+        GeometryReader { geometry in
                 ZStack {
                     Canvas { context, _ in
                         context.concatenate(CGAffineTransform(
@@ -108,17 +164,26 @@ struct JSONCanvasRendererView: View {
                             let geometry = JSONCanvasEdgeGeometry(
                                 source: edge.sourceFrame,
                                 destination: edge.destinationFrame)
+                            let edgeColor = rendererColor(for: edge.color) ?? .secondary
                             var path = Path()
                             path.move(to: CGPoint(x: geometry.start.x, y: geometry.start.y))
                             path.addLine(to: CGPoint(x: geometry.end.x, y: geometry.end.y))
-                            context.stroke(path, with: .color(.secondary), lineWidth: 1)
+                            context.stroke(path, with: .color(edgeColor), lineWidth: 1)
 
                             var arrowhead = Path()
                             arrowhead.move(to: CGPoint(x: geometry.end.x, y: geometry.end.y))
                             arrowhead.addLine(to: CGPoint(x: geometry.arrowBaseLeft.x, y: geometry.arrowBaseLeft.y))
                             arrowhead.addLine(to: CGPoint(x: geometry.arrowBaseRight.x, y: geometry.arrowBaseRight.y))
                             arrowhead.closeSubpath()
-                            context.fill(arrowhead, with: .color(.secondary))
+                            context.fill(arrowhead, with: .color(edgeColor))
+
+                            if let label = edge.label, label.isEmpty == false {
+                                let text = context.resolve(
+                                    Text(label).font(.caption).foregroundStyle(edgeColor))
+                                context.draw(text, at: CGPoint(
+                                    x: (geometry.start.x + geometry.end.x) / 2,
+                                    y: (geometry.start.y + geometry.end.y) / 2))
+                            }
                         }
 
                         for node in document.renderProjection.nodes {
@@ -128,42 +193,30 @@ struct JSONCanvasRendererView: View {
                                 width: node.frame.width,
                                 height: node.frame.height)
                             let path = Path(roundedRect: rect, cornerRadius: 8)
-                            context.fill(path, with: .color(.secondary.opacity(0.08)))
+                            let nodeColor = rendererColor(for: node.color)
+                            context.fill(path, with: .color(nodeColor?.opacity(0.16) ?? .secondary.opacity(0.08)))
                             context.stroke(
                                 path,
-                                with: .color(viewport.selectedNodeID == node.id ? .accentColor : .secondary),
+                                with: .color(viewport.selectedNodeID == node.id ? .accentColor : nodeColor ?? .secondary),
                                 lineWidth: viewport.selectedNodeID == node.id ? 2 : 1)
                             let text = context.resolve(Text(node.text).font(.body).foregroundStyle(.primary))
                             context.draw(text, in: rect.insetBy(dx: 10, dy: 8))
+                            if let background = node.background,
+                               let style = node.backgroundStyle {
+                                let caption = context.resolve(
+                                    Text("\(background.displayLabel) · \(style.rawValue)")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary))
+                                context.draw(
+                                    caption,
+                                    at: CGPoint(x: rect.minX + 10, y: rect.maxY - 10),
+                                    anchor: .bottomLeading)
+                            }
                         }
                     }
 
                     ForEach(document.renderProjection.nodes) { node in
-                        Button {
-                            selectCanvasNode(node.id)
-                        } label: {
-                            Color.clear.contentShape(.rect)
-                        }
-                        .buttonStyle(.plain)
-                        .frame(
-                            width: node.frame.width * viewport.scale,
-                            height: node.frame.height * viewport.scale)
-                        .position(nodePosition(for: node))
-                        .accessibilityIdentifier("json-canvas-node-\(node.id.rawValue)")
-                        .accessibilityLabel("Canvas node: \(accessibilityLabel(for: node))")
-                        .accessibilityValue(viewport.selectedNodeID == node.id ? "Selected" : "Not selected")
-                        .accessibilityHint("Press Return to select this read-only canvas node.")
-                        .accessibilityAction(named: Text("Select")) {
-                            selectCanvasNode(node.id)
-                        }
-                        .onMoveCommand { handleMoveCommand($0, from: .canvas) }
-                        .contextMenu {
-                            if document.hostAction(for: node.id) != nil {
-                                Button("Open Internal Link") {
-                                    requestHostAction(for: node.id)
-                                }
-                            }
-                        }
+                        nodeOverlay(node)
                     }
                 }
                 .background(.background)
@@ -175,12 +228,51 @@ struct JSONCanvasRendererView: View {
                 .simultaneousGesture(magnifyGesture)
                 .accessibilityLabel("JSON Canvas nodes")
                 .accessibilityHint("Use the Up and Down Arrow keys to select a canvas node.")
+                .onAppear {
+                    fitCanvasOnce(to: geometry.size)
+                }
             }
     }
 
     private enum FocusSurface: Hashable {
         case outline
         case canvas
+    }
+
+    private func nodeOverlay(_ node: JSONCanvasRenderProjection.Node) -> some View {
+        Button {
+            selectCanvasNode(node.id)
+        } label: {
+            Color.clear.contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .frame(
+            width: node.frame.width * viewport.scale,
+            height: node.frame.height * viewport.scale)
+        .position(nodePosition(for: node))
+        .accessibilityIdentifier("json-canvas-node-\(node.id.rawValue)")
+        .accessibilityLabel("Canvas node: \(accessibilityLabel(for: node))")
+        .accessibilityValue(viewport.selectedNodeID == node.id ? "Selected" : "Not selected")
+        .accessibilityHint(document.hostAction(for: node.id) == nil
+            ? "Press Return to select this read-only canvas node."
+            : "Press Return to select, or use Open to follow this canvas node.")
+        .accessibilityAction(named: Text("Select")) {
+            selectCanvasNode(node.id)
+        }
+        .accessibilityAction(named: Text("Open")) {
+            requestHostAction(for: node.id)
+        }
+        .simultaneousGesture(TapGesture(count: 2).onEnded {
+            requestHostAction(for: node.id)
+        })
+        .onMoveCommand { handleMoveCommand($0, from: .canvas) }
+        .contextMenu {
+            if document.hostAction(for: node.id) != nil {
+                Button("Open") {
+                    requestHostAction(for: node.id)
+                }
+            }
+        }
     }
 
     private var dragGesture: some Gesture {
@@ -262,6 +354,18 @@ struct JSONCanvasRendererView: View {
         interactionObserver(.init(viewport: viewport))
     }
 
+    private func fitCanvasOnce(to size: CGSize) {
+        guard fittedSurface == false else { return }
+        viewport.fit(
+            document: document,
+            surfaceWidth: size.width,
+            surfaceHeight: size.height,
+            padding: 20)
+        magnificationBaseline = viewport.scale
+        fittedSurface = true
+        reportInteraction()
+    }
+
     private func nodePosition(for node: JSONCanvasRenderProjection.Node) -> CGPoint {
         CGPoint(
             x: node.frame.origin.x * viewport.scale + viewport.translation.x + node.frame.width * viewport.scale / 2,
@@ -271,6 +375,32 @@ struct JSONCanvasRendererView: View {
     private func accessibilityLabel(for node: JSONCanvasRenderProjection.Node) -> String {
         let label = node.text.split(whereSeparator: \.isNewline).first.map(String.init) ?? ""
         return label.isEmpty ? "Text node" : label
+    }
+
+    private func rendererColor(for color: JSONCanvasColor?) -> Color? {
+        switch color {
+        case .none:
+            nil
+        case .preset(.red):
+            .red
+        case .preset(.orange):
+            .orange
+        case .preset(.yellow):
+            .yellow
+        case .preset(.green):
+            .green
+        case .preset(.cyan):
+            .cyan
+        case .preset(.purple):
+            .purple
+        case .hex(let red, let green, let blue):
+            Color(
+                .sRGB,
+                red: Double(red) / 255,
+                green: Double(green) / 255,
+                blue: Double(blue) / 255,
+                opacity: 1)
+        }
     }
 }
 #endif

--- a/Sources/WikiFS/Renderer/JSONCanvasViewportState.swift
+++ b/Sources/WikiFS/Renderer/JSONCanvasViewportState.swift
@@ -40,6 +40,32 @@ struct JSONCanvasViewportState: Sendable, Equatable {
         self.scale = Self.clampedScale(scale)
     }
 
+    mutating func fit(
+        document: JSONCanvasDocument,
+        surfaceWidth: Double,
+        surfaceHeight: Double,
+        padding: Double
+    ) {
+        guard let first = document.renderProjection.nodes.first,
+              surfaceWidth.isFinite, surfaceHeight.isFinite, padding.isFinite,
+              surfaceWidth > padding * 2, surfaceHeight > padding * 2
+        else { return }
+        let bounds = document.renderProjection.nodes.dropFirst().reduce(first.frame) { bounds, node in
+            let minX = min(bounds.origin.x, node.frame.origin.x)
+            let minY = min(bounds.origin.y, node.frame.origin.y)
+            let maxX = max(bounds.origin.x + bounds.width, node.frame.origin.x + node.frame.width)
+            let maxY = max(bounds.origin.y + bounds.height, node.frame.origin.y + node.frame.height)
+            return JSONCanvasRect(origin: .init(x: minX, y: minY), width: maxX - minX, height: maxY - minY)
+        }
+        let fittedScale = min(
+            (surfaceWidth - padding * 2) / bounds.width,
+            (surfaceHeight - padding * 2) / bounds.height)
+        setScale(min(1, fittedScale))
+        setTranslation(.init(
+            x: (surfaceWidth - bounds.width * scale) / 2 - bounds.origin.x * scale,
+            y: (surfaceHeight - bounds.height * scale) / 2 - bounds.origin.y * scale))
+    }
+
     mutating func select(nodeID: JSONCanvasNodeID?) {
         selectedNodeID = nodeID
     }

--- a/Sources/WikiFS/Renderer/RendererInlineAttachmentResolver.swift
+++ b/Sources/WikiFS/Renderer/RendererInlineAttachmentResolver.swift
@@ -31,7 +31,8 @@ enum RendererInlineAttachmentResolverFactory {
     static func make(
         store: WikiStore,
         installedRendererFactory: InstalledRendererFactory,
-        installedRendererFactoryInputs: InstalledRendererFactory.Inputs
+        installedRendererFactoryInputs: InstalledRendererFactory.Inputs,
+        onJSONCanvasHostAction: @escaping (JSONCanvasHostAction) -> Void
     ) -> RendererInlineAttachmentResolver {
         { context, placeholderID, onSessionFailure in
             resolve(
@@ -40,7 +41,8 @@ enum RendererInlineAttachmentResolverFactory {
                 onSessionFailure: onSessionFailure,
                 store: store,
                 installedRendererFactory: installedRendererFactory,
-                installedRendererFactoryInputs: installedRendererFactoryInputs)
+                installedRendererFactoryInputs: installedRendererFactoryInputs,
+                onJSONCanvasHostAction: onJSONCanvasHostAction)
         }
     }
 
@@ -60,9 +62,13 @@ enum RendererInlineAttachmentResolverFactory {
         onSessionFailure: @escaping @MainActor (RendererSessionFailure) -> Void,
         store: WikiStore,
         installedRendererFactory: InstalledRendererFactory,
-        installedRendererFactoryInputs: InstalledRendererFactory.Inputs
+        installedRendererFactoryInputs: InstalledRendererFactory.Inputs,
+        onJSONCanvasHostAction: @escaping (JSONCanvasHostAction) -> Void
     ) -> RendererInlineAttachmentResolution {
-        let builtIn = resolveBuiltIn(context: context, placeholderID: placeholderID)
+        let builtIn = resolveBuiltIn(
+            context: context,
+            placeholderID: placeholderID,
+            onJSONCanvasHostAction: onJSONCanvasHostAction)
         guard case .unsupported = builtIn else { return builtIn }
 
         guard let descriptor = installedRendererFactoryInputs.enabledDescriptors.first(where: {
@@ -89,14 +95,17 @@ enum RendererInlineAttachmentResolverFactory {
     @MainActor
     private static func resolveBuiltIn(
         context: RendererEmbedActivationContext,
-        placeholderID: RendererAttachmentPlaceholderID
+        placeholderID: RendererAttachmentPlaceholderID,
+        onJSONCanvasHostAction: @escaping (JSONCanvasHostAction) -> Void = { _ in }
     ) -> RendererInlineAttachmentResolution {
         guard context.rendererReference == BuiltInRendererReference.reference(for: .jsonCanvas),
               case .inlineArtifact(let artifact) = context.input
         else { return .unsupported }
         do {
             let factory = NativeJSONCanvasAttachmentFactory.fencedOnly()
-            return .content(try factory.makeView(for: .fenced(artifact)))
+            return .content(try factory.makeView(
+                for: .fenced(artifact),
+                onHostAction: onJSONCanvasHostAction))
         } catch {
             DebugLog.reader("native JSON Canvas attachment failed for \(placeholderID.rawValue): \(error)")
             return .failed

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -1376,7 +1376,8 @@ struct SourceDetailView: View {
                             inlineAttachmentResolver: RendererInlineAttachmentResolverFactory.make(
                                 store: store.internalStore,
                                 installedRendererFactory: installedRendererFactory,
-                                installedRendererFactoryInputs: installedRendererFactoryInputs),
+                                installedRendererFactoryInputs: installedRendererFactoryInputs,
+                                onJSONCanvasHostAction: JSONCanvasHostActionRouter.handler(for: store)),
                             findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
                 .zoomShortcuts($readerZoom)
                 .zoomScroll($readerZoom)
@@ -1395,7 +1396,8 @@ struct SourceDetailView: View {
                             inlineAttachmentResolver: RendererInlineAttachmentResolverFactory.make(
                                 store: store.internalStore,
                                 installedRendererFactory: installedRendererFactory,
-                                installedRendererFactoryInputs: installedRendererFactoryInputs),
+                                installedRendererFactoryInputs: installedRendererFactoryInputs,
+                                onJSONCanvasHostAction: JSONCanvasHostActionRouter.handler(for: store)),
                             findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
                 .zoomShortcuts($readerZoom)
                 .zoomScroll($readerZoom)

--- a/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
+++ b/Tests/WikiFSAppTests/JSONCanvasRendererTests.swift
@@ -71,7 +71,60 @@ struct JSONCanvasRendererTests {
         #expect(document.nodes.map(\.id.rawValue) == ["second", "first"])
         #expect(document.outline.map(\.label) == ["First note", "Second note"])
         #expect(document.renderProjection.edges.map(\.id) == ["edge-1"])
-        #expect(document.renderProjection.nodes.map(\.id.rawValue) == ["first", "second"])
+        #expect(document.renderProjection.nodes.map(\.id.rawValue) == ["second", "first"])
+    }
+
+    @Test("decoder accepts standard colors on text nodes")
+    func decoderAcceptsTextNodeColors() throws {
+        let document = try JSONCanvasDocument.decode(Self.coloredTextCanvas)
+
+        #expect(document.nodes.map(\.color) == [
+            .preset(.red),
+            .hex(red: 0x25, green: 0x63, blue: 0xeb),
+        ])
+        #expect(document.renderProjection.nodes.map(\.color) == document.nodes.map(\.color))
+    }
+
+    @Test("decoder accepts and preserves standard edge colors and labels")
+    func decoderAcceptsEdgeColorsAndLabels() throws {
+        let document = try JSONCanvasDocument.decode(Self.coloredEdgeCanvas)
+        let edge = try #require(document.edges.first)
+        let renderEdge = try #require(document.renderProjection.edges.first)
+
+        #expect(edge.color == .hex(red: 0x11, green: 0x18, blue: 0x27))
+        #expect(edge.label == "layering")
+        #expect(renderEdge.color == edge.color)
+        #expect(renderEdge.label == edge.label)
+    }
+
+    @Test("rendering and hit testing preserve Canvas array z-order")
+    func renderingPreservesCanvasZOrder() throws {
+        let document = try JSONCanvasDocument.decode(Self.layeredCanvas)
+        let overlap = JSONCanvasPoint(x: 40, y: 40)
+
+        #expect(document.renderProjection.nodes.map(\.id.rawValue) == ["behind", "front"])
+        #expect(document.outline.map(\.nodeID.rawValue) == ["front", "behind"])
+        #expect(document.nodeID(containing: overlap)?.rawValue == "front")
+    }
+
+    @Test("decoder accepts group backgrounds and all standard background styles")
+    func decoderAcceptsGroupBackgrounds() throws {
+        let document = try JSONCanvasDocument.decode(Self.groupBackgroundCanvas)
+
+        #expect(document.nodes.map(\.backgroundStyle) == [.cover, .ratio, .repeat])
+        #expect(document.nodes.map { $0.background?.rawValue } == ["SVG", "SVG", "SVG"])
+        #expect(document.renderProjection.nodes.map(\.backgroundStyle) == [.cover, .ratio, .repeat])
+    }
+
+    @Test("decoder rejects invalid node colors")
+    func decoderRejectsInvalidNodeColors() {
+        let invalidCanvas = Data("""
+        {"nodes":[{"id":"bad","type":"text","x":0,"y":0,"width":120,"height":60,"color":"7","text":"Bad"}],"edges":[]}
+        """.utf8)
+
+        #expect(throws: JSONCanvasDecodingError.invalidColor("bad")) {
+            try JSONCanvasDocument.decode(invalidCanvas)
+        }
     }
 
     @Test("edge geometry clips to node boundaries and points its arrow at the destination")
@@ -101,6 +154,40 @@ struct JSONCanvasRendererTests {
         #expect(document.hostAction(for: try JSONCanvasNodeID(validating: "file")) == .openFile(fileReference))
         #expect(document.hostAction(for: try JSONCanvasNodeID(validating: "page")) == .openWiki(.page(pageID)))
         #expect(document.hostAction(for: try JSONCanvasNodeID(validating: "source")) == .openWiki(.source(sourceID)))
+    }
+
+    @Test("decoder accepts a file subpath with external link nodes")
+    func decoderAcceptsFileSubpathAndExternalLinks() throws {
+        let document = try JSONCanvasDocument.decode(Self.fileSubpathAndExternalLinkCanvas)
+        let fileNode = try #require(document.nodes.first)
+        guard case .file(let reference) = fileNode.internalLink else {
+            Issue.record("expected a typed file reference")
+            return
+        }
+
+        #expect(reference.rawValue == "JSON Canvas")
+        #expect(reference.subpath?.rawValue == "#JSON Canvas Testbed")
+        #expect(document.renderProjection.nodes.map(\.text) == [
+            "JSON Canvas",
+            "https://jsoncanvas.org/spec/1.0/",
+        ])
+        #expect(document.hostAction(for: try JSONCanvasNodeID(validating: "link")) == .openExternal(
+            try #require(URL(string: "https://jsoncanvas.org/spec/1.0/"))))
+    }
+
+    @Test("host actions resolve files, wiki references, and external URLs")
+    func hostActionsResolveEverySupportedTarget() throws {
+        let fileReference = try #require(JSONCanvasInternalFileReference(
+            path: "JSON Canvas.md",
+            subpath: "#JSON Canvas Testbed"))
+        let pageID = PageID(rawValue: "01J00000000000000000000000")
+        let externalURL = try #require(URL(string: "https://jsoncanvas.org/"))
+
+        #expect(JSONCanvasHostActionRouter.target(for: .openFile(fileReference)) == .namedContent(
+            title: "JSON Canvas",
+            anchor: "JSON Canvas Testbed"))
+        #expect(JSONCanvasHostActionRouter.target(for: .openWiki(.page(pageID))) == .page(pageID))
+        #expect(JSONCanvasHostActionRouter.target(for: .openExternal(externalURL)) == .external(externalURL))
     }
 
     @Test("internal host actions dispatch only the typed request")
@@ -249,6 +336,25 @@ struct JSONCanvasRendererTests {
         #expect(viewport.scale == 2)
     }
 
+    @Test("viewport fits the complete canvas inside the available surface")
+    func viewportFitsDocumentBounds() throws {
+        let document = try JSONCanvasDocument.decode(Self.fileSubpathAndExternalLinkCanvas)
+        var viewport = JSONCanvasViewportState()
+
+        viewport.fit(document: document, surfaceWidth: 700, surfaceHeight: 420, padding: 20)
+
+        for node in document.renderProjection.nodes {
+            let left = node.frame.origin.x * viewport.scale + viewport.translation.x
+            let top = node.frame.origin.y * viewport.scale + viewport.translation.y
+            let right = left + node.frame.width * viewport.scale
+            let bottom = top + node.frame.height * viewport.scale
+            #expect(left >= 20)
+            #expect(top >= 20)
+            #expect(right <= 680)
+            #expect(bottom <= 400)
+        }
+    }
+
     @Test("viewport traversal follows the deterministic document outline")
     func viewportTraversalFollowsDocumentOutline() throws {
         let document = try JSONCanvasDocument.decode(Self.validCanvas)
@@ -267,8 +373,9 @@ struct JSONCanvasRendererTests {
         let source = try Self.rendererViewSource()
 
         for semanticStyle in [
-            ".color(.secondary.opacity(0.08))",
-            ".color(.secondary)",
+            "nodeColor?.opacity(0.16) ?? .secondary.opacity(0.08)",
+            ".color(edgeColor)",
+            "rendererColor(for: node.color)",
             ".background(.background)",
             "Text(node.text).font(.body).foregroundStyle(.primary)",
         ] {
@@ -362,12 +469,54 @@ struct JSONCanvasRendererTests {
     }
     """.utf8)
 
+    private static let coloredTextCanvas = Data("""
+    {
+      "nodes": [
+        {"id":"preset","type":"text","x":0,"y":0,"width":120,"height":60,"color":"1","text":"Preset"},
+        {"id":"hex","type":"text","x":140,"y":0,"width":120,"height":60,"color":"#2563eb","text":"Hex"}
+      ],
+      "edges": []
+    }
+    """.utf8)
+
+    private static let coloredEdgeCanvas = Data("""
+    {
+      "nodes": [
+        {"id":"first","type":"text","x":0,"y":0,"width":120,"height":60,"text":"First"},
+        {"id":"second","type":"text","x":240,"y":0,"width":120,"height":60,"text":"Second"}
+      ],
+      "edges": [
+        {"id":"edge","fromNode":"first","toNode":"second","color":"#111827","label":"layering"}
+      ]
+    }
+    """.utf8)
+
+    private static let layeredCanvas = Data("""
+    {
+      "nodes": [
+        {"id":"behind","type":"text","x":20,"y":20,"width":120,"height":80,"color":"1","text":"Behind"},
+        {"id":"front","type":"text","x":0,"y":0,"width":120,"height":80,"color":"6","text":"Front"}
+      ],
+      "edges": []
+    }
+    """.utf8)
+
     private static let internalLinkCanvas = Data("""
     {
       "nodes": [
         {"id":"file","type":"file","x":0,"y":0,"width":120,"height":60,"file":"notes/Readme.md"},
         {"id":"page","type":"link","x":0,"y":80,"width":120,"height":60,"url":"[[page:01J00000000000000000000000]]"},
         {"id":"source","type":"link","x":0,"y":160,"width":120,"height":60,"url":"[[source:01J00000000000000000000001]]"}
+      ],
+      "edges": []
+    }
+    """.utf8)
+
+    private static let fileSubpathAndExternalLinkCanvas = Data("""
+    {
+      "nodes": [
+        {"id":"file","type":"file","x":0,"y":0,"width":360,"height":240,"file":"JSON Canvas","subpath":"#JSON Canvas Testbed","color":"5"},
+        {"id":"link","type":"link","x":0,"y":320,"width":360,"height":160,"url":"https://jsoncanvas.org/spec/1.0/","color":"2"}
       ],
       "edges": []
     }
@@ -435,6 +584,17 @@ struct JSONCanvasRendererTests {
     {
       "nodes": [
         {"id":"first","type":"text","x":1e999,"y":0,"width":120,"height":60,"text":"First"}
+      ],
+      "edges": []
+    }
+    """.utf8)
+
+    private static let groupBackgroundCanvas = Data("""
+    {
+      "nodes": [
+        {"id":"cover","type":"group","x":0,"y":0,"width":360,"height":300,"color":"4","label":"Cover background","background":"SVG","backgroundStyle":"cover"},
+        {"id":"ratio","type":"group","x":440,"y":0,"width":360,"height":300,"color":"5","label":"Ratio background","background":"SVG","backgroundStyle":"ratio"},
+        {"id":"repeat","type":"group","x":0,"y":380,"width":800,"height":260,"color":"6","label":"Repeat background","background":"SVG","backgroundStyle":"repeat"}
       ],
       "edges": []
     }

--- a/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
@@ -10,6 +10,12 @@ import WikiFSTypes
 
 @Suite("Reader renderer attachment coordinator", .serialized, .timeLimit(.minutes(5)))
 struct RendererAttachmentCoordinatorTests {
+    @Test("JSON Canvas reserves an expanded inline surface")
+    func jsonCanvasReservesExpandedInlineSurface() {
+        #expect(RendererAttachmentHostPolicy.preferredReservedHeight(
+            for: BuiltInRendererReference.reference(for: .jsonCanvas)) == 480)
+    }
+
     @Test("Escape exits the hosted native attachment and restores reader focus")
     @MainActor
     func escapeExitsNativeAttachment() throws {
@@ -544,6 +550,8 @@ struct RendererAttachmentCoordinatorTests {
 
         #expect(source.contains("RendererInlineAttachmentResolver"))
         #expect(source.contains("BuiltInRendererReference.reference(for: .jsonCanvas)") == false)
+        #expect(source.contains(#"__sdwRendererAttachmentReserve(\"\(identifier)\""#))
+        #expect(source.contains(#"\(function)(\"\(identifier)\")"#))
 
         let pageDetail = try String(
             contentsOf: root.appendingPathComponent("Sources/WikiFS/Pages/PageDetailView.swift"),

--- a/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentCoordinatorTests.swift
@@ -410,6 +410,53 @@ struct RendererAttachmentCoordinatorTests {
         #expect(collapsed)
     }
 
+    @Test("attachment header routes genuine pointer clicks to its controls")
+    @MainActor
+    func attachmentHeaderRoutesPointerClicks() throws {
+        let webView = WikiReaderWebView()
+        let container = WikiReaderContainerView(webView: webView)
+        container.frame = .init(x: 0, y: 0, width: 400, height: 300)
+        let window = NSWindow(contentRect: container.bounds, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        defer { container.teardown(); window.orderOut(nil) }
+
+        let placeholder = try RendererAttachmentPlaceholderID(validating: "pointer-header-canvas")
+        var opened = false
+        var collapsed = false
+        container.updateAttachmentViewport(.init(x: 40, y: 80, width: 300, height: 180))
+        container.activateAttachment(
+            named: placeholder,
+            onOpen: { opened = true },
+            onExit: { collapsed = true })
+        container.layoutSubtreeIfNeeded()
+
+        let child = try #require(container.subviews.flatMap(\.subviews).first {
+            $0.accessibilityIdentifier() == "renderer-attachment-pointer-header-canvas"
+        })
+        let toolbar = try #require(child.subviews.first {
+            $0.accessibilityIdentifier() == "renderer-attachment-toolbar-pointer-header-canvas"
+        })
+        let buttons = toolbar.subviews.flatMap(\.subviews).compactMap { $0 as? NSButton }
+        let openButton = try #require(buttons.first { $0.title == "Open in Window" })
+        let collapseButton = try #require(buttons.first { $0.title == "Collapse" })
+
+        let openPoint = openButton.convert(
+            NSPoint(x: openButton.bounds.midX, y: openButton.bounds.midY),
+            to: container)
+        let collapsePoint = collapseButton.convert(
+            NSPoint(x: collapseButton.bounds.midX, y: collapseButton.bounds.midY),
+            to: container)
+        #expect(container.hitTest(openPoint) === openButton)
+        #expect(container.hitTest(collapsePoint) === collapseButton)
+
+        Self.sendPointerClick(to: window, view: openButton)
+        Self.sendPointerClick(to: window, view: collapseButton)
+
+        #expect(opened)
+        #expect(collapsed)
+    }
+
     @Test("hosted JSON Canvas attachment mounts the factory's native SwiftUI view")
     @MainActor
     func hostedJSONCanvasAttachmentMountsNativeView() throws {
@@ -432,11 +479,15 @@ struct RendererAttachmentCoordinatorTests {
         container.updateAttachmentViewport(.init(x: 40, y: 80, width: 160, height: 96))
 
         container.activateAttachment(named: placeholder, content: try factory.makeView(for: input))
+        container.layoutSubtreeIfNeeded()
 
         let child = try #require(container.subviews.flatMap(\.subviews).first {
             $0.accessibilityIdentifier() == "renderer-attachment-mounted-json-canvas"
         })
         #expect(Self.containsHostingView(in: child))
+        let canvasHit = container.hitTest(.init(x: 100, y: 100))
+        #expect(canvasHit !== child)
+        #expect(canvasHit !== webView)
         #expect(window.firstResponder === child)
     }
 
@@ -948,6 +999,28 @@ struct RendererAttachmentCoordinatorTests {
     private static func containsHostingView(in view: NSView) -> Bool {
         String(describing: type(of: view)).contains("NSHostingView") ||
             view.subviews.contains(where: containsHostingView)
+    }
+
+    @MainActor
+    private static func sendPointerClick(to window: NSWindow, view: NSView) {
+        let point = view.convert(NSPoint(x: view.bounds.midX, y: view.bounds.midY), to: nil)
+        for eventType in [NSEvent.EventType.leftMouseDown, .leftMouseUp] {
+            guard let event = NSEvent.mouseEvent(
+                with: eventType,
+                location: point,
+                modifierFlags: [],
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: window.windowNumber,
+                context: nil,
+                eventNumber: 0,
+                clickCount: 1,
+                pressure: eventType == .leftMouseDown ? 1 : 0)
+            else {
+                Issue.record("failed to construct attachment pointer event")
+                return
+            }
+            window.sendEvent(event)
+        }
     }
 
     private static let jsonCanvasBytes = Data("""


### PR DESCRIPTION
## Summary

- Render JSON Canvas text, file, link, group, edge, color, and layering data in the native renderer.
- Open file, wiki, and external link nodes through the host application.
- Fit inline and full canvas views to their content.
- Accept group background paths and the `cover`, `ratio`, and `repeat` styles.

## Verification

- `make build`
- `make test` — 3,511 tests passed
- `WIKIFS_APP_TESTS=1 swift test --filter decoderAcceptsGroupBackgrounds`
- Live inspection of the Testbed JSON Canvas fixtures
- `git diff --check`
