### PR TITLE
Fix Mermaid renderer window session lookup

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -399,18 +399,6 @@ struct WikiReaderView: View {
         }
     }
 
-    /// One-shot loader for the vendored Mermaid library. Reads the bundled
-    /// `mermaid.js` once and caches it; `nil` when unbundled (e.g. `swift test`,
-    /// `swift run` without `./build.sh`), so diagram pages degrade gracefully to
-    /// ordinary code blocks. `nonisolated` so it's safe off the main actor where
-    /// the convert task reads it.
-    nonisolated private static let mermaidLib: String? = {
-        guard let url = Bundle.main.url(forResource: "mermaid", withExtension: "js"),
-              let src = DebugLog.trying("load mermaid.js", operation: { try String(contentsOf: url, encoding: .utf8) }),
-              !src.isEmpty else { return nil }
-        return src
-    }()
-
     /// Bootstrap that initializes Mermaid (matching the system appearance via
     /// `prefers-color-scheme`), converts each
     /// `<pre><code class="language-mermaid">` into a `<div class="mermaid">`
@@ -468,7 +456,7 @@ struct WikiReaderView: View {
         var mermaidScripts = ""
         if (body.contains("class=\"language-mermaid\"")
                 || body.contains("class=\"mermaid\"")),
-           let lib = mermaidLib {
+           let lib = MermaidRendererAssets.library {
             mermaidScripts = "<script>\(lib)</script>\n<script>\(mermaidBootstrapJS)</script>"
         }
         return """

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -622,8 +622,7 @@ struct WikiReaderView: View {
           iframe.wiki-embed-audio { width: 100%; height: 152px; border: none; border-radius: 8px; }
           audio.wiki-embed { width: 100%; }
           mark.sdwhl { background: rgba(255, 213, 79, 0.8); border-radius: 2px; }
-          .mermaid { text-align:center; margin:0 0 1em; overflow:auto; }
-          .mermaid svg { max-width:100%; height:auto; }
+          \(MermaidRendererAssets.sharedCSS)
           .sdw-mermaid-row__expansion { margin-top:0.6em; }
           .sdw-mermaid-row__diagram { min-height:0; }
           .sdw-mermaid-row__expansion[aria-hidden="true"] { display:none; }

--- a/Sources/WikiFS/Renderer/BuiltInRendererFactoryMap.swift
+++ b/Sources/WikiFS/Renderer/BuiltInRendererFactoryMap.swift
@@ -67,7 +67,9 @@ enum BuiltInRendererFactoryMap {
 
     private static func makeMermaid(_ inputs: BuiltInRendererFactoryInputs) -> AnyView? {
         AnyView(Group {
-            if let markdown = inputs.mermaidMarkdown {
+            if let source = inputs.mermaidDiagramSource {
+                MermaidRendererView(source: source)
+            } else if let markdown = inputs.mermaidMarkdown {
                 WikiReaderView(markdown: markdown, currentSelection: inputs.selection, store: inputs.store)
                     .zoomShortcuts(inputs.readerZoom)
                     .zoomScroll(inputs.readerZoom)
@@ -116,9 +118,32 @@ struct BuiltInRendererFactoryInputs {
     let pdfQuote: String?
     let htmlSource: String?
     let mermaidMarkdown: String?
+    let mermaidDiagramSource: String?
     let mediaTarget: EmbedTarget?
     let selection: WikiSelection?
     let store: WikiStoreModel
     let readerZoom: Binding<Double>
+
+    init(
+        sourceBytes: Data?,
+        pdfQuote: String?,
+        htmlSource: String?,
+        mermaidMarkdown: String?,
+        mermaidDiagramSource: String? = nil,
+        mediaTarget: EmbedTarget?,
+        selection: WikiSelection?,
+        store: WikiStoreModel,
+        readerZoom: Binding<Double>
+    ) {
+        self.sourceBytes = sourceBytes
+        self.pdfQuote = pdfQuote
+        self.htmlSource = htmlSource
+        self.mermaidMarkdown = mermaidMarkdown
+        self.mermaidDiagramSource = mermaidDiagramSource
+        self.mediaTarget = mediaTarget
+        self.selection = selection
+        self.store = store
+        self.readerZoom = readerZoom
+    }
 }
 #endif

--- a/Sources/WikiFS/Renderer/MermaidRendererView.swift
+++ b/Sources/WikiFS/Renderer/MermaidRendererView.swift
@@ -1,0 +1,142 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import WebKit
+import WikiFSCore
+
+/// Cached access to the trusted Mermaid runtime bundled with the app.
+enum MermaidRendererAssets {
+    nonisolated static let library: String? = {
+        guard let url = Bundle.main.url(forResource: "mermaid", withExtension: "js"),
+              let source = DebugLog.trying(
+                  "load mermaid.js",
+                  operation: { try String(contentsOf: url, encoding: .utf8) }),
+              source.isEmpty == false
+        else { return nil }
+        return source
+    }()
+}
+
+/// Renders one Mermaid diagram as renderer content, without inline-reader card chrome.
+struct MermaidRendererView: View {
+    let source: String
+    @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
+
+    var body: some View {
+        MermaidRendererWebView(source: source, zoom: readerZoom)
+            .zoomShortcuts($readerZoom)
+            .zoomScroll($readerZoom)
+    }
+}
+
+struct MermaidRendererWebView: NSViewRepresentable {
+    let source: String
+    let zoom: Double
+
+    func makeNSView(context: Context) -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = true
+        configuration.defaultWebpagePreferences = preferences
+        configuration.suppressesIncrementalRendering = true
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.underPageBackgroundColor = .textBackgroundColor
+        webView.navigationDelegate = context.coordinator
+        webView.pageZoom = zoom
+        context.coordinator.load(source: source, into: webView)
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        webView.pageZoom = zoom
+        guard context.coordinator.loadedSource != source else { return }
+        context.coordinator.load(source: source, into: webView)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        var loadedSource: String?
+
+        func load(source: String, into webView: WKWebView) {
+            loadedSource = source
+            webView.loadHTMLString(Self.documentHTML(source: source), baseURL: nil)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+        ) {
+            let isInitialDocument = navigationAction.navigationType == .other
+                && navigationAction.request.url?.absoluteString == "about:blank"
+            decisionHandler(isInitialDocument ? .allow : .cancel)
+        }
+
+        nonisolated static func documentHTML(
+            source: String,
+            library: String? = MermaidRendererAssets.library
+        ) -> String {
+            let escapedSource = HTMLEntities.escapeHTML(source)
+            guard let library else {
+                return fallbackHTML(source: escapedSource)
+            }
+            return """
+            <!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+            <meta name="color-scheme" content="light dark">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data: blob:">
+            <style>
+              html, body { width: 100%; min-height: 100%; margin: 0; }
+              body {
+                display: flex; align-items: flex-start; justify-content: center;
+                box-sizing: border-box; padding: 24px;
+                color: CanvasText; background: Canvas;
+                font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+              }
+              #diagram { max-width: 100%; }
+              #diagram svg { max-width: 100%; height: auto; }
+              #error { max-width: 720px; white-space: pre-wrap; color: #ff453a; }
+            </style></head><body>
+            <div id="diagram" aria-label="Mermaid diagram"></div>
+            <pre id="source" hidden>\(escapedSource)</pre>
+            <pre id="error" role="alert" hidden></pre>
+            <script>\(library)</script>
+            <script>
+            (function(){
+              var diagram = document.getElementById('diagram');
+              var source = document.getElementById('source').textContent;
+              var error = document.getElementById('error');
+              var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+              try {
+                mermaid.initialize({ startOnLoad:false, securityLevel:'strict', theme:dark ? 'dark' : 'default' });
+                diagram.textContent = source;
+                mermaid.run({ nodes:[diagram] }).catch(function(reason){
+                  diagram.hidden = true;
+                  error.hidden = false;
+                  error.textContent = 'The Mermaid diagram could not be rendered.\n\n' + String(reason);
+                });
+              } catch (reason) {
+                diagram.hidden = true;
+                error.hidden = false;
+                error.textContent = 'The Mermaid diagram could not be rendered.\n\n' + String(reason);
+              }
+            })();
+            </script></body></html>
+            """
+        }
+
+        nonisolated private static func fallbackHTML(source: String) -> String {
+            """
+            <!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+            <meta name="color-scheme" content="light dark">
+            <style>
+              body { margin: 0; padding: 24px; color: CanvasText; background: Canvas; }
+              pre { white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+            </style></head><body><pre>\(source)</pre></body></html>
+            """
+        }
+    }
+}
+#endif

--- a/Sources/WikiFS/Renderer/MermaidRendererView.swift
+++ b/Sources/WikiFS/Renderer/MermaidRendererView.swift
@@ -6,6 +6,11 @@ import WikiFSCore
 
 /// Cached access to the trusted Mermaid runtime bundled with the app.
 enum MermaidRendererAssets {
+    nonisolated static let sharedCSS = """
+    .mermaid { text-align:center; margin:0 0 1em; overflow:auto; }
+    .mermaid svg { max-width:100%; height:auto; }
+    """
+
     nonisolated static let library = library(in: .main)
 
     nonisolated static func library(in bundle: Bundle) -> String? {
@@ -19,14 +24,36 @@ enum MermaidRendererAssets {
     }
 }
 
+enum MermaidRendererTheme: String, Sendable {
+    case light
+    case dark
+
+    init(colorScheme: ColorScheme) {
+        self = colorScheme == .dark ? .dark : .light
+    }
+
+    nonisolated var mermaidName: String {
+        switch self {
+        case .light: "default"
+        case .dark: "dark"
+        }
+    }
+}
+
 /// Renders one Mermaid diagram as renderer content, without inline-reader card chrome.
 struct MermaidRendererView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     let source: String
     var library: String? = MermaidRendererAssets.library
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
 
     var body: some View {
-        MermaidRendererWebView(source: source, library: library, zoom: readerZoom)
+        MermaidRendererWebView(
+            source: source,
+            library: library,
+            theme: MermaidRendererTheme(colorScheme: colorScheme),
+            zoom: readerZoom)
             .zoomShortcuts($readerZoom)
             .zoomScroll($readerZoom)
     }
@@ -35,6 +62,7 @@ struct MermaidRendererView: View {
 struct MermaidRendererWebView: NSViewRepresentable {
     let source: String
     let library: String?
+    let theme: MermaidRendererTheme
     let zoom: Double
 
     func makeNSView(context: Context) -> WKWebView {
@@ -49,15 +77,15 @@ struct MermaidRendererWebView: NSViewRepresentable {
         webView.underPageBackgroundColor = .textBackgroundColor
         webView.navigationDelegate = context.coordinator
         webView.pageZoom = zoom
-        context.coordinator.load(source: source, library: library, into: webView)
+        context.coordinator.load(source: source, library: library, theme: theme, into: webView)
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         webView.pageZoom = zoom
-        let contentIdentity = Coordinator.contentIdentity(source: source, library: library)
+        let contentIdentity = Coordinator.contentIdentity(source: source, library: library, theme: theme)
         guard context.coordinator.loadedContentIdentity != contentIdentity else { return }
-        context.coordinator.load(source: source, library: library, into: webView)
+        context.coordinator.load(source: source, library: library, theme: theme, into: webView)
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -65,15 +93,27 @@ struct MermaidRendererWebView: NSViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate {
         var loadedContentIdentity: Int?
 
-        func load(source: String, library: String?, into webView: WKWebView) {
-            loadedContentIdentity = Self.contentIdentity(source: source, library: library)
-            webView.loadHTMLString(Self.documentHTML(source: source, library: library), baseURL: nil)
+        func load(
+            source: String,
+            library: String?,
+            theme: MermaidRendererTheme,
+            into webView: WKWebView
+        ) {
+            loadedContentIdentity = Self.contentIdentity(source: source, library: library, theme: theme)
+            webView.loadHTMLString(
+                Self.documentHTML(source: source, library: library, theme: theme),
+                baseURL: nil)
         }
 
-        nonisolated static func contentIdentity(source: String, library: String?) -> Int {
+        nonisolated static func contentIdentity(
+            source: String,
+            library: String?,
+            theme: MermaidRendererTheme
+        ) -> Int {
             var hasher = Hasher()
             hasher.combine(source)
             hasher.combine(library)
+            hasher.combine(theme.rawValue)
             return hasher.finalize()
         }
 
@@ -89,12 +129,15 @@ struct MermaidRendererWebView: NSViewRepresentable {
 
         nonisolated static func documentHTML(
             source: String,
-            library: String? = MermaidRendererAssets.library
+            library: String? = MermaidRendererAssets.library,
+            theme: MermaidRendererTheme
         ) -> String {
             let escapedSource = HTMLEntities.escapeHTML(source)
             guard let library else {
                 return fallbackHTML(source: escapedSource)
             }
+            let width = Int(PageEditorMetrics.readableContentWidth)
+            let mermaidTheme = theme.mermaidName
             return """
             <!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
             <meta name="color-scheme" content="light dark">
@@ -103,24 +146,24 @@ struct MermaidRendererWebView: NSViewRepresentable {
               html, body { width: 100%; min-height: 100%; margin: 0; }
               body {
                 display: flex; align-items: flex-start; justify-content: center;
-                box-sizing: border-box; padding: 24px;
+                box-sizing: border-box; padding: 24px 12px 72px;
                 color: CanvasText; background: Canvas;
                 font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+                font-size: 15px; line-height: 1.55;
               }
-              #diagram { max-width: 100%; }
-              #diagram svg { max-width: 100%; height: auto; }
-              #error { max-width: 720px; white-space: pre-wrap; color: #ff453a; }
+              #diagram { box-sizing: border-box; width: \(width)px; max-width: 100%; }
+              \(MermaidRendererAssets.sharedCSS)
+              #error { width: \(width)px; max-width: 100%; white-space: pre-wrap; color: #ff453a; }
             </style></head><body>
-            <div id="diagram" class="mermaid" aria-label="Mermaid diagram">\(escapedSource)</div>
+            <div id="diagram" class="mermaid" aria-label="Mermaid diagram" data-mermaid-theme="\(mermaidTheme)">\(escapedSource)</div>
             <pre id="error" role="alert" hidden></pre>
             <script>\(library)</script>
             <script>
             (function(){
               var diagram = document.getElementById('diagram');
               var error = document.getElementById('error');
-              var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
               try {
-                mermaid.initialize({ startOnLoad:false, securityLevel:'strict', theme:dark ? 'dark' : 'default' });
+                mermaid.initialize({ startOnLoad:false, securityLevel:'strict', theme:'\(mermaidTheme)' });
                 mermaid.run({ nodes:[diagram] }).catch(function(reason){
                   diagram.hidden = true;
                   error.hidden = false;

--- a/Sources/WikiFS/Renderer/MermaidRendererView.swift
+++ b/Sources/WikiFS/Renderer/MermaidRendererView.swift
@@ -167,12 +167,12 @@ struct MermaidRendererWebView: NSViewRepresentable {
                 mermaid.run({ nodes:[diagram] }).catch(function(reason){
                   diagram.hidden = true;
                   error.hidden = false;
-                  error.textContent = 'The Mermaid diagram could not be rendered.\n\n' + String(reason);
+                  error.textContent = 'The Mermaid diagram could not be rendered.\\n\\n' + String(reason);
                 });
               } catch (reason) {
                 diagram.hidden = true;
                 error.hidden = false;
-                error.textContent = 'The Mermaid diagram could not be rendered.\n\n' + String(reason);
+                error.textContent = 'The Mermaid diagram could not be rendered.\\n\\n' + String(reason);
               }
             })();
             </script></body></html>

--- a/Sources/WikiFS/Renderer/MermaidRendererView.swift
+++ b/Sources/WikiFS/Renderer/MermaidRendererView.swift
@@ -6,24 +6,27 @@ import WikiFSCore
 
 /// Cached access to the trusted Mermaid runtime bundled with the app.
 enum MermaidRendererAssets {
-    nonisolated static let library: String? = {
-        guard let url = Bundle.main.url(forResource: "mermaid", withExtension: "js"),
+    nonisolated static let library = library(in: .main)
+
+    nonisolated static func library(in bundle: Bundle) -> String? {
+        guard let url = bundle.url(forResource: "mermaid", withExtension: "js"),
               let source = DebugLog.trying(
                   "load mermaid.js",
                   operation: { try String(contentsOf: url, encoding: .utf8) }),
               source.isEmpty == false
         else { return nil }
         return source
-    }()
+    }
 }
 
 /// Renders one Mermaid diagram as renderer content, without inline-reader card chrome.
 struct MermaidRendererView: View {
     let source: String
+    var library: String? = MermaidRendererAssets.library
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
 
     var body: some View {
-        MermaidRendererWebView(source: source, zoom: readerZoom)
+        MermaidRendererWebView(source: source, library: library, zoom: readerZoom)
             .zoomShortcuts($readerZoom)
             .zoomScroll($readerZoom)
     }
@@ -31,6 +34,7 @@ struct MermaidRendererView: View {
 
 struct MermaidRendererWebView: NSViewRepresentable {
     let source: String
+    let library: String?
     let zoom: Double
 
     func makeNSView(context: Context) -> WKWebView {
@@ -45,24 +49,32 @@ struct MermaidRendererWebView: NSViewRepresentable {
         webView.underPageBackgroundColor = .textBackgroundColor
         webView.navigationDelegate = context.coordinator
         webView.pageZoom = zoom
-        context.coordinator.load(source: source, into: webView)
+        context.coordinator.load(source: source, library: library, into: webView)
         return webView
     }
 
     func updateNSView(_ webView: WKWebView, context: Context) {
         webView.pageZoom = zoom
-        guard context.coordinator.loadedSource != source else { return }
-        context.coordinator.load(source: source, into: webView)
+        let contentIdentity = Coordinator.contentIdentity(source: source, library: library)
+        guard context.coordinator.loadedContentIdentity != contentIdentity else { return }
+        context.coordinator.load(source: source, library: library, into: webView)
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
-        var loadedSource: String?
+        var loadedContentIdentity: Int?
 
-        func load(source: String, into webView: WKWebView) {
-            loadedSource = source
-            webView.loadHTMLString(Self.documentHTML(source: source), baseURL: nil)
+        func load(source: String, library: String?, into webView: WKWebView) {
+            loadedContentIdentity = Self.contentIdentity(source: source, library: library)
+            webView.loadHTMLString(Self.documentHTML(source: source, library: library), baseURL: nil)
+        }
+
+        nonisolated static func contentIdentity(source: String, library: String?) -> Int {
+            var hasher = Hasher()
+            hasher.combine(source)
+            hasher.combine(library)
+            return hasher.finalize()
         }
 
         func webView(
@@ -99,19 +111,16 @@ struct MermaidRendererWebView: NSViewRepresentable {
               #diagram svg { max-width: 100%; height: auto; }
               #error { max-width: 720px; white-space: pre-wrap; color: #ff453a; }
             </style></head><body>
-            <div id="diagram" aria-label="Mermaid diagram"></div>
-            <pre id="source" hidden>\(escapedSource)</pre>
+            <div id="diagram" class="mermaid" aria-label="Mermaid diagram">\(escapedSource)</div>
             <pre id="error" role="alert" hidden></pre>
             <script>\(library)</script>
             <script>
             (function(){
               var diagram = document.getElementById('diagram');
-              var source = document.getElementById('source').textContent;
               var error = document.getElementById('error');
               var dark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
               try {
                 mermaid.initialize({ startOnLoad:false, securityLevel:'strict', theme:dark ? 'dark' : 'default' });
-                diagram.textContent = source;
                 mermaid.run({ nodes:[diagram] }).catch(function(reason){
                   diagram.hidden = true;
                   error.hidden = false;

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -567,24 +567,24 @@ struct RendererActivationView: View {
 
     private var builtInInputs: BuiltInRendererFactoryInputs {
         let inputBytes: Data?
-        let mermaidMarkdown: String?
+        let mermaidDiagramSource: String?
         switch request.input {
         case .inlineArtifact(let artifact):
             inputBytes = artifact.bytes
-            let rawMarkdown = String(decoding: artifact.bytes, as: UTF8.self)
-            mermaidMarkdown = MermaidSourceDetector.renderableMarkdown(from: rawMarkdown)
+            mermaidDiagramSource = String(decoding: artifact.bytes, as: UTF8.self)
         case .source:
             inputBytes = nil
-            mermaidMarkdown = nil
+            mermaidDiagramSource = nil
         case .markdown:
             inputBytes = nil
-            mermaidMarkdown = nil
+            mermaidDiagramSource = nil
         }
         return BuiltInRendererFactoryInputs(
             sourceBytes: inputBytes,
             pdfQuote: nil,
             htmlSource: nil,
-            mermaidMarkdown: mermaidMarkdown,
+            mermaidMarkdown: nil,
+            mermaidDiagramSource: mermaidDiagramSource,
             mediaTarget: nil,
             selection: store.selection,
             store: store,

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -27,6 +27,10 @@ public final class SessionManager {
     /// Live sessions keyed by wiki ID. A wiki open in multiple windows
     /// shares ONE session (one store, one bus, one gate).
     public private(set) var sessions: [WikiID: WikiSession] = [:]
+    /// Number of live `RootScene` owners for each cached session. A renderer
+    /// window does not own a lease; it resolves through the session retained by
+    /// the wiki window that activated it.
+    @ObservationIgnored private var sessionLeaseCounts: [WikiID: Int] = [:]
 
     /// Per-wiki store-open failures (issue #881). When `session(for:)` throws
     /// (the on-disk DB couldn't be opened), the error message is recorded here
@@ -165,6 +169,7 @@ public final class SessionManager {
             // Refresh the descriptor in case the registry mutated (rename /
             // set home page) since this session was created.
             existing.updateDescriptor(descriptor)
+            sessionLeaseCounts[wikiID, default: 0] += 1
             return existing
         }
         let newSession: WikiSession
@@ -206,13 +211,26 @@ public final class SessionManager {
             newSession.pendingWikiLink = pending
         }
         sessions[wikiID] = newSession
+        sessionLeaseCounts[wikiID] = 1
         return newSession
     }
 
-    /// Remove a session from the cache (called when the last window for a
-    /// wiki closes). Flushes pending saves before removal so no buffered
-    /// edits are stranded.
+    /// Release one window's lease on a session. The session leaves the cache
+    /// only after its last `RootScene` closes, so another window showing the
+    /// same wiki can still resolve renderer and comparison windows through the
+    /// shared manager.
     public func releaseSession(for wikiID: WikiID) {
+        guard sessions[wikiID] != nil else { return }
+        let remainingLeases = max(0, sessionLeaseCounts[wikiID, default: 1] - 1)
+        guard remainingLeases == 0 else {
+            sessionLeaseCounts[wikiID] = remainingLeases
+            return
+        }
+        removeSession(for: wikiID)
+    }
+
+    private func removeSession(for wikiID: WikiID) {
+        sessionLeaseCounts.removeValue(forKey: wikiID)
         guard let session = sessions.removeValue(forKey: wikiID) else { return }
         session.store.flushPendingSaves()
         let token = UUID()
@@ -225,9 +243,10 @@ public final class SessionManager {
     }
 
     /// Release all live sessions, await owned teardown, then dispose the private
-    /// search root. Safe to call repeatedly during app termination.
+    /// search root. App termination force-removes sessions regardless of how
+    /// many window leases remain. Safe to call repeatedly.
     public func shutdownSearchRuntimes() async {
-        for wikiID in Array(sessions.keys) { releaseSession(for: wikiID) }
+        for wikiID in Array(sessions.keys) { removeSession(for: wikiID) }
         let releases = Array(searchReleaseTasks.values)
         for release in releases { await release.task.value }
         searchReleaseTasks.removeAll()

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -728,6 +728,7 @@ struct MarkdownHTMLRendererTests {
         #expect(html.contains(#"id="diagram" class="mermaid""#))
         #expect(html.contains(#"data-mermaid-theme="dark""#))
         #expect(html.contains("theme:'dark'"))
+        #expect(html.contains(#"rendered.\n\n' + String(reason)"#))
         #expect(html.contains("width: \(Int(PageEditorMetrics.readableContentWidth))px"))
         #expect(html.contains(MermaidRendererAssets.sharedCSS))
         #expect(html.contains(#"id="source" hidden"#) == false)

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -722,10 +722,14 @@ struct MarkdownHTMLRendererTests {
         let source = "flowchart LR\nA[Start <&>] --> B[Finish]"
         let html = MermaidRendererWebView.Coordinator.documentHTML(
             source: source,
-            library: "window.mermaid = window.mermaid || {};"
-        )
+            library: "window.mermaid = window.mermaid || {};",
+            theme: .dark)
 
         #expect(html.contains(#"id="diagram" class="mermaid""#))
+        #expect(html.contains(#"data-mermaid-theme="dark""#))
+        #expect(html.contains("theme:'dark'"))
+        #expect(html.contains("width: \(Int(PageEditorMetrics.readableContentWidth))px"))
+        #expect(html.contains(MermaidRendererAssets.sharedCSS))
         #expect(html.contains(#"id="source" hidden"#) == false)
         #expect(html.contains(#"id="error" role="alert" hidden"#))
         #expect(html.contains("securityLevel:'strict'"))
@@ -737,6 +741,37 @@ struct MarkdownHTMLRendererTests {
         #expect(html.contains("data-mermaid-disclosure") == false)
         #expect(html.contains("data-renderer-action") == false)
         #expect(html.contains("Open in Window") == false)
+    }
+
+    @Test("standalone Mermaid renderer uses the explicit app theme")
+    func standaloneMermaidRendererUsesExplicitTheme() {
+        let source = "flowchart LR\nA --> B"
+        let library = "window.mermaid = window.mermaid || {};"
+        let lightHTML = MermaidRendererWebView.Coordinator.documentHTML(
+            source: source,
+            library: library,
+            theme: .light)
+        let darkHTML = MermaidRendererWebView.Coordinator.documentHTML(
+            source: source,
+            library: library,
+            theme: .dark)
+
+        #expect(lightHTML.contains(#"data-mermaid-theme="default""#))
+        #expect(lightHTML.contains("theme:'default'"))
+        #expect(darkHTML.contains(#"data-mermaid-theme="dark""#))
+        #expect(darkHTML.contains("theme:'dark'"))
+        #expect(lightHTML.contains("matchMedia") == false)
+        #expect(darkHTML.contains("matchMedia") == false)
+
+        let lightIdentity = MermaidRendererWebView.Coordinator.contentIdentity(
+            source: source,
+            library: library,
+            theme: .light)
+        let darkIdentity = MermaidRendererWebView.Coordinator.contentIdentity(
+            source: source,
+            library: library,
+            theme: .dark)
+        #expect(lightIdentity != darkIdentity)
     }
 
     @Test("renderer row stylesheet stays compact, relative, focus-visible, and motion-aware")

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -717,6 +717,28 @@ struct MarkdownHTMLRendererTests {
         #expect(html.contains("sdw-renderer-card") == false)
     }
 
+    @Test("standalone Mermaid renderer contains no inline card chrome")
+    func standaloneMermaidRendererOmitsInlineCardChrome() {
+        let source = "flowchart LR\nA[Start <&>] --> B[Finish]"
+        let html = MermaidRendererWebView.Coordinator.documentHTML(
+            source: source,
+            library: "window.mermaid = window.mermaid || {};"
+        )
+
+        #expect(html.contains(#"id="diagram""#))
+        #expect(html.contains(#"id="source" hidden"#))
+        #expect(html.contains(#"id="error" role="alert" hidden"#))
+        #expect(html.contains("securityLevel:'strict'"))
+        #expect(html.contains("default-src 'none'"))
+        #expect(html.contains("flowchart LR"))
+        #expect(html.contains("Start &lt;&amp;&gt;"))
+        #expect(html.contains("sdw-renderer-card") == false)
+        #expect(html.contains("sdw-renderer-card__row") == false)
+        #expect(html.contains("data-mermaid-disclosure") == false)
+        #expect(html.contains("data-renderer-action") == false)
+        #expect(html.contains("Open in Window") == false)
+    }
+
     @Test("renderer row stylesheet stays compact, relative, focus-visible, and motion-aware")
     func rendererRowStylesUseNativeReaderScaleAndFocus() {
         let html = WikiReaderView.documentHTML("<p>Body</p>")
@@ -746,7 +768,7 @@ struct MarkdownHTMLRendererTests {
     }
 
     @Test func documentHTMLEmbedsNoScriptWhenLibAbsent() {
-        // Under `swift test` there's no .app bundle, so `mermaidLib` is nil →
+        // Under `swift test` there's no .app bundle, so the shared Mermaid library is nil →
         // documentHTML embeds NO <script>, and the mermaid block is preserved as
         // ordinary code. Pins graceful degradation (AC.4/AC.5).
         let h = WikiReaderView.documentHTML("<pre><code class=\"language-mermaid\">graph TD</code></pre>")

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -725,8 +725,8 @@ struct MarkdownHTMLRendererTests {
             library: "window.mermaid = window.mermaid || {};"
         )
 
-        #expect(html.contains(#"id="diagram""#))
-        #expect(html.contains(#"id="source" hidden"#))
+        #expect(html.contains(#"id="diagram" class="mermaid""#))
+        #expect(html.contains(#"id="source" hidden"#) == false)
         #expect(html.contains(#"id="error" role="alert" hidden"#))
         #expect(html.contains("securityLevel:'strict'"))
         #expect(html.contains("default-src 'none'"))

--- a/Tests/WikiFSAppTests/MermaidRendererHostedTests.swift
+++ b/Tests/WikiFSAppTests/MermaidRendererHostedTests.swift
@@ -1,0 +1,83 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import Testing
+import WebKit
+@testable import WikiFS
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct MermaidRendererHostedTests {
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    @Test("standalone Mermaid renderer paints an SVG with the packaged runtime")
+    func standaloneRendererPaintsSVG() async throws {
+        _ = Self.app
+        let appURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "build/Self Driving Wiki.app")
+        let appBundle = try #require(Bundle(url: appURL))
+        let library = try #require(MermaidRendererAssets.library(in: appBundle))
+
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        let view = MermaidRendererView(
+            source: "flowchart LR\nA[Start] --> B[Finish]",
+            library: library)
+        let hosting = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: hosting)
+        window.setContentSize(NSSize(width: 800, height: 600))
+        window.orderFront(nil)
+        defer {
+            window.orderOut(nil)
+            lease.release()
+        }
+
+        let webView = try await waitForWebView(in: window)
+        var result = ""
+        for _ in 0..<100 {
+            result = await evaluateJavaScriptWithTimeout(webView, """
+            (function(){
+              if (document.querySelector('#diagram svg')) return 'svg';
+              var error = document.getElementById('error');
+              if (error && !error.hidden) return 'error:' + error.textContent;
+              return 'waiting:' + document.readyState + ':' + typeof window.mermaid;
+            })()
+            """, timeout: .seconds(2)) ?? "no-result"
+            if result == "svg" || result.hasPrefix("error:") { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        #expect(result == "svg", "standalone Mermaid runtime result: \(result)")
+    }
+
+    private func waitForWebView(in window: NSWindow, timeout: Duration = .seconds(5)) async throws -> WKWebView {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let contentView = window.contentView,
+               let webView = findWebView(in: contentView) {
+                return webView
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        throw NSError(
+            domain: "MermaidRendererHostedTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "No hosted Mermaid WKWebView appeared"])
+    }
+
+    private func findWebView(in view: NSView) -> WKWebView? {
+        if let webView = view as? WKWebView { return webView }
+        for subview in view.subviews {
+            if let webView = findWebView(in: subview) { return webView }
+        }
+        return nil
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/MermaidRendererHostedTests.swift
+++ b/Tests/WikiFSAppTests/MermaidRendererHostedTests.swift
@@ -15,7 +15,7 @@ struct MermaidRendererHostedTests {
     }()
 
     @Test(
-        "standalone Mermaid renderer paints the Testbed diagram at reader size and app theme",
+        "standalone Mermaid renderer paints the requested palette at reader size",
         arguments: [ColorScheme.light, .dark])
     func standaloneRendererMatchesReaderPresentation(colorScheme: ColorScheme) async throws {
         _ = Self.app
@@ -54,7 +54,10 @@ struct MermaidRendererHostedTests {
               var diagram = document.getElementById('diagram');
               var svg = diagram && diagram.querySelector('svg');
               if (svg) {
-                return 'svg:' + diagram.dataset.mermaidTheme + ':'
+                var node = svg.querySelector('.node rect, .node polygon, .node circle');
+                var fill = node ? getComputedStyle(node).fill : 'missing';
+                var configuredTheme = mermaid.mermaidAPI.getConfig().theme || 'missing';
+                return 'svg:' + configuredTheme + ':' + fill + ':'
                   + Math.round(diagram.getBoundingClientRect().width) + ':'
                   + Math.round(svg.getBoundingClientRect().width);
               }
@@ -67,11 +70,18 @@ struct MermaidRendererHostedTests {
             try await Task.sleep(for: .milliseconds(50))
         }
 
-        let expectedTheme = MermaidRendererTheme(colorScheme: colorScheme).mermaidName
         let expectedWidth = Int(PageEditorMetrics.readableContentWidth)
-        #expect(
-            result == "svg:\(expectedTheme):\(expectedWidth):\(expectedWidth)",
-            "standalone Mermaid runtime result: \(result)")
+        let expectedTheme = MermaidRendererTheme(colorScheme: colorScheme).mermaidName
+        let expectedFill = colorScheme == .dark ? "rgb(31, 32, 32)" : "rgb(236, 236, 255)"
+        let fields = result.split(separator: ":")
+        #expect(fields.count == 5, "standalone Mermaid runtime result: \(result)")
+        if fields.count == 5 {
+            #expect(fields[0] == "svg")
+            #expect(fields[1] == Substring(expectedTheme))
+            #expect(fields[2] == Substring(expectedFill), "Mermaid node fill: \(fields[2])")
+            #expect(fields[3] == Substring(String(expectedWidth)))
+            #expect(fields[4] == Substring(String(expectedWidth)))
+        }
     }
 
     private func waitForWebView(in window: NSWindow, timeout: Duration = .seconds(5)) async throws -> WKWebView {

--- a/Tests/WikiFSAppTests/MermaidRendererHostedTests.swift
+++ b/Tests/WikiFSAppTests/MermaidRendererHostedTests.swift
@@ -14,8 +14,10 @@ struct MermaidRendererHostedTests {
         return app
     }()
 
-    @Test("standalone Mermaid renderer paints an SVG with the packaged runtime")
-    func standaloneRendererPaintsSVG() async throws {
+    @Test(
+        "standalone Mermaid renderer paints the Testbed diagram at reader size and app theme",
+        arguments: [ColorScheme.light, .dark])
+    func standaloneRendererMatchesReaderPresentation(colorScheme: ColorScheme) async throws {
         _ = Self.app
         let appURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -26,12 +28,18 @@ struct MermaidRendererHostedTests {
         let library = try #require(MermaidRendererAssets.library(in: appBundle))
 
         let lease = await HostedAppKitTestGate.shared.acquire()
-        let view = MermaidRendererView(
-            source: "flowchart LR\nA[Start] --> B[Finish]",
-            library: library)
+        let source = """
+        flowchart LR
+            Sources["Raw sources<br/>(immutable)"] --> Wiki["The wiki<br/>(LLM-owned markdown)"]
+            Schema["The schema<br/>(CLAUDE.md / AGENTS.md)"] -.->|governs| Wiki
+            You["You"] -->|curate and ask| Sources
+            Wiki -->|you read| You
+        """
+        let view = MermaidRendererView(source: source, library: library)
+            .environment(\.colorScheme, colorScheme)
         let hosting = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: hosting)
-        window.setContentSize(NSSize(width: 800, height: 600))
+        window.setContentSize(NSSize(width: 900, height: 640))
         window.orderFront(nil)
         defer {
             window.orderOut(nil)
@@ -43,17 +51,27 @@ struct MermaidRendererHostedTests {
         for _ in 0..<100 {
             result = await evaluateJavaScriptWithTimeout(webView, """
             (function(){
-              if (document.querySelector('#diagram svg')) return 'svg';
+              var diagram = document.getElementById('diagram');
+              var svg = diagram && diagram.querySelector('svg');
+              if (svg) {
+                return 'svg:' + diagram.dataset.mermaidTheme + ':'
+                  + Math.round(diagram.getBoundingClientRect().width) + ':'
+                  + Math.round(svg.getBoundingClientRect().width);
+              }
               var error = document.getElementById('error');
               if (error && !error.hidden) return 'error:' + error.textContent;
               return 'waiting:' + document.readyState + ':' + typeof window.mermaid;
             })()
             """, timeout: .seconds(2)) ?? "no-result"
-            if result == "svg" || result.hasPrefix("error:") { break }
+            if result.hasPrefix("svg:") || result.hasPrefix("error:") { break }
             try await Task.sleep(for: .milliseconds(50))
         }
 
-        #expect(result == "svg", "standalone Mermaid runtime result: \(result)")
+        let expectedTheme = MermaidRendererTheme(colorScheme: colorScheme).mermaidName
+        let expectedWidth = Int(PageEditorMetrics.readableContentWidth)
+        #expect(
+            result == "svg:\(expectedTheme):\(expectedWidth):\(expectedWidth)",
+            "standalone Mermaid runtime result: \(result)")
     }
 
     private func waitForWebView(in window: NSWindow, timeout: Duration = .seconds(5)) async throws -> WKWebView {

--- a/Tests/WikiFSTests/SessionManagerTests.swift
+++ b/Tests/WikiFSTests/SessionManagerTests.swift
@@ -114,6 +114,24 @@ struct SessionManagerTests {
         #expect(manager.sessions.isEmpty)
     }
 
+    @Test func releasingOneOfTwoWikiWindowsKeepsSharedSessionAvailable() throws {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let manager = makeSessionManager(dir: dir)
+        let descriptor = try #require(registry.wikis.first)
+
+        let firstWindowSession = try manager.session(for: descriptor.id, descriptor: descriptor)
+        let secondWindowSession = try manager.session(for: descriptor.id, descriptor: descriptor)
+        #expect(firstWindowSession === secondWindowSession)
+
+        manager.releaseSession(for: descriptor.id)
+
+        #expect(manager.sessions[descriptor.id] === firstWindowSession)
+
+        manager.releaseSession(for: descriptor.id)
+        #expect(manager.sessions[descriptor.id] == nil)
+    }
+
     @Test func testReleaseSessionFlushesPendingSaves() {
         let dir = tempDirectory()
         let registry = makeSeededRegistry(dir: dir)


### PR DESCRIPTION
## Summary

- Keep a shared wiki session until its last wiki window closes.
- Render activated Mermaid artifacts through a dedicated content view.
- Paint Mermaid source through the runtime-supported visible node contract.
- Execute the standalone Mermaid bootstrap with the app color scheme.
- Display the initial standalone SVG at the reader content width.
- Keep collapsible renderer cards only in inline Markdown readers.
- Add session, HTML-contract, and hosted WebKit regression tests.

## Causes

`SessionManager` shared one session across wiki windows but did not count its owners. The first closed window removed the shared session. An activated renderer could not resolve that session.

The Mermaid factory also used `WikiReaderView` as renderer content. The reader projected the Mermaid fence as another collapsible inline card.

The first direct renderer passed an empty diagram node to Mermaid and stored the source in a hidden sibling. The Mermaid runtime loaded but did not complete that render. The window stayed blank.

The standalone bootstrap also contained literal newline characters inside a single-quoted JavaScript error string. WebKit could not parse the bootstrap. Mermaid then rendered the visible `.mermaid` node through its automatic startup path with the default lavender palette. The explicit dark-theme initialization never ran.

The standalone SVG also had no stable reader-width container, so the diagram stayed small.

## Design

Inline projection owns the row, disclosure control, fallback, and Open in Window action. A standalone renderer window hosts only renderer content.

`MermaidRendererView` places escaped source directly in a visible `.mermaid` node before it calls `mermaid.run`. This follows Mermaid's supported runtime contract.

The view converts SwiftUI `ColorScheme` to a typed Mermaid theme. The theme forms part of the WebView content identity, so an appearance change reloads the diagram.

The JavaScript error message now uses escaped newline sequences. This keeps the bootstrap valid, so `mermaid.initialize` applies the requested theme before `mermaid.run` renders the SVG.

The standalone canvas uses `PageEditorMetrics.readableContentWidth`. Shared Mermaid CSS keeps the inline and standalone SVG sizing rules equal.

This PR does not add zoom controls or new zoom modes. Those controls will use a separate PR.

The view uses the bundled Mermaid runtime, strict Mermaid security, a restrictive content security policy, a nonpersistent WebKit data store, and blocked navigation.

The normal Markdown reader keeps its existing collapsible Mermaid card behavior.

## Tests

Passed:

- `make build`
- Hosted production-view test with the packaged app bundle and real Mermaid runtime
- Hosted light and dark cases with the exact Testbed Mermaid diagram
- Hosted checks for Mermaid's active theme and actual SVG node fill
- Hosted canvas and SVG width checks at the 900 by 640 default window size
- Standalone no-card, valid-bootstrap, and explicit-theme HTML contract tests
- Inline Mermaid card preservation test
- `make test` (3,528 tests in 342 suites)
- Pre-commit SwiftLint gate (546 files, zero violations)

The broad opt-in `WIKIFS_APP_TESTS=1 swift test` command previously reported unrelated existing failures in MIME, queue-client, planner, and daemon-chat suites. The focused Mermaid app tests pass within that test target.
