### PR TITLE
feat(cordis)!: delete the privileged core; boot app, daemon, and CLI from profiles

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -330,6 +330,7 @@ let package = Package(
             name: "WikiFSEngine",
             dependencies: [
                 "Cordis",
+                "CordisLoader",
                 "WikiFSCore",
                 // ACP client runtime (ACPBackend — plans/acp-backend-and-permissions.md).
                 // The `ACP` product is macOS-only: it uses ACPProcessManager and os.log.

--- a/Sources/CordisLoader/EntryTree.swift
+++ b/Sources/CordisLoader/EntryTree.swift
@@ -193,23 +193,32 @@ public enum CordisBoot {
     public struct Options: Sendable {
         public var catalog: PluginCatalog
         public var layers: [PatchFile]
+        /// Optional process context whose services are inherited by this profile.
+        /// Per-wiki profiles use a child so process services keep process lifetime.
+        public var parent: CordisContext?
         /// Supplies ambient facts (home path, app group id, wiki id) on the
-        /// root context before entries mount.
+        /// profile context before entries mount.
         public var configure: (@Sendable (CordisContext) async throws -> Void)?
 
         public init(
             catalog: PluginCatalog,
             layers: [PatchFile],
+            parent: CordisContext? = nil,
             configure: (@Sendable (CordisContext) async throws -> Void)? = nil
         ) {
             self.catalog = catalog
             self.layers = layers
+            self.parent = parent
             self.configure = configure
         }
     }
 
     public static func boot(_ options: Options) async throws -> BootedProfile {
-        let context = CordisContext()
+        let context = if let parent = options.parent {
+            try await parent.child()
+        } else {
+            CordisContext()
+        }
         if let configure = options.configure {
             try await configure(context)
         }

--- a/Sources/WikiCtlCore/CLIPluginCatalog.swift
+++ b/Sources/WikiCtlCore/CLIPluginCatalog.swift
@@ -1,0 +1,12 @@
+#if os(macOS)
+import Cordis
+import WikiFSEngine
+
+public enum WikiCtlPluginCatalog {
+    public static func build(
+        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+    ) throws -> PluginCatalog {
+        try CLIPluginCatalog.build(makeTantivyRuntime: makeTantivyRuntime)
+    }
+}
+#endif

--- a/Sources/WikiCtlCore/CLIPluginCatalog.swift
+++ b/Sources/WikiCtlCore/CLIPluginCatalog.swift
@@ -4,7 +4,7 @@ import WikiFSEngine
 
 public enum WikiCtlPluginCatalog {
     public static func build(
-        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeCompositionFactory.runtimeFactory
     ) throws -> PluginCatalog {
         try CLIPluginCatalog.build(makeTantivyRuntime: makeTantivyRuntime)
     }

--- a/Sources/WikiCtlCore/CLITantivyLegResolver.swift
+++ b/Sources/WikiCtlCore/CLITantivyLegResolver.swift
@@ -287,13 +287,13 @@ public enum CLITantivyLegResolver {
         var handle: SearchRuntimeHandle?
         do {
             let child = try await root.child()
-            let assembly = SearchRuntimeAssembly(
+            let runtime = SearchRuntimeAssembly.runtimeFactory(
                 identity: SearchRuntimeIdentity(
                     wikiID: wikiID,
                     containerDirectory: containerDirectory),
                 contentSource: StoreBackedTantivyContentSource(store: store),
                 changeStreamFactory: FinishedSearchChangeStreamFactory())
-            let assembled = try await assembly.assemble(in: child)
+            let assembled = try await runtime.assemble(in: child)
             handle = assembled
             let hits = try await assembled.services.search(
                 query: query,

--- a/Sources/WikiCtlCore/CLITantivyLegResolver.swift
+++ b/Sources/WikiCtlCore/CLITantivyLegResolver.swift
@@ -3,6 +3,7 @@ import WikiFSCore
 
 #if os(macOS)
 import Cordis
+import CordisLoader
 import WikiFSEngine
 /// Bridges the wikictl CLI's three search commands (`page search`,
 /// `source search`, `chat search`) onto the SAME Tantivy BM25 leg the app's
@@ -34,6 +35,10 @@ import WikiFSEngine
 /// issue #628 — no C scalar). Request-scoped runtime startup rebuilds an empty
 /// derived index before querying, including for wikis not yet opened by the app.
 public enum CLITantivyLegResolver {
+    private enum ProfileSearchError: Error, Sendable {
+        case missingTantivyProvider
+    }
+
     struct SearchRequestKey: Hashable, Sendable {
         let wikiID: WikiID
         let containerPath: String
@@ -283,11 +288,20 @@ public enum CLITantivyLegResolver {
         kind: TantivyDocumentKind,
         limit: Int
     ) async -> [TantivyShadowSearchResult] {
-        let root = CordisContext()
+        var profile: BootedProfile?
         var handle: SearchRuntimeHandle?
         do {
-            let child = try await root.child()
-            let runtime = SearchRuntimeAssembly.runtimeFactory(
+            let booted = try await CordisBoot.boot(.init(
+                catalog: try CLIPluginCatalog.build(),
+                layers: [PatchFile(entries: ProductionProfileEntries.cli())]))
+            profile = booted
+            let providers = try await booted.context.require(SearchServiceKeys.providers)
+            guard let registration = await providers.resolve(TantivySearchPlugin.key),
+                  case .tantivy(let provider) = registration.adapter else {
+                throw ProfileSearchError.missingTantivyProvider
+            }
+            let child = try await booted.context.child()
+            let runtime = provider.runtime(
                 identity: SearchRuntimeIdentity(
                     wikiID: wikiID,
                     containerDirectory: containerDirectory),
@@ -299,18 +313,18 @@ public enum CLITantivyLegResolver {
                 query: query,
                 kinds: [kind],
                 limit: limit)
-            await dispose(handle: assembled, root: root, wikiID: wikiID)
+            await dispose(handle: assembled, profile: booted, wikiID: wikiID)
             return hits
         } catch {
             DebugLog.store("wikictl: Tantivy search unavailable for wiki \(wikiID.rawValue): \(error)")
-            await dispose(handle: handle, root: root, wikiID: wikiID)
+            await dispose(handle: handle, profile: profile, wikiID: wikiID)
             return []
         }
     }
 
     private static func dispose(
         handle: SearchRuntimeHandle?,
-        root: CordisContext,
+        profile: BootedProfile?,
         wikiID: WikiID
     ) async {
         if let handle {
@@ -320,10 +334,12 @@ public enum CLITantivyLegResolver {
                 DebugLog.store("wikictl: search child cleanup failed for wiki \(wikiID.rawValue): \(error)")
             }
         }
-        do {
-            try await root.dispose()
-        } catch {
-            DebugLog.store("wikictl: search root cleanup failed for wiki \(wikiID.rawValue): \(error)")
+        if let profile {
+            do {
+                try await profile.shutdown()
+            } catch {
+                DebugLog.store("wikictl: search profile cleanup failed for wiki \(wikiID.rawValue): \(error)")
+            }
         }
     }
 

--- a/Sources/WikiFS/BackgroundIngestCoordinator.swift
+++ b/Sources/WikiFS/BackgroundIngestCoordinator.swift
@@ -155,7 +155,7 @@ final class BackgroundIngestCoordinator {
     // MARK: - Per-wiki scan
 
     
-    private func scanWiki(session: WikiSession) async {
+    private func scanWiki(session: any WikiSessionProtocol) async {
         let wikiID = session.wikiID
         let store = session.store
         let sources = store.sources

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -15,7 +15,7 @@ struct ChatDetailView: View {
     @Bindable var store: WikiStoreModel
     var remoteSession: RemoteChatSession
     var coordinator: ChatDaemonCoordinator
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     let fileProvider: FileProviderFacade
     @Environment(WindowRightInspectorController.self) private var rightInspector
 

--- a/Sources/WikiFS/Pages/PageDetailView.swift
+++ b/Sources/WikiFS/Pages/PageDetailView.swift
@@ -12,7 +12,7 @@ struct PageDetailView: View {
     @Bindable var store: WikiStoreModel
     @Bindable var launcher: AgentLauncher
     /// The per-active-wiki session (store + launchers + descriptor).
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     let fileProvider: FileProviderFacade
     /// Optional typed renderer admission sink. When absent, rich cards stay
     /// static and do not expose activation metadata.
@@ -63,7 +63,7 @@ struct PageDetailView: View {
     init(
         store: WikiStoreModel,
         launcher: AgentLauncher,
-        session: WikiSession,
+        session: any WikiSessionProtocol,
         fileProvider: FileProviderFacade,
         installedRendererFactory: InstalledRendererFactory = .unavailable,
         installedRendererFactoryInputs: InstalledRendererFactory.Inputs = .unavailable,

--- a/Sources/WikiFS/Pages/PagesContainerView.swift
+++ b/Sources/WikiFS/Pages/PagesContainerView.swift
@@ -10,7 +10,7 @@ struct PagesContainerView: View {
     @Bindable var store: WikiStoreModel
     let fileProvider: FileProviderFacade
     /// The per-active-wiki session (store + launchers + descriptor).
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     /// App-scoped registry — used for `setHomePage` persistence.
     var registry: WikiRegistryClient
     let launcher: AgentLauncher

--- a/Sources/WikiFS/Pages/PagesListView.swift
+++ b/Sources/WikiFS/Pages/PagesListView.swift
@@ -15,7 +15,7 @@ import WikiFSCore
 struct PagesListView: NSViewControllerRepresentable {
     let store: WikiStoreModel
     let fileProvider: FileProviderFacade
-    let session: WikiSession
+    let session: any WikiSessionProtocol
     let launcher: AgentLauncher
     let callbacks: PagesListCallbacks
 

--- a/Sources/WikiFS/Queue/AppQueueExtractionProvider.swift
+++ b/Sources/WikiFS/Queue/AppQueueExtractionProvider.swift
@@ -35,7 +35,7 @@ final class SessionLookupBox: @unchecked Sendable {
 
     /// Returns the live `WikiSession` for a wikiID, or nil if no session is
     /// open. Used by the ingestion provider to access the session's launcher.
-    private var sessionLookup: @MainActor @Sendable (WikiID) -> WikiSession?
+    private var sessionLookup: @MainActor @Sendable (WikiID) -> (any WikiSessionProtocol)?
 
     init() {
         // No sessions exist yet — return nil. Replaced after SessionManager
@@ -50,7 +50,7 @@ final class SessionLookupBox: @unchecked Sendable {
     }
 
     /// Synchronous session resolution (caller must be on the main actor).
-    func resolveSession(for wikiID: WikiID) -> WikiSession? {
+    func resolveSession(for wikiID: WikiID) -> (any WikiSessionProtocol)? {
         sessionLookup(wikiID)
     }
 
@@ -60,7 +60,7 @@ final class SessionLookupBox: @unchecked Sendable {
     }
 
     /// Wire the session-lookup closure to the real session manager.
-    func setSessionLookup(_ lookup: @escaping @MainActor @Sendable (WikiID) -> WikiSession?) {
+    func setSessionLookup(_ lookup: @escaping @MainActor @Sendable (WikiID) -> (any WikiSessionProtocol)?) {
         self.sessionLookup = lookup
     }
 }

--- a/Sources/WikiFS/Renderer/RendererCompositionOwner.swift
+++ b/Sources/WikiFS/Renderer/RendererCompositionOwner.swift
@@ -204,7 +204,7 @@ final class AppProcessComposition {
             operation: { try DatabaseLocation.queueDatabaseURL() })
             ?? containerDirectory.appendingPathComponent("queue.sqlite", isDirectory: false)
         let queueController = LocalQueueRuntimeController {
-            try await QueueRuntimeAssembly(
+            try await QueueRuntimeFactory(
                 databaseURL: queueDBURL,
                 extractionProvider: await MainActor.run { extractionProvider(extractionServices) },
                 makeIngestionProvider: { store in
@@ -213,7 +213,7 @@ final class AppProcessComposition {
                 .assemble()
         }
         let transportOwner = DaemonTransportCompositionOwner {
-            try await DaemonTransportRuntimeAssembly(
+            try await DaemonTransportRuntimeFactory(
                 connectionFactory: transportBridge.connectionFactory,
                 configuration: .init(
                     retryInterval: .seconds(30),
@@ -229,7 +229,7 @@ final class AppProcessComposition {
             preconditionFailure("Resolved app-group renderer layout was invalid: \(error)")
         }
         let rendererOwner = RendererCompositionOwner {
-            try await RendererRuntimeAssembly(
+            try await RendererRuntimeFactory(
                 layout: rendererLayout,
                 bundledPackageSource: { BundledRendererPackages.excalidrawResourceURL() },
                 reviewedBundledIdentity: .init(
@@ -247,7 +247,7 @@ final class AppProcessComposition {
 
         profileOwner = AppProcessProfileOwner(factories: ProcessPluginCatalogFactories(
                 makeAgentProvider: {
-                    let handle = try await AgentProviderRuntimeAssembly(
+                    let handle = try await AgentProviderRuntimeFactory(
                         readConfiguration: { AgentProvidersConfig.loadOrSeed(from: containerDirectory) },
                         resolveCommand: { providers in
                             let searchPath = await PathPreflight.loginShellPATH()
@@ -277,7 +277,7 @@ final class AppProcessComposition {
                 },
                 makeExtraction: {
                     let owner = ExtractionCompositionOwner(services: extractionServices) {
-                        try await ExtractionRuntimeAssembly(
+                        try await ExtractionRuntimeFactory(
                             readConfiguration: { ExtractionConfig.load(from: containerDirectory) },
                             readCredential: { extractionCredentialStore.secret($0) },
                             resolveACP: { configuration in

--- a/Sources/WikiFS/Renderer/RendererCompositionOwner.swift
+++ b/Sources/WikiFS/Renderer/RendererCompositionOwner.swift
@@ -1,6 +1,8 @@
 #if os(macOS)
 import Foundation
 import Synchronization
+import WikiFSCore
+import WikiFSEngine
 import WikiFSTypes
 
 final class RendererPublicationAdmission: Sendable {
@@ -169,5 +171,166 @@ actor RendererCompositionOwner {
             DebugLog.store("Renderer composition \(phase) cleanup failed.")
         }
     }
+}
+
+/// App-target process composition. It creates stable facades synchronously for
+/// SwiftUI consumers, while the process profile owns every concrete runtime
+/// through its plugin leases.
+@MainActor
+final class AppProcessComposition {
+    let profileOwner: AppProcessProfileOwner
+    let providerServices: MutableAgentProviderServices
+    let extractionServices: MutableExtractionServices
+    let queueController: LocalQueueRuntimeController
+    let transportOwner: DaemonTransportCompositionOwner
+    let rendererOwner: RendererCompositionOwner
+
+    init(
+        containerDirectory: URL,
+        transportBridge: DaemonTransportAppBridge,
+        extractionProvider: @escaping @MainActor (any ExtractionServices) -> any QueueExtractionProvider,
+        makeIngestionProvider: @escaping @MainActor (
+            QueueStore,
+            any AgentProviderServices
+        ) -> any QueueIngestionProvider
+    ) {
+        let providerServices = MutableAgentProviderServices()
+        let extractionServices = MutableExtractionServices()
+        let extractionCredentialStore = KeychainExtractionCredentialStore()
+        let acpCredentialStore = KeychainACPCredentialStore()
+
+        let queueDBURL = DebugLog.trying(
+            "resolve queue database URL",
+            operation: { try DatabaseLocation.queueDatabaseURL() })
+            ?? containerDirectory.appendingPathComponent("queue.sqlite", isDirectory: false)
+        let queueController = LocalQueueRuntimeController {
+            try await QueueRuntimeAssembly(
+                databaseURL: queueDBURL,
+                extractionProvider: await MainActor.run { extractionProvider(extractionServices) },
+                makeIngestionProvider: { store in
+                    await MainActor.run { makeIngestionProvider(store, providerServices) }
+                })
+                .assemble()
+        }
+        let transportOwner = DaemonTransportCompositionOwner {
+            try await DaemonTransportRuntimeAssembly(
+                connectionFactory: transportBridge.connectionFactory,
+                configuration: .init(
+                    retryInterval: .seconds(30),
+                    healthCheckInterval: .seconds(30),
+                    healthCheckTimeout: 5,
+                    acceptanceDeadline: .seconds(30)))
+                .assemble()
+        }
+        let rendererLayout: RendererPackageStoreLayout
+        do {
+            rendererLayout = try RendererPackageStoreLayout(appGroupContainerRoot: containerDirectory)
+        } catch {
+            preconditionFailure("Resolved app-group renderer layout was invalid: \(error)")
+        }
+        let rendererOwner = RendererCompositionOwner {
+            try await RendererRuntimeAssembly(
+                layout: rendererLayout,
+                bundledPackageSource: { BundledRendererPackages.excalidrawResourceURL() },
+                reviewedBundledIdentity: .init(
+                    packageID: BundledRendererPackages.excalidrawPackageID,
+                    version: BundledRendererPackages.excalidrawVersion,
+                    registrationID: BundledRendererPackages.excalidrawRegistrationID))
+                .assemble()
+        }
+
+        self.providerServices = providerServices
+        self.extractionServices = extractionServices
+        self.queueController = queueController
+        self.transportOwner = transportOwner
+        self.rendererOwner = rendererOwner
+
+        profileOwner = AppProcessProfileOwner(factories: ProcessPluginCatalogFactories(
+                makeAgentProvider: {
+                    let handle = try await AgentProviderRuntimeAssembly(
+                        readConfiguration: { AgentProvidersConfig.loadOrSeed(from: containerDirectory) },
+                        resolveCommand: { providers in
+                            let searchPath = await PathPreflight.loginShellPATH()
+                            return Dictionary(uniqueKeysWithValues: providers.compactMap { provider in
+                                AgentLauncher.resolveCommand(for: provider, searchPath: searchPath)
+                                    .map { (provider.id, $0) }
+                            })
+                        },
+                        readCredential: { providerID in
+                            KeychainACPCredentialStore().apiKey(forProvider: providerID.rawValue)
+                        },
+                        resolvePermissionPolicy: { operation in
+                            let key: String
+                            switch operation {
+                            case .chat: key = AgentLauncher.PermissionModeKey.chat
+                            case .ingest: key = AgentLauncher.PermissionModeKey.ingest
+                            case .lint: key = AgentLauncher.PermissionModeKey.lint
+                            }
+                            let raw = UserDefaults.standard.string(forKey: key) ?? ""
+                            return PermissionPolicy(rawValue: raw) ?? .bypass
+                        })
+                        .assemble()
+                    await providerServices.install(handle.services)
+                    return ProcessRuntimeLease(service: providerServices) {
+                        try await handle.dispose()
+                    }
+                },
+                makeExtraction: {
+                    let owner = ExtractionCompositionOwner(services: extractionServices) {
+                        try await ExtractionRuntimeAssembly(
+                            readConfiguration: { ExtractionConfig.load(from: containerDirectory) },
+                            readCredential: { extractionCredentialStore.secret($0) },
+                            resolveACP: { configuration in
+                                ACPExtractionClient.resolveProvider(
+                                    containerDirectory: containerDirectory,
+                                    acpProviderId: configuration.acpProviderId,
+                                    acpCredentialStore: acpCredentialStore)
+                            },
+                            httpFetcher: URLSessionRequestFetcher(),
+                            makeLocalExtractor: {
+                                await MainActor.run { LocalPdf2MarkdownExtractor() }
+                            })
+                            .assemble()
+                    }
+                    await owner.start()
+                    await owner.awaitSettled()
+                    if let failure = await owner.failureDescription() {
+                        throw AppProcessCompositionError.runtimeUnavailable("extraction: \(failure)")
+                    }
+                    return ProcessRuntimeLease(service: extractionServices) {
+                        await owner.shutdown()
+                    }
+                },
+                makeQueue: {
+                    await MainActor.run { queueController.start() }
+                    await queueController.awaitSettled()
+                    if let failure = await MainActor.run(body: { queueController.startupError }) {
+                        throw AppProcessCompositionError.runtimeUnavailable("queue: \(failure)")
+                    }
+                    return ProcessRuntimeLease(service: queueController.client) {
+                        _ = await queueController.dispose()
+                    }
+                },
+                makeTransport: {
+                    await transportOwner.start()
+                    return ProcessRuntimeLease(service: transportOwner.services) {
+                        await transportOwner.shutdown()
+                    }
+                },
+                makeRenderer: {
+                    await rendererOwner.start()
+                    await rendererOwner.awaitSettled()
+                    if let failure = await rendererOwner.failureDescription() {
+                        throw AppProcessCompositionError.runtimeUnavailable("renderer: \(failure)")
+                    }
+                    return ProcessRuntimeLease(service: rendererOwner.services) {
+                        await rendererOwner.shutdown()
+                    }
+                }))
+    }
+}
+
+enum AppProcessCompositionError: Error {
+    case runtimeUnavailable(String)
 }
 #endif

--- a/Sources/WikiFS/Renderer/RendererRuntimeFactory.swift
+++ b/Sources/WikiFS/Renderer/RendererRuntimeFactory.swift
@@ -4,13 +4,13 @@ import Foundation
 import WikiFSCore
 import WikiFSTypes
 
-enum RendererRuntimeAssemblyError: Error, Equatable, Sendable {
+enum RendererRuntimeFactoryError: Error, Equatable, Sendable {
     case missingService(ServiceDescriptor)
     case activationFailed(component: String, failure: CordisFailure)
     case assemblyAndCleanupFailed(assembly: CordisFailure, cleanup: CordisFailure)
 }
 
-struct RendererRuntimeAssembly: Sendable {
+struct RendererRuntimeFactory: Sendable {
     enum Component: String, CaseIterable, Sendable {
         case packageStoreLayout
         case machineIndexStore
@@ -73,12 +73,12 @@ struct RendererRuntimeAssembly: Sendable {
             }
             for component in Component.allCases {
                 guard let handle = handles[component] else {
-                    throw RendererRuntimeAssemblyError.activationFailed(
+                    throw RendererRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: CordisFailure("component was not registered"))
                 }
                 if case .failed(_, let failure) = try await handle.awaitSettled() {
-                    throw RendererRuntimeAssemblyError.activationFailed(
+                    throw RendererRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: failure)
                 }
@@ -90,7 +90,7 @@ struct RendererRuntimeAssembly: Sendable {
             let assemblyFailure = CordisFailure(error)
             do { try await context.dispose() }
             catch {
-                throw RendererRuntimeAssemblyError.assemblyAndCleanupFailed(
+                throw RendererRuntimeFactoryError.assemblyAndCleanupFailed(
                     assembly: assemblyFailure,
                     cleanup: CordisFailure(error))
             }
@@ -103,7 +103,7 @@ struct RendererRuntimeAssembly: Sendable {
         from context: CordisContext
     ) async throws -> Value {
         guard let value = try await context.find(key) else {
-            throw RendererRuntimeAssemblyError.missingService(
+            throw RendererRuntimeFactoryError.missingService(
                 ServiceDependency(key).descriptor)
         }
         return value

--- a/Sources/WikiFS/Sources/SourcesContainerView.swift
+++ b/Sources/WikiFS/Sources/SourcesContainerView.swift
@@ -12,7 +12,7 @@ struct SourcesContainerView: View {
     @Bindable var store: WikiStoreModel
     let fileProvider: FileProviderFacade
     /// The per-active-wiki session (store + launchers + descriptor).
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     @Environment(QueueActivityTracker.self) private var tracker
     let launcher: AgentLauncher
     let queueEngine: any QueueEngineClient

--- a/Sources/WikiFS/Sources/SourcesListView.swift
+++ b/Sources/WikiFS/Sources/SourcesListView.swift
@@ -16,7 +16,7 @@ import WikiFSCore
 struct SourcesListView: NSViewControllerRepresentable {
     let store: WikiStoreModel
     let fileProvider: FileProviderFacade
-    let session: WikiSession
+    let session: any WikiSessionProtocol
     let launcher: AgentLauncher
     let ingestingSourceIDs: Set<SourceID>
     let extractingSourceIDs: Set<SourceID>

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     @Environment(QueueActivityTracker.self) private var tracker
     @Bindable var store: WikiStoreModel
     /// The per-active-wiki session (store + launchers + gate + descriptor).
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     /// App-scoped registry: wiki list + active id + create/select/delete.
     @Bindable var registry: WikiRegistryClient
     let fileProvider: FileProviderFacade
@@ -61,7 +61,7 @@ struct ContentView: View {
 
     init(
         store: WikiStoreModel,
-        session: WikiSession,
+        session: any WikiSessionProtocol,
         registry: WikiRegistryClient,
         fileProvider: FileProviderFacade,
         agentLauncher: AgentLauncher,

--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -486,7 +486,7 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     /// falling back to ANY live session — a status-item menu is reachable
     /// while no wiki window is key, and a silent `return` there reads as a
     /// dead menu item.
-    private var targetSession: WikiSession? {
+    private var targetSession: (any WikiSessionProtocol)? {
         sessionManager?.frontmostSession ?? sessionManager?.allSessions.first
     }
 

--- a/Sources/WikiFS/Window/RootScene.swift
+++ b/Sources/WikiFS/Window/RootScene.swift
@@ -36,7 +36,7 @@ struct RootScene: View {
     let fileProvider: FileProviderFacade
     let installedRendererHost: InstalledRendererHost
 
-    @State private var session: WikiSession?
+    @State private var session: (any WikiSessionProtocol)?
     @State private var isSceneActive = false
     @Environment(\.scenePhase) private var scenePhase
 
@@ -190,7 +190,7 @@ struct RootScene: View {
     /// Extracted from `body` to avoid type-checker timeouts (the `.alert`
     /// modifier has complex `Binding` + two trailing closures).
     @ViewBuilder
-    private func sessionView(_ session: WikiSession) -> some View {
+    private func sessionView(_ session: any WikiSessionProtocol) -> some View {
         RootView(
             session: session,
             registry: registry,
@@ -247,9 +247,9 @@ struct RootScene: View {
             // `session(for:)` throws when the on-disk store can't be opened
             // (issue #881). SessionManager records the error so the error
             // branch above renders; `session` stays nil.
-            let resolved: WikiSession
+            let resolved: any WikiSessionProtocol
             do {
-                resolved = try sessionManager.session(for: wikiID, descriptor: descriptor)
+                resolved = try await sessionManager.readySession(for: wikiID, descriptor: descriptor)
             } catch {
                 return
             }

--- a/Sources/WikiFS/Window/RootView.swift
+++ b/Sources/WikiFS/Window/RootView.swift
@@ -19,7 +19,7 @@ struct RootView: View {
     /// The per-active-wiki session (store + launchers + gate). Non-optional —
     /// `RootScene` guarantees the session is resolved before instantiating
     /// `RootView`. The empty/loading state is handled by `RootScene`.
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     /// App-scoped registry: wiki list + active id + create/select/delete.
     @Bindable var registry: WikiRegistryClient
     let fileProvider: FileProviderFacade

--- a/Sources/WikiFS/Window/SidebarView.swift
+++ b/Sources/WikiFS/Window/SidebarView.swift
@@ -13,7 +13,7 @@ struct SidebarView: View {
     /// App-scoped registry — backs the switcher header at the top of the list.
     @Bindable var registry: WikiRegistryClient
     /// The per-active-wiki session (store + launchers + descriptor).
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     /// Used to open an ingested file in its default app via its user-visible URL.
     let fileProvider: FileProviderFacade
     /// Required to launch the LLM lint from the sidebar context menu.

--- a/Sources/WikiFS/Window/WikiChangeBridge.swift
+++ b/Sources/WikiFS/Window/WikiChangeBridge.swift
@@ -33,7 +33,7 @@ final class WikiChangeBridge {
     /// returns all matching sessions so `flush(wikiID:)` can poke each one's
     /// bus. The app sets this to `{ wikiID in sessionManager.allSessions.filter
     /// { $0.wikiID == wikiID } }`.
-    var sessionLookup: @MainActor @Sendable (WikiID) -> [WikiSession] = { _ in [] }
+    var sessionLookup: @MainActor @Sendable (WikiID) -> [any WikiSessionProtocol] = { _ in [] }
     private var coalescer: ChangeCoalescer?
 
     /// The wiki ids we currently observe, so `refreshObservations()` is

--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -11,7 +11,7 @@ struct WikiDetailView: View {
     @Bindable var store: WikiStoreModel
     @Bindable var launcher: AgentLauncher       // ingest/lint launcher (chat is daemon-hosted after Phase C4)
     /// The per-active-wiki session (store + descriptor).
-    var session: WikiSession
+    var session: any WikiSessionProtocol
     let fileProvider: FileProviderFacade
     let extractionCoordinator: ExtractionCoordinator
     @Environment(QueueActivityTracker.self) private var tracker
@@ -31,7 +31,7 @@ struct WikiDetailView: View {
     init(
         store: WikiStoreModel,
         launcher: AgentLauncher,
-        session: WikiSession,
+        session: any WikiSessionProtocol,
         fileProvider: FileProviderFacade,
         extractionCoordinator: ExtractionCoordinator,
         queueEngine: any QueueEngineClient,

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -22,6 +22,8 @@ struct WikiFSApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     private let launchLocationWarning: LaunchLocationWarning?
     private let containerDirectory: URL
+    /// Boots the parallel Cordis process profile while legacy owners remain active.
+    @State private var processProfileOwner: AppProcessProfileOwner
     @State private var registry: WikiRegistryClient
     /// Multi-window: owns the `[wikiID: WikiSession]` cache. Each window's
     /// `RootScene` calls `sessionManager.session(for:descriptor:)` to resolve
@@ -344,6 +346,14 @@ struct WikiFSApp: App {
                 .assemble()
         }
         rendererCompositionOwner = rendererOwner
+        let processProfileOwner = AppProcessProfileOwner(
+            agentProvider: providerServices,
+            extraction: extractionServices,
+            queue: queueEngine,
+            transport: transportOwner.services,
+            renderer: AppProcessRendererService())
+        _processProfileOwner = State(initialValue: processProfileOwner)
+        processProfileOwner.start()
         let rendererHost = InstalledRendererHost(services: rendererOwner.services)
         _installedRendererHost = State(initialValue: rendererHost)
         Task { @MainActor in
@@ -576,13 +586,15 @@ struct WikiFSApp: App {
             localQueueRuntimeController,
             sessionManager,
             extractionCompositionOwner,
-            rendererCompositionOwner
+            rendererCompositionOwner,
+            processProfileOwner
         ] in
             await daemonTransportCoordinator.shutdown()
             _ = await localQueueRuntimeController.dispose()
             await sessionManager.shutdownSearchRuntimes()
             await extractionCompositionOwner.shutdown()
             await rendererCompositionOwner.shutdown()
+            await processProfileOwner.shutdown()
         }
         appDelegate.unregisterDaemon = {
             // The daemon is a bundled XPC service — the system manages its

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -313,6 +313,28 @@ struct WikiFSApp: App {
         _activityTracker = State(initialValue: activityTracker)
 
         let searchRuntimeRegistry = SearchRuntimeRegistry()
+        let processProfileOwner = AppProcessProfileOwner(
+            agentProvider: providerServices,
+            extraction: extractionServices,
+            queue: queueEngine,
+            transport: transportOwner.services,
+            renderer: AppProcessRendererService())
+        _processProfileOwner = State(initialValue: processProfileOwner)
+        processProfileOwner.start()
+        let appCatalog = {
+            do {
+                return try AppPluginCatalog.build(factories: AppPluginCatalogFactories(
+                    base: BasePluginCatalogFactories(
+                        agentProviderServices: providerServices,
+                        makePDFExtractor: { await MainActor.run { LocalPdf2MarkdownExtractor() } }),
+                    makeRendererServices: { AppProcessRendererService() },
+                    makeDefuddleExtractor: { await MainActor.run { LocalDefuddleExtractor() } },
+                    makeDaemonTransport: { transportOwner.services },
+                    makeURLFetcher: { URLSessionRequestFetcher() }))
+            } catch {
+                preconditionFailure("App profile catalog construction failed: \(error)")
+            }
+        }()
         let sm = SessionManager(
             containerDirectory: directory,
             extractionCoordinator: coordinator,
@@ -326,6 +348,32 @@ struct WikiFSApp: App {
             podcastBackendResolver: { ExtractionConfig.load(from: directory).podcastBackend },
             interactiveUsageRecorder: { [weak activityTracker] usage in
                 activityTracker?.recordInteractiveUsage(usage)
+            },
+            asyncSessionLoader: { [weak processProfileOwner, weak activityTracker] wikiID, descriptor in
+                guard let processProfileOwner else {
+                    throw SessionLoadingError.processProfileUnavailable("app process profile owner was released")
+                }
+                await processProfileOwner.awaitSettled()
+                guard let processProfile = processProfileOwner.profile,
+                      let processServices = processProfileOwner.services else {
+                    throw SessionLoadingError.processProfileUnavailable("app process profile is not ready: \(processProfileOwner.readiness)")
+                }
+                return try await ProfileWikiSession.boot(
+                    wikiID: wikiID,
+                    descriptor: descriptor,
+                    containerDirectory: directory,
+                    catalog: appCatalog,
+                    processProfile: processProfile,
+                    processServices: processServices,
+                    extractionProvider: extractionProvider,
+                    searchRuntimeRegistry: searchRuntimeRegistry,
+                    pdf2mdScriptPathResolver: { PdfExtractionService.resolveScript()?.path },
+                    htmlMarkdownExtractorFactory: { LocalDefuddleExtractor() },
+                    htmlBackendResolver: { ExtractionConfig.load(from: directory).htmlBackend },
+                    podcastBackendResolver: { ExtractionConfig.load(from: directory).podcastBackend },
+                    interactiveUsageRecorder: { usage in
+                        activityTracker?.recordInteractiveUsage(usage)
+                    })
             }
         )
         _sessionManager = State(initialValue: sm)
@@ -346,14 +394,6 @@ struct WikiFSApp: App {
                 .assemble()
         }
         rendererCompositionOwner = rendererOwner
-        let processProfileOwner = AppProcessProfileOwner(
-            agentProvider: providerServices,
-            extraction: extractionServices,
-            queue: queueEngine,
-            transport: transportOwner.services,
-            renderer: AppProcessRendererService())
-        _processProfileOwner = State(initialValue: processProfileOwner)
-        processProfileOwner.start()
         let rendererHost = InstalledRendererHost(services: rendererOwner.services)
         _installedRendererHost = State(initialValue: rendererHost)
         Task { @MainActor in

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -22,7 +22,7 @@ struct WikiFSApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     private let launchLocationWarning: LaunchLocationWarning?
     private let containerDirectory: URL
-    /// Boots the parallel Cordis process profile while legacy owners remain active.
+    /// Owns the app process profile and its five process-scoped runtime leases.
     @State private var processProfileOwner: AppProcessProfileOwner
     @State private var registry: WikiRegistryClient
     /// Multi-window: owns the `[wikiID: WikiSession]` cache. Each window's
@@ -31,10 +31,8 @@ struct WikiFSApp: App {
     @State private var sessionManager: SessionManager
     @State private var fileProvider = FileProviderFacade()
     @State private var installedRendererHost: InstalledRendererHost
-    /// Retains the app-scoped runtime's Cordis context for the lifetime of the
-    /// app. Agent launchers receive its services facade, not this handle.
-    @State private var agentProviderRuntimeHandle: AgentProviderRuntimeHandle?
-    @State private var agentProviderServices = MutableAgentProviderServices()
+    /// Stable provider facade resolved by the app process profile.
+    @State private var agentProviderServices: MutableAgentProviderServices
     /// One app-scoped launcher for Settings-only use ("Test Connection" + backend
     /// config). Has its own `GenerationGate`, independent of any session's gate
     /// — a Settings connection test doesn't block an active wiki's ingest.
@@ -43,12 +41,6 @@ struct WikiFSApp: App {
     /// Serve). Threaded like `settingsLauncher` — one instance, owned by the app,
     /// shared as a ref into each `WikiSession` (it carries no per-wiki state).
     @State private var extractionCoordinator: ExtractionCoordinator
-    /// Owns the app-scoped extraction context and its asynchronous startup.
-    private let extractionCompositionOwner: ExtractionCompositionOwner
-    /// Owns the app-scoped renderer context, bootstrap, publication, and shutdown.
-    private let rendererCompositionOwner: RendererCompositionOwner
-    /// Owns daemon transport assembly, admission, retry work, and disposal.
-    private let daemonTransportCompositionOwner: DaemonTransportCompositionOwner
     /// Keeps concrete XPC connections outside the Engine Cordis assembly.
     private let daemonTransportBridge: DaemonTransportAppBridge
     /// Adapts typed transport events into queue/chat ownership policy.
@@ -169,32 +161,6 @@ struct WikiFSApp: App {
         // plans/keychain-sharing.md.
         KeychainSecretStore.migrateLegacyItemsToDataProtection()
         containerDirectory = directory
-        let providerServices = MutableAgentProviderServices()
-        _agentProviderServices = State(initialValue: providerServices)
-        let providerAssembly = AgentProviderRuntimeAssembly(
-            readConfiguration: {
-                AgentProvidersConfig.loadOrSeed(from: directory)
-            },
-            resolveCommand: { providers in
-                let loginShellPath = await PathPreflight.loginShellPATH()
-                return Dictionary(uniqueKeysWithValues: providers.compactMap { provider in
-                    AgentLauncher.resolveCommand(for: provider, searchPath: loginShellPath)
-                        .map { (provider.id, $0) }
-                })
-            },
-            readCredential: { providerID in
-                KeychainACPCredentialStore().apiKey(forProvider: providerID.rawValue)
-            },
-            resolvePermissionPolicy: { operation in
-                let key: String
-                switch operation {
-                case .chat: key = AgentLauncher.PermissionModeKey.chat
-                case .ingest: key = AgentLauncher.PermissionModeKey.ingest
-                case .lint: key = AgentLauncher.PermissionModeKey.lint
-                }
-                let raw = UserDefaults.standard.string(forKey: key) ?? ""
-                return PermissionPolicy(rawValue: raw) ?? .bypass
-            })
         // Populate wikis BEFORE handing the registry to @State so SwiftUI's
         // first render sees a non-empty list.  activateNow: false means
         // activeWikiID stays nil for that render — NSTableView's initial
@@ -205,83 +171,45 @@ struct WikiFSApp: App {
         let r = WikiRegistryClient(containerDirectory: directory)
         r.bootstrap(activateNow: false)
         _registry = State(initialValue: r)
-        let extractionCredentialStore = KeychainExtractionCredentialStore()
-        let acpCredentialStore = KeychainACPCredentialStore()
-        let extractionOwner = ExtractionCompositionOwner {
-            try await ExtractionRuntimeAssembly(
-                readConfiguration: { ExtractionConfig.load(from: directory) },
-                readCredential: { extractionCredentialStore.secret($0) },
-                resolveACP: { configuration in
-                    ACPExtractionClient.resolveProvider(
-                        containerDirectory: directory,
-                        acpProviderId: configuration.acpProviderId,
-                        acpCredentialStore: acpCredentialStore)
-                },
-                httpFetcher: URLSessionRequestFetcher(),
-                makeLocalExtractor: {
-                    await MainActor.run { LocalPdf2MarkdownExtractor() }
-                })
-                .assemble()
-        }
-        extractionCompositionOwner = extractionOwner
-        let extractionServices = extractionOwner.services
-        let coordinator = ExtractionCoordinator(services: extractionServices)
-        _extractionCoordinator = State(initialValue: coordinator)
-        Task { await extractionOwner.start() }
-
-        // Queue engine: start with a LOCAL engine as the initial fallback
-        // (#878 BLOCKER 2). The daemon connection is deferred to a Task so
-        // init() never blocks the main thread. If the daemon is available, the
-        // `QueueEngineHotSwap` router swaps to the XPC proxy; if the daemon
-        // dies later, the `DaemonHealthMonitor` swaps back to a local engine.
-        //
-        // The daemon (when healthy) owns the ENTIRE queue. The app is a pure
-        // XPC client — all 13 QueueEngineClient methods proxy to the daemon.
-        // One DB, one engine, one owner.
+        // The synchronous app initializer creates stable facades only. The
+        // asynchronous process profile is the sole owner of all five concrete
+        // runtimes and publishes those same facades through its plugin leases.
         let sessionBox = SessionLookupBox()
         sessionLookupBox = sessionBox
+        let fileProviderBox = FileProviderBox()
+        let transportBridge = DaemonTransportAppBridge()
+        daemonTransportBridge = transportBridge
+        let processComposition = AppProcessComposition(
+            containerDirectory: directory,
+            transportBridge: transportBridge,
+            extractionProvider: { services in
+                AppQueueExtractionProvider(
+                    extractionServices: services,
+                    sessionBox: sessionBox)
+            },
+            makeIngestionProvider: { store, providerServices in
+                AppQueueIngestionProvider(
+                    sessionBox: sessionBox,
+                    fileProviderBox: fileProviderBox,
+                    wikictlDirectory: HelpersLocation.wikictlDirectory,
+                    queueStore: store,
+                    providerServices: providerServices)
+            })
+        let providerServices = processComposition.providerServices
+        _agentProviderServices = State(initialValue: providerServices)
+        let extractionServices = processComposition.extractionServices
+        let coordinator = ExtractionCoordinator(services: extractionServices)
+        _extractionCoordinator = State(initialValue: coordinator)
         let extractionProvider = AppQueueExtractionProvider(
             extractionServices: extractionServices,
             sessionBox: sessionBox)
-        let fileProviderBox = FileProviderBox()
+        let runtimeController = processComposition.queueController
+        let transportOwner = processComposition.transportOwner
+        let rendererOwner = processComposition.rendererOwner
+        let processProfileOwner = processComposition.profileOwner
+        _processProfileOwner = State(initialValue: processProfileOwner)
+        processProfileOwner.start()
 
-        let activityTracker = QueueActivityTracker()
-
-        let queueDBURL = DebugLog.trying(
-            "resolve queue database URL",
-            operation: { try DatabaseLocation.queueDatabaseURL() })
-            ?? directory.appendingPathComponent("queue.sqlite", isDirectory: false)
-        let runtimeController = LocalQueueRuntimeController {
-            try await QueueRuntimeAssembly(
-                databaseURL: queueDBURL,
-                extractionProvider: extractionProvider,
-                makeIngestionProvider: { store in
-                    await MainActor.run {
-                        AppQueueIngestionProvider(
-                            sessionBox: sessionBox,
-                            fileProviderBox: fileProviderBox,
-                            wikictlDirectory: HelpersLocation.wikictlDirectory,
-                            queueStore: store,
-                            providerServices: providerServices)
-                    }
-                })
-                .assemble()
-        }
-        runtimeController.start()
-
-        let transportBridge = DaemonTransportAppBridge()
-        daemonTransportBridge = transportBridge
-        let transportOwner = DaemonTransportCompositionOwner {
-            try await DaemonTransportRuntimeAssembly(
-                connectionFactory: transportBridge.connectionFactory,
-                configuration: .init(
-                    retryInterval: .seconds(30),
-                    healthCheckInterval: .seconds(30),
-                    healthCheckTimeout: 5,
-                    acceptanceDeadline: .seconds(30)))
-                .assemble()
-        }
-        daemonTransportCompositionOwner = transportOwner
         let transportMonitor = DaemonHealthMonitor(services: transportOwner.services)
         _healthMonitor = State(initialValue: transportMonitor)
         daemonTransportCoordinator = DaemonTransportAppCoordinator(
@@ -292,19 +220,12 @@ struct WikiFSApp: App {
             observeEvent: { [weak transportMonitor] event in
                 transportMonitor?.consume(event)
             })
-        Task { await transportOwner.start() }
 
-        // All consumers retain one stable facade. The controller owns its local
-        // runtime handle and changes only the facade's admitted inner client.
-        let router = runtimeController.client
-        activityTracker.attach(engine: router)
-        Task { await activityTracker.rehydrate(from: router) }
-        // #871 self-heal: poll the snapshot so a finished item still clears
-        // the spinner if the event stream breaks. The router forwards to the
-        // current engine, so this works across swaps.
-        activityTracker.startSnapshotWatchdog(engine: router)
-
-        let queueEngine = router
+        let activityTracker = QueueActivityTracker()
+        let queueEngine = runtimeController.client
+        activityTracker.attach(engine: queueEngine)
+        Task { await activityTracker.rehydrate(from: queueEngine) }
+        activityTracker.startSnapshotWatchdog(engine: queueEngine)
 
         _queueEngine = State(initialValue: queueEngine)
         _localQueueRuntimeController = State(initialValue: runtimeController)
@@ -313,21 +234,13 @@ struct WikiFSApp: App {
         _activityTracker = State(initialValue: activityTracker)
 
         let searchRuntimeRegistry = SearchRuntimeRegistry()
-        let processProfileOwner = AppProcessProfileOwner(
-            agentProvider: providerServices,
-            extraction: extractionServices,
-            queue: queueEngine,
-            transport: transportOwner.services,
-            renderer: AppProcessRendererService())
-        _processProfileOwner = State(initialValue: processProfileOwner)
-        processProfileOwner.start()
         let appCatalog = {
             do {
                 return try AppPluginCatalog.build(factories: AppPluginCatalogFactories(
                     base: BasePluginCatalogFactories(
                         agentProviderServices: providerServices,
                         makePDFExtractor: { await MainActor.run { LocalPdf2MarkdownExtractor() } }),
-                    makeRendererServices: { AppProcessRendererService() },
+                    makeRendererServices: { rendererOwner.services },
                     makeDefuddleExtractor: { await MainActor.run { LocalDefuddleExtractor() } },
                     makeDaemonTransport: { transportOwner.services },
                     makeURLFetcher: { URLSessionRequestFetcher() }))
@@ -377,28 +290,10 @@ struct WikiFSApp: App {
             }
         )
         _sessionManager = State(initialValue: sm)
-        let rendererLayout: RendererPackageStoreLayout
-        do {
-            rendererLayout = try RendererPackageStoreLayout(appGroupContainerRoot: directory)
-        } catch {
-            preconditionFailure("Resolved app-group renderer layout was invalid: \(error)")
-        }
-        let rendererOwner = RendererCompositionOwner {
-            try await RendererRuntimeAssembly(
-                layout: rendererLayout,
-                bundledPackageSource: { BundledRendererPackages.excalidrawResourceURL() },
-                reviewedBundledIdentity: .init(
-                    packageID: BundledRendererPackages.excalidrawPackageID,
-                    version: BundledRendererPackages.excalidrawVersion,
-                    registrationID: BundledRendererPackages.excalidrawRegistrationID))
-                .assemble()
-        }
-        rendererCompositionOwner = rendererOwner
         let rendererHost = InstalledRendererHost(services: rendererOwner.services)
         _installedRendererHost = State(initialValue: rendererHost)
         Task { @MainActor in
-            await rendererOwner.start()
-            await rendererOwner.awaitSettled()
+            await processProfileOwner.awaitSettled()
             if let publication = await rendererOwner.consumeStartupPreparation() {
                 publication.publish(to: rendererHost)
             }
@@ -462,16 +357,6 @@ struct WikiFSApp: App {
         // so the `.task` copies that remain are harmless redundant fallbacks,
         // not the primary path. Add new one-time launch work HERE, not to an
         // individual window's `.task`.
-        Task { @MainActor [self, providerAssembly, providerServices] in
-            do {
-                let handle = try await providerAssembly.assemble()
-                await providerServices.install(handle.services)
-                agentProviderRuntimeHandle = handle
-            } catch {
-                DebugLog.agent("WikiFSApp: agent provider runtime assembly failed. Agent features are unavailable: \(error)")
-            }
-        }
-
         appDelegate.bootstrap = { [self] in
             startStatusItem()
             applyAppKitAppearance()
@@ -623,17 +508,11 @@ struct WikiFSApp: App {
         }
         appDelegate.shutdownForTermination = { [
             daemonTransportCoordinator,
-            localQueueRuntimeController,
             sessionManager,
-            extractionCompositionOwner,
-            rendererCompositionOwner,
             processProfileOwner
         ] in
             await daemonTransportCoordinator.shutdown()
-            _ = await localQueueRuntimeController.dispose()
             await sessionManager.shutdownSearchRuntimes()
-            await extractionCompositionOwner.shutdown()
-            await rendererCompositionOwner.shutdown()
             await processProfileOwner.shutdown()
         }
         appDelegate.unregisterDaemon = {
@@ -656,9 +535,6 @@ struct WikiFSApp: App {
 
     @MainActor
     private func connectToDaemon() {
-        // Start composition if needed. The owner ignores duplicate calls and
-        // retries assembly while startup remains in progress.
-        Task { await daemonTransportCompositionOwner.start() }
         daemonTransportCoordinator.installChatReplacement { coordinator in
             replaceChatDaemonCoordinator(coordinator)
         }

--- a/Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift
+++ b/Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift
@@ -2,13 +2,13 @@ import Cordis
 import Foundation
 import WikiFSCore
 
-public enum AgentProviderRuntimeAssemblyError: Error, Equatable, Sendable {
+public enum AgentProviderRuntimeFactoryError: Error, Equatable, Sendable {
     case missingService(ServiceDescriptor)
     case activationFailed(component: String, failure: CordisFailure)
     case assemblyAndCleanupFailed(assembly: CordisFailure, cleanup: CordisFailure)
 }
 
-public struct AgentProviderRuntimeAssembly: Sendable {
+public struct AgentProviderRuntimeFactory: Sendable {
     internal enum Component: String, CaseIterable, Sendable {
         case configurationReader
         case commandResolver
@@ -75,12 +75,12 @@ public struct AgentProviderRuntimeAssembly: Sendable {
             }
             for component in Component.allCases {
                 guard let handle = handles[component] else {
-                    throw AgentProviderRuntimeAssemblyError.activationFailed(
+                    throw AgentProviderRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: CordisFailure("component was not registered"))
                 }
                 if case .failed(_, let failure) = try await handle.awaitSettled() {
-                    throw AgentProviderRuntimeAssemblyError.activationFailed(component: component.rawValue, failure: failure)
+                    throw AgentProviderRuntimeFactoryError.activationFailed(component: component.rawValue, failure: failure)
                 }
             }
             return AgentProviderRuntimeHandle(
@@ -91,7 +91,7 @@ public struct AgentProviderRuntimeAssembly: Sendable {
             do {
                 try await context.dispose()
             } catch let cleanupError {
-                throw AgentProviderRuntimeAssemblyError.assemblyAndCleanupFailed(
+                throw AgentProviderRuntimeFactoryError.assemblyAndCleanupFailed(
                     assembly: assemblyFailure,
                     cleanup: CordisFailure(cleanupError))
             }
@@ -101,7 +101,7 @@ public struct AgentProviderRuntimeAssembly: Sendable {
 
     private func require<Value: Sendable>(_ key: ServiceKey<Value>, from context: CordisContext) async throws -> Value {
         guard let value = try await context.find(key) else {
-            throw AgentProviderRuntimeAssemblyError.missingService(ServiceDependency(key).descriptor)
+            throw AgentProviderRuntimeFactoryError.missingService(ServiceDependency(key).descriptor)
         }
         return value
     }

--- a/Sources/WikiFSEngine/DaemonTransportRuntimeFactory.swift
+++ b/Sources/WikiFSEngine/DaemonTransportRuntimeFactory.swift
@@ -2,13 +2,13 @@
 import Cordis
 import Foundation
 
-public enum DaemonTransportRuntimeAssemblyError: Error, Equatable, Sendable {
+public enum DaemonTransportRuntimeFactoryError: Error, Equatable, Sendable {
     case missingService(ServiceDescriptor)
     case activationFailed(component: String, failure: CordisFailure)
     case assemblyAndCleanupFailed(assembly: CordisFailure, cleanup: CordisFailure)
 }
 
-public struct DaemonTransportRuntimeAssembly: Sendable {
+public struct DaemonTransportRuntimeFactory: Sendable {
     public enum ServiceLabels {
         public static let connectionFactory = "daemon-transport.connection-factory"
         public static let configuration = "daemon-transport.configuration"
@@ -60,12 +60,12 @@ public struct DaemonTransportRuntimeAssembly: Sendable {
             }
             for component in Component.allCases {
                 guard let handle = handles[component] else {
-                    throw DaemonTransportRuntimeAssemblyError.activationFailed(
+                    throw DaemonTransportRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: CordisFailure("component was not registered"))
                 }
                 if case .failed(_, let failure) = try await handle.awaitSettled() {
-                    throw DaemonTransportRuntimeAssemblyError.activationFailed(
+                    throw DaemonTransportRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: failure)
                 }
@@ -78,7 +78,7 @@ public struct DaemonTransportRuntimeAssembly: Sendable {
             do {
                 try await context.dispose()
             } catch let cleanupError {
-                throw DaemonTransportRuntimeAssemblyError.assemblyAndCleanupFailed(
+                throw DaemonTransportRuntimeFactoryError.assemblyAndCleanupFailed(
                     assembly: assemblyFailure,
                     cleanup: CordisFailure(cleanupError))
             }
@@ -91,7 +91,7 @@ public struct DaemonTransportRuntimeAssembly: Sendable {
         from context: CordisContext
     ) async throws -> Value {
         guard let value = try await context.find(key) else {
-            throw DaemonTransportRuntimeAssemblyError.missingService(
+            throw DaemonTransportRuntimeFactoryError.missingService(
                 ServiceDependency(key).descriptor)
         }
         return value

--- a/Sources/WikiFSEngine/ExtractionPlugins.swift
+++ b/Sources/WikiFSEngine/ExtractionPlugins.swift
@@ -62,7 +62,7 @@ public enum Pdf2mdExtractionPlugin {
     public static let key = ExtractionBackendKey(kind: .pdf, backendID: ExtractionBackend.localPdf2md.rawValue)
 
     public static func definition(
-        makeExtractor: @escaping ExtractionRuntimeAssembly.LocalExtractorFactory
+        makeExtractor: @escaping ExtractionPluginFactory.LocalExtractor
     ) -> PluginDefinition {
         adapterDefinition(id: id, label: "Local pdf2md extraction", key: key) {
             .pdf(ExtractionPreparation(
@@ -79,8 +79,8 @@ public enum ACPExtractionPlugin {
 
     public static func definition(
         configuration: ExtractionConfig,
-        resolve: @escaping ExtractionRuntimeAssembly.ACPResolver,
-        fallback: @escaping ExtractionRuntimeAssembly.LocalExtractorFactory
+        resolve: @escaping ExtractionPluginFactory.ACPResolver,
+        fallback: @escaping ExtractionPluginFactory.LocalExtractor
     ) -> PluginDefinition {
         adapterDefinition(id: id, label: "ACP extraction", key: key) {
             let extractor: any MarkdownExtractor
@@ -102,7 +102,7 @@ public enum AnthropicExtractionPlugin {
     public static let key = ExtractionBackendKey(kind: .pdf, backendID: ExtractionBackend.anthropic.rawValue)
 
     public static func definition(
-        readCredential: @escaping ExtractionRuntimeAssembly.CredentialReader,
+        readCredential: @escaping ExtractionPluginFactory.CredentialReader,
         fetcher: any HTTPRequestFetcher
     ) -> PluginDefinition {
         PluginDefinition(
@@ -130,7 +130,7 @@ public enum GeminiExtractionPlugin {
     public static let key = ExtractionBackendKey(kind: .pdf, backendID: ExtractionBackend.gemini.rawValue)
 
     public static func definition(
-        readCredential: @escaping ExtractionRuntimeAssembly.CredentialReader,
+        readCredential: @escaping ExtractionPluginFactory.CredentialReader,
         fetcher: any HTTPRequestFetcher
     ) -> PluginDefinition {
         PluginDefinition(
@@ -158,7 +158,7 @@ public enum DoclingExtractionPlugin {
     public static let key = ExtractionBackendKey(kind: .pdf, backendID: ExtractionBackend.doclingServe.rawValue)
 
     public static func definition(
-        readCredential: @escaping ExtractionRuntimeAssembly.CredentialReader,
+        readCredential: @escaping ExtractionPluginFactory.CredentialReader,
         fetcher: any HTTPRequestFetcher
     ) -> PluginDefinition {
         PluginDefinition(

--- a/Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift
+++ b/Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift
@@ -10,9 +10,6 @@ public enum ExtractionRuntimeAssemblyError: Error, Equatable, Sendable {
 }
 
 public struct ExtractionRuntimeAssembly: Sendable {
-    public typealias CredentialReader = @Sendable (ExtractionSecret) -> String?
-    public typealias ACPResolver = @Sendable (ExtractionConfig) -> (any MarkdownExtractor)?
-    public typealias LocalExtractorFactory = @Sendable () async -> any MarkdownExtractor
     public typealias BackendResolver = ExtractionRuntime.BackendResolver
 
     internal enum Component: String, CaseIterable, Sendable {
@@ -29,13 +26,13 @@ public struct ExtractionRuntimeAssembly: Sendable {
     private enum Keys {
         static let configurationReader = ServiceKey<ExtractionRuntime.ConfigurationReader>(
             label: "extraction.configuration-reader")
-        static let credentialReader = ServiceKey<CredentialReader>(
+        static let credentialReader = ServiceKey<ExtractionPluginFactory.CredentialReader>(
             label: "extraction.credential-reader")
-        static let acpResolver = ServiceKey<ACPResolver>(
+        static let acpResolver = ServiceKey<ExtractionPluginFactory.ACPResolver>(
             label: "extraction.acp-resolver")
         static let httpFetcher = ServiceKey<any HTTPRequestFetcher>(
             label: "extraction.http-fetcher")
-        static let localExtractorFactory = ServiceKey<LocalExtractorFactory>(
+        static let localExtractorFactory = ServiceKey<ExtractionPluginFactory.LocalExtractor>(
             label: "extraction.local-extractor-factory")
         static let backendResolver = ServiceKey<BackendResolver>(
             label: "extraction.backend-resolver")
@@ -46,17 +43,17 @@ public struct ExtractionRuntimeAssembly: Sendable {
     }
 
     public let readConfiguration: ExtractionRuntime.ConfigurationReader
-    public let readCredential: CredentialReader
-    public let resolveACP: ACPResolver
+    public let readCredential: ExtractionPluginFactory.CredentialReader
+    public let resolveACP: ExtractionPluginFactory.ACPResolver
     public let httpFetcher: any HTTPRequestFetcher
-    public let makeLocalExtractor: LocalExtractorFactory
+    public let makeLocalExtractor: ExtractionPluginFactory.LocalExtractor
 
     public init(
         readConfiguration: @escaping ExtractionRuntime.ConfigurationReader,
-        readCredential: @escaping CredentialReader,
-        resolveACP: @escaping ACPResolver,
+        readCredential: @escaping ExtractionPluginFactory.CredentialReader,
+        resolveACP: @escaping ExtractionPluginFactory.ACPResolver,
         httpFetcher: any HTTPRequestFetcher,
-        makeLocalExtractor: @escaping LocalExtractorFactory
+        makeLocalExtractor: @escaping ExtractionPluginFactory.LocalExtractor
     ) {
         self.readConfiguration = readConfiguration
         self.readCredential = readCredential

--- a/Sources/WikiFSEngine/ExtractionRuntimeFactory.swift
+++ b/Sources/WikiFSEngine/ExtractionRuntimeFactory.swift
@@ -3,13 +3,13 @@ import Cordis
 import Foundation
 import WikiFSCore
 
-public enum ExtractionRuntimeAssemblyError: Error, Equatable, Sendable {
+public enum ExtractionRuntimeFactoryError: Error, Equatable, Sendable {
     case missingService(ServiceDescriptor)
     case activationFailed(component: String, failure: CordisFailure)
     case assemblyAndCleanupFailed(assembly: CordisFailure, cleanup: CordisFailure)
 }
 
-public struct ExtractionRuntimeAssembly: Sendable {
+public struct ExtractionRuntimeFactory: Sendable {
     public typealias BackendResolver = ExtractionRuntime.BackendResolver
 
     internal enum Component: String, CaseIterable, Sendable {
@@ -77,12 +77,12 @@ public struct ExtractionRuntimeAssembly: Sendable {
             }
             for component in Component.allCases {
                 guard let handle = handles[component] else {
-                    throw ExtractionRuntimeAssemblyError.activationFailed(
+                    throw ExtractionRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: CordisFailure("component was not registered"))
                 }
                 if case .failed(_, let failure) = try await handle.awaitSettled() {
-                    throw ExtractionRuntimeAssemblyError.activationFailed(
+                    throw ExtractionRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: failure)
                 }
@@ -95,7 +95,7 @@ public struct ExtractionRuntimeAssembly: Sendable {
             do {
                 try await context.dispose()
             } catch let cleanupError {
-                throw ExtractionRuntimeAssemblyError.assemblyAndCleanupFailed(
+                throw ExtractionRuntimeFactoryError.assemblyAndCleanupFailed(
                     assembly: assemblyFailure,
                     cleanup: CordisFailure(cleanupError))
             }
@@ -108,7 +108,7 @@ public struct ExtractionRuntimeAssembly: Sendable {
         from context: CordisContext
     ) async throws -> Value {
         guard let value = try await context.find(key) else {
-            throw ExtractionRuntimeAssemblyError.missingService(
+            throw ExtractionRuntimeFactoryError.missingService(
                 ServiceDependency(key).descriptor)
         }
         return value

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -1,0 +1,129 @@
+#if os(macOS)
+import Cordis
+import WikiFSCore
+
+/// Assembly-independent factory signatures shared by extraction plugins and
+/// the legacy extraction assembly while it remains during the migration.
+public enum ExtractionPluginFactory {
+    public typealias CredentialReader = @Sendable (ExtractionSecret) -> String?
+    public typealias ACPResolver = @Sendable (ExtractionConfig) -> (any MarkdownExtractor)?
+    public typealias LocalExtractor = @Sendable () async -> any MarkdownExtractor
+}
+
+public struct BasePluginCatalogFactories: Sendable {
+    public let agentProviderServices: any AgentProviderServices
+    public let makePDFExtractor: ExtractionPluginFactory.LocalExtractor
+    public let configureEmbeddings: EmbeddingsSearchProvider.Configure
+    public let selectedEmbeddingIdentifier: EmbeddingsSearchProvider.SelectedIdentifier
+    public let embeddingsAvailable: EmbeddingsSearchProvider.Availability
+
+    public init(
+        agentProviderServices: any AgentProviderServices,
+        makePDFExtractor: @escaping ExtractionPluginFactory.LocalExtractor,
+        configureEmbeddings: @escaping EmbeddingsSearchProvider.Configure = { await EmbeddingService.configure() },
+        selectedEmbeddingIdentifier: @escaping EmbeddingsSearchProvider.SelectedIdentifier = { EmbeddingService.selectedEmbedderIdentifier() },
+        embeddingsAvailable: @escaping EmbeddingsSearchProvider.Availability = { EmbeddingService.isAvailable }
+    ) {
+        self.agentProviderServices = agentProviderServices
+        self.makePDFExtractor = makePDFExtractor
+        self.configureEmbeddings = configureEmbeddings
+        self.selectedEmbeddingIdentifier = selectedEmbeddingIdentifier
+        self.embeddingsAvailable = embeddingsAvailable
+    }
+}
+
+public struct AppPluginCatalogFactories: Sendable {
+    public let base: BasePluginCatalogFactories
+    public let makeRendererServices: RegisteredRendererProvider.Factory
+    public let makeDefuddleExtractor: @Sendable () async -> any HtmlMarkdownExtractor
+    public let makeDaemonTransport: RegisteredTransportProvider.Factory
+    public let makeURLFetcher: RegisteredIntegrationCapability.Factory
+    public let makeTantivyRuntime: SearchRuntimeFactory.Factory
+
+    public init(
+        base: BasePluginCatalogFactories,
+        makeRendererServices: @escaping RegisteredRendererProvider.Factory,
+        makeDefuddleExtractor: @escaping @Sendable () async -> any HtmlMarkdownExtractor,
+        makeDaemonTransport: @escaping RegisteredTransportProvider.Factory,
+        makeURLFetcher: @escaping RegisteredIntegrationCapability.Factory,
+        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+    ) {
+        self.base = base
+        self.makeRendererServices = makeRendererServices
+        self.makeDefuddleExtractor = makeDefuddleExtractor
+        self.makeDaemonTransport = makeDaemonTransport
+        self.makeURLFetcher = makeURLFetcher
+        self.makeTantivyRuntime = makeTantivyRuntime
+    }
+}
+
+public struct DaemonPluginCatalogFactories: Sendable {
+    public let base: BasePluginCatalogFactories
+
+    public init(base: BasePluginCatalogFactories) {
+        self.base = base
+    }
+}
+
+public enum AppPluginCatalog {
+    public static func build(
+        factories: AppPluginCatalogFactories,
+        additionalDefinitions: [PluginDefinition] = []
+    ) throws -> PluginCatalog {
+        var definitions = baseDefinitions(factories.base)
+        definitions.append(contentsOf: [
+            DefuddleExtractionPlugin.definition(makeExtractor: factories.makeDefuddleExtractor),
+            RendererServicesPlugin.definition(makeServices: factories.makeRendererServices),
+            DaemonTransportPlugin.definition(makeServices: factories.makeDaemonTransport),
+            URLFetchIntegrationPlugin.definition(makeFetcher: factories.makeURLFetcher),
+        ])
+        definitions.append(TantivySearchPlugin.definition(makeRuntime: factories.makeTantivyRuntime))
+        definitions.append(contentsOf: additionalDefinitions)
+        return try PluginCatalog(definitions)
+    }
+}
+
+public enum DaemonPluginCatalog {
+    public static func build(
+        factories: DaemonPluginCatalogFactories,
+        additionalDefinitions: [PluginDefinition] = []
+    ) throws -> PluginCatalog {
+        try PluginCatalog(baseDefinitions(factories.base) + additionalDefinitions)
+    }
+}
+
+public enum CLIPluginCatalog {
+    public static func build(
+        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+    ) throws -> PluginCatalog {
+        try PluginCatalog([
+            SearchPlugin.definition,
+            TantivySearchPlugin.definition(makeRuntime: makeTantivyRuntime),
+        ])
+    }
+}
+
+private func baseDefinitions(_ factories: BasePluginCatalogFactories) -> [PluginDefinition] {
+    [
+        StorePlugin.definition,
+        SessionsPlugin.definition,
+        ChatsPersistencePlugin.definition,
+        LlmRuntimePlugin.definition,
+        ACPModelAdapterPlugin.definition(services: factories.agentProviderServices),
+        ToolsPlugin.definition,
+        NoOpToolPlugin.definition,
+        SystemPromptPlugin.definition,
+        AgentLoopPlugin.definition,
+        ExtractionPlugin.definition,
+        Pdf2mdExtractionPlugin.definition(makeExtractor: factories.makePDFExtractor),
+        SearchPlugin.definition,
+        EmbeddingsSearchPlugin.definition(
+            configure: factories.configureEmbeddings,
+            selectedIdentifier: factories.selectedEmbeddingIdentifier,
+            isAvailable: factories.embeddingsAvailable),
+        RenderersPlugin.definition,
+        TransportPlugin.definition,
+        IntegrationsPlugin.definition,
+    ]
+}
+#endif

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -257,7 +257,7 @@ public struct AppServices: Sendable {
 /// inherited process services. It mirrors `WikiSession` until callers migrate.
 @MainActor
 @Observable
-public final class ProfileWikiSession {
+public final class ProfileWikiSession: WikiSessionProtocol {
     public let profile: BootedProfile
     @ObservationIgnored private let session: WikiSession
 

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -96,7 +96,7 @@ public struct AppPluginCatalogFactories: Sendable {
         makeDefuddleExtractor: @escaping @Sendable () async -> any HtmlMarkdownExtractor,
         makeDaemonTransport: @escaping RegisteredTransportProvider.Factory,
         makeURLFetcher: @escaping RegisteredIntegrationCapability.Factory,
-        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeCompositionFactory.runtimeFactory
     ) {
         self.base = base
         self.makeRendererServices = makeRendererServices
@@ -273,7 +273,7 @@ public actor DaemonProcessProfileOwner {
         let acpCredentialStore = KeychainACPCredentialStore()
         let processFactories = ProcessPluginCatalogFactories(
             makeAgentProvider: {
-                let handle = try await AgentProviderRuntimeAssembly(
+                let handle = try await AgentProviderRuntimeFactory(
                     readConfiguration: { AgentProvidersConfig.loadOrSeed(from: containerDirectory) },
                     resolveCommand: { providers in
                         let searchPath = await PathPreflight.loginShellPATH()
@@ -291,7 +291,7 @@ public actor DaemonProcessProfileOwner {
                 return ProcessRuntimeLease(service: providerServices) { try await handle.dispose() }
             },
             makeExtraction: {
-                let handle = try await ExtractionRuntimeAssembly(
+                let handle = try await ExtractionRuntimeFactory(
                     readConfiguration: { ExtractionConfig.load(from: containerDirectory) },
                     readCredential: { extractionCredentialStore.secret($0) },
                     resolveACP: { configuration in
@@ -654,7 +654,7 @@ public enum DaemonPluginCatalog {
 
 public enum CLIPluginCatalog {
     public static func build(
-        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+        makeTantivyRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeCompositionFactory.runtimeFactory
     ) throws -> PluginCatalog {
         try PluginCatalog([
             SearchPlugin.definition,

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -253,6 +253,144 @@ public struct AppServices: Sendable {
     }
 }
 
+/// Observable per-wiki application facade built from one child profile and its
+/// inherited process services. It mirrors `WikiSession` until callers migrate.
+@MainActor
+@Observable
+public final class ProfileWikiSession {
+    public let profile: BootedProfile
+    @ObservationIgnored private let session: WikiSession
+
+    public var wikiID: WikiID { session.wikiID }
+    public var descriptor: WikiDescriptor { session.descriptor }
+    public var store: WikiStoreModel { session.store }
+    public var agentLauncher: AgentLauncher { session.agentLauncher }
+    public var extractionCoordinator: ExtractionCoordinator { session.extractionCoordinator }
+    public var queueEngine: any QueueEngineClient { session.queueEngine }
+    public var extractionProvider: any QueueExtractionProvider { session.extractionProvider }
+    public var generationGate: GenerationGate { session.generationGate }
+    public var searchServices: any SearchServices { session.searchServices }
+
+    public var pendingBlobVacuum: BlobVacuumReport? {
+        get { session.pendingBlobVacuum }
+        set { session.pendingBlobVacuum = newValue }
+    }
+
+    public var pendingVacuumAll: VacuumReport? {
+        get { session.pendingVacuumAll }
+        set { session.pendingVacuumAll = newValue }
+    }
+
+    public var pendingWikiLink: (url: URL, openInNewTab: Bool)? {
+        get { session.pendingWikiLink }
+        set { session.pendingWikiLink = newValue }
+    }
+
+    public static func boot(
+        wikiID: WikiID,
+        descriptor: WikiDescriptor,
+        containerDirectory: URL,
+        catalog: PluginCatalog,
+        processProfile: BootedProfile,
+        processServices: AppProcessServices,
+        extractionProvider: any QueueExtractionProvider,
+        searchRuntimeRegistry: SearchRuntimeRegistry = SearchRuntimeRegistry(),
+        pdf2mdScriptPathResolver: @escaping () -> String? = { nil },
+        htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)? = { nil },
+        htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend? = { nil },
+        podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend? = { nil },
+        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
+    ) async throws -> ProfileWikiSession {
+        let databaseURL = containerDirectory.appendingPathComponent("\(wikiID.rawValue).sqlite", isDirectory: false)
+        let profile = try await CordisBoot.boot(.init(
+            catalog: catalog,
+            layers: [PatchFile(entries: ProductionProfileEntries.app(databaseURL: databaseURL, wikiID: wikiID))],
+            parent: processProfile.context))
+        do {
+            let childServices = try await AppServices.resolve(from: profile)
+            return try ProfileWikiSession(
+                wikiID: wikiID,
+                descriptor: descriptor,
+                containerDirectory: containerDirectory,
+                childServices: childServices,
+                processServices: processServices,
+                extractionProvider: extractionProvider,
+                searchRuntimeRegistry: searchRuntimeRegistry,
+                pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
+                htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
+                htmlBackendResolver: htmlBackendResolver,
+                podcastBackendResolver: podcastBackendResolver,
+                interactiveUsageRecorder: interactiveUsageRecorder)
+        } catch {
+            do {
+                try await profile.shutdown()
+            } catch {
+                DebugLog.store("Per-wiki profile cleanup after facade failure failed: \(error)")
+            }
+            throw error
+        }
+    }
+
+    private init(
+        wikiID: WikiID,
+        descriptor: WikiDescriptor,
+        containerDirectory: URL,
+        childServices: AppServices,
+        processServices: AppProcessServices,
+        extractionProvider: any QueueExtractionProvider,
+        searchRuntimeRegistry: SearchRuntimeRegistry,
+        pdf2mdScriptPathResolver: @escaping () -> String?,
+        htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)?,
+        htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend?,
+        podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend?,
+        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void)
+    ) throws {
+        profile = childServices.profile
+        let coordinator = ExtractionCoordinator(services: processServices.extraction)
+        let resolvedStore = childServices.store
+        session = try WikiSession(
+            wikiID: wikiID,
+            descriptor: descriptor,
+            containerDirectory: containerDirectory,
+            extractionCoordinator: coordinator,
+            queueEngine: processServices.queue,
+            extractionProvider: extractionProvider,
+            searchRuntimeRegistry: searchRuntimeRegistry,
+            providerServices: processServices.agentProvider,
+            makeStore: { _ in resolvedStore },
+            pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
+            htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
+            htmlBackendResolver: htmlBackendResolver,
+            podcastBackendResolver: podcastBackendResolver,
+            interactiveUsageRecorder: interactiveUsageRecorder)
+        session.store.readPool = childServices.readPool
+    }
+
+    public func updateDescriptor(_ descriptor: WikiDescriptor) { session.updateDescriptor(descriptor) }
+    public func previewBlobVacuum() { session.previewBlobVacuum() }
+    public func applyBlobVacuum() { session.applyBlobVacuum() }
+    public func previewVacuumAll() { session.previewVacuumAll() }
+    public func applyVacuumAll() { session.applyVacuumAll() }
+    public func upgradeSearchIndex() async { await session.upgradeSearchIndex() }
+
+    public func searchTantivy(
+        query: String,
+        kinds: [TantivyDocumentKind] = [],
+        limit: Int = 20
+    ) async -> [TantivyShadowSearchResult]? {
+        await session.searchTantivy(query: query, kinds: kinds, limit: limit)
+    }
+
+    public func shutdown() async {
+        await session.shutdownSearchRuntime()
+        do {
+            try await profile.shutdown()
+        } catch {
+            DebugLog.store("Per-wiki profile shutdown failed: \(error)")
+        }
+    }
+}
+
 /// Concrete per-wiki profile rows. The store row is a complete replacement for
 /// the machine-independent placeholder shipped in `wikifs-base`.
 public enum ProductionProfileEntries {

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -230,6 +230,207 @@ public final class AppProcessProfileOwner {
     }
 }
 
+/// Typed process services resolved once from the daemon process profile.
+public struct DaemonProcessServices: Sendable {
+    public let agentProvider: any AgentProviderServices
+    public let extraction: any ExtractionServices
+
+    public static func resolve(from profile: BootedProfile) async throws -> DaemonProcessServices {
+        DaemonProcessServices(
+            agentProvider: try await profile.context.require(ProcessServiceKeys.agentProvider),
+            extraction: try await profile.context.require(ProcessServiceKeys.extraction))
+    }
+}
+
+/// Owns daemon process-profile startup and its retained per-wiki child profiles.
+/// The actor owns every startup task and makes repeated shutdown requests safe.
+public actor DaemonProcessProfileOwner {
+    public typealias Boot = @Sendable () async throws -> BootedProfile
+    public typealias BootWiki = @Sendable (WikiID, BootedProfile) async throws -> BootedProfile
+
+    private let boot: Boot
+    private let bootWiki: BootWiki
+    private var startupTask: Task<(BootedProfile, DaemonProcessServices), Error>?
+    private var process: (BootedProfile, DaemonProcessServices)?
+    private var wikiTasks: [WikiID: Task<AppServices, Error>] = [:]
+    private var wikiServices: [WikiID: AppServices] = [:]
+    private var shutdownStarted = false
+
+    public init(boot: @escaping Boot, bootWiki: @escaping BootWiki) {
+        self.boot = boot
+        self.bootWiki = bootWiki
+    }
+
+    public static func production(
+        containerDirectory: URL,
+        makeLocalExtractor: @escaping ExtractionPluginFactory.LocalExtractor
+    ) throws -> DaemonProcessProfileOwner {
+        let providerServices = MutableAgentProviderServices()
+        let extractionCredentialStore = KeychainExtractionCredentialStore()
+        let acpCredentialStore = KeychainACPCredentialStore()
+        let processFactories = ProcessPluginCatalogFactories(
+            makeAgentProvider: {
+                let handle = try await AgentProviderRuntimeAssembly(
+                    readConfiguration: { AgentProvidersConfig.loadOrSeed(from: containerDirectory) },
+                    resolveCommand: { providers in
+                        let searchPath = await PathPreflight.loginShellPATH()
+                        return Dictionary(uniqueKeysWithValues: providers.compactMap { provider in
+                            AgentLauncher.resolveCommand(for: provider, searchPath: searchPath)
+                                .map { (provider.id, $0) }
+                        })
+                    },
+                    readCredential: { providerID in
+                        KeychainACPCredentialStore().apiKey(forProvider: providerID.rawValue)
+                    },
+                    resolvePermissionPolicy: { _ in .bypass })
+                    .assemble()
+                await providerServices.install(handle.services)
+                return ProcessRuntimeLease(service: providerServices) { try await handle.dispose() }
+            },
+            makeExtraction: {
+                let handle = try await ExtractionRuntimeAssembly(
+                    readConfiguration: { ExtractionConfig.load(from: containerDirectory) },
+                    readCredential: { extractionCredentialStore.secret($0) },
+                    resolveACP: { configuration in
+                        ACPExtractionClient.resolveProvider(
+                            containerDirectory: containerDirectory,
+                            acpProviderId: configuration.acpProviderId,
+                            acpCredentialStore: acpCredentialStore)
+                    },
+                    httpFetcher: URLSessionRequestFetcher(),
+                    makeLocalExtractor: makeLocalExtractor)
+                    .assemble()
+                return ProcessRuntimeLease(service: handle.services) { try await handle.dispose() }
+            })
+        let processCatalog = try ProcessPluginCatalog.build(factories: processFactories)
+        let childCatalog = try DaemonPluginCatalog.build(factories: .init(base: .init(
+            agentProviderServices: providerServices,
+            makePDFExtractor: makeLocalExtractor)))
+        return DaemonProcessProfileOwner(
+            boot: {
+                try await CordisBoot.boot(.init(
+                    catalog: processCatalog,
+                    layers: [PatchFile(entries: ProductionProfileEntries.daemonProcess())]))
+            },
+            bootWiki: { wikiID, processProfile in
+                let databaseURL = containerDirectory.appendingPathComponent("\(wikiID.rawValue).sqlite", isDirectory: false)
+                return try await CordisBoot.boot(.init(
+                    catalog: childCatalog,
+                    layers: [PatchFile(entries: ProductionProfileEntries.daemon(databaseURL: databaseURL, wikiID: wikiID))],
+                    parent: processProfile.context))
+            })
+    }
+
+    @discardableResult
+    public func start() async throws -> DaemonProcessServices {
+        if shutdownStarted { throw CancellationError() }
+        if let process { return process.1 }
+        if startupTask == nil {
+            let boot = self.boot
+            startupTask = Task {
+                let profile = try await boot()
+                do {
+                    return (profile, try await DaemonProcessServices.resolve(from: profile))
+                } catch {
+                    do { try await profile.shutdown() } catch {
+                        DebugLog.store("Daemon process profile cleanup after startup failure failed: \(error)")
+                    }
+                    throw error
+                }
+            }
+        }
+        guard let startupTask else { throw CancellationError() }
+        let resolved = try await startupTask.value
+        guard !shutdownStarted else {
+            try await resolved.0.shutdown()
+            throw CancellationError()
+        }
+        process = resolved
+        return resolved.1
+    }
+
+    public func services() async throws -> DaemonProcessServices {
+        try await start()
+    }
+
+    public func wiki(wikiID: WikiID) async throws -> AppServices {
+        if let services = wikiServices[wikiID] { return services }
+        let processProfile: BootedProfile
+        if let process { processProfile = process.0 } else {
+            _ = try await start()
+            guard let process else { throw CancellationError() }
+            processProfile = process.0
+        }
+        if wikiTasks[wikiID] == nil {
+            let bootWiki = self.bootWiki
+            wikiTasks[wikiID] = Task {
+                let profile = try await bootWiki(wikiID, processProfile)
+                do { return try await AppServices.resolve(from: profile) }
+                catch {
+                    do { try await profile.shutdown() } catch {
+                        DebugLog.store("Daemon wiki profile cleanup after startup failure failed: \(error)")
+                    }
+                    throw error
+                }
+            }
+        }
+        guard let wikiTask = wikiTasks[wikiID] else { throw CancellationError() }
+        let services = try await wikiTask.value
+        guard !shutdownStarted else {
+            try await services.shutdown()
+            throw CancellationError()
+        }
+        wikiServices[wikiID] = services
+        return services
+    }
+
+    public func removeWiki(_ wikiID: WikiID) async {
+        wikiTasks[wikiID]?.cancel()
+        if let task = wikiTasks.removeValue(forKey: wikiID) {
+            do { _ = try await task.value } catch is CancellationError {
+                // Removal intentionally cancels an unfinished child-profile boot.
+            } catch {
+                DebugLog.store("Daemon wiki profile task ended during removal: \(error)")
+            }
+        }
+        if let services = wikiServices.removeValue(forKey: wikiID) {
+            do { try await services.shutdown() } catch {
+                DebugLog.store("Daemon wiki profile shutdown failed: \(error)")
+            }
+        }
+    }
+
+    public func shutdown() async {
+        guard !shutdownStarted else { return }
+        shutdownStarted = true
+        startupTask?.cancel()
+        for task in wikiTasks.values { task.cancel() }
+        for services in wikiServices.values {
+            do { try await services.shutdown() } catch {
+                DebugLog.store("Daemon wiki profile shutdown failed: \(error)")
+            }
+        }
+        wikiServices.removeAll()
+        wikiTasks.removeAll()
+        if let profile = process?.0 {
+            do { try await profile.shutdown() } catch {
+                DebugLog.store("Daemon process profile shutdown failed: \(error)")
+            }
+        } else if let startupTask {
+            do {
+                let result = try await startupTask.value
+                try await result.0.shutdown()
+            } catch is CancellationError {
+                // Shutdown intentionally cancels unfinished process-profile boot.
+            } catch {
+                DebugLog.store("Daemon process profile shutdown failed: \(error)")
+            }
+        }
+        process = nil
+        startupTask = nil
+    }
+}
+
 /// Typed services resolved once from a booted profile. Consumers receive this
 /// facade rather than a Cordis context or a legacy runtime assembly.
 public struct AppServices: Sendable {

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -457,39 +457,10 @@ public struct AppServices: Sendable {
     }
 }
 
-/// Observable per-wiki application facade built from one child profile and its
-/// inherited process services. It mirrors `WikiSession` until callers migrate.
+/// Boots the observable per-wiki application facade from one child profile and
+/// its inherited process services.
 @MainActor
-@Observable
-public final class ProfileWikiSession: WikiSessionProtocol {
-    public let profile: BootedProfile
-    @ObservationIgnored private let session: WikiSession
-
-    public var wikiID: WikiID { session.wikiID }
-    public var descriptor: WikiDescriptor { session.descriptor }
-    public var store: WikiStoreModel { session.store }
-    public var agentLauncher: AgentLauncher { session.agentLauncher }
-    public var extractionCoordinator: ExtractionCoordinator { session.extractionCoordinator }
-    public var queueEngine: any QueueEngineClient { session.queueEngine }
-    public var extractionProvider: any QueueExtractionProvider { session.extractionProvider }
-    public var generationGate: GenerationGate { session.generationGate }
-    public var searchServices: any SearchServices { session.searchServices }
-
-    public var pendingBlobVacuum: BlobVacuumReport? {
-        get { session.pendingBlobVacuum }
-        set { session.pendingBlobVacuum = newValue }
-    }
-
-    public var pendingVacuumAll: VacuumReport? {
-        get { session.pendingVacuumAll }
-        set { session.pendingVacuumAll = newValue }
-    }
-
-    public var pendingWikiLink: (url: URL, openInNewTab: Bool)? {
-        get { session.pendingWikiLink }
-        set { session.pendingWikiLink = newValue }
-    }
-
+extension ProfileWikiSession {
     public static func boot(
         wikiID: WikiID,
         descriptor: WikiDescriptor,
@@ -512,19 +483,24 @@ public final class ProfileWikiSession: WikiSessionProtocol {
             parent: processProfile.context))
         do {
             let childServices = try await AppServices.resolve(from: profile)
+            let resolvedStore = childServices.store
             return try ProfileWikiSession(
                 wikiID: wikiID,
                 descriptor: descriptor,
                 containerDirectory: containerDirectory,
-                childServices: childServices,
-                processServices: processServices,
+                extractionCoordinator: ExtractionCoordinator(services: processServices.extraction),
+                queueEngine: processServices.queue,
                 extractionProvider: extractionProvider,
                 searchRuntimeRegistry: searchRuntimeRegistry,
+                providerServices: processServices.agentProvider,
+                makeStore: { _ in resolvedStore },
                 pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
                 htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
                 htmlBackendResolver: htmlBackendResolver,
                 podcastBackendResolver: podcastBackendResolver,
-                interactiveUsageRecorder: interactiveUsageRecorder)
+                interactiveUsageRecorder: interactiveUsageRecorder,
+                profile: childServices.profile,
+                readPool: childServices.readPool)
         } catch {
             do {
                 try await profile.shutdown()
@@ -535,64 +511,6 @@ public final class ProfileWikiSession: WikiSessionProtocol {
         }
     }
 
-    private init(
-        wikiID: WikiID,
-        descriptor: WikiDescriptor,
-        containerDirectory: URL,
-        childServices: AppServices,
-        processServices: AppProcessServices,
-        extractionProvider: any QueueExtractionProvider,
-        searchRuntimeRegistry: SearchRuntimeRegistry,
-        pdf2mdScriptPathResolver: @escaping () -> String?,
-        htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)?,
-        htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend?,
-        podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend?,
-        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void)
-    ) throws {
-        profile = childServices.profile
-        let coordinator = ExtractionCoordinator(services: processServices.extraction)
-        let resolvedStore = childServices.store
-        session = try WikiSession(
-            wikiID: wikiID,
-            descriptor: descriptor,
-            containerDirectory: containerDirectory,
-            extractionCoordinator: coordinator,
-            queueEngine: processServices.queue,
-            extractionProvider: extractionProvider,
-            searchRuntimeRegistry: searchRuntimeRegistry,
-            providerServices: processServices.agentProvider,
-            makeStore: { _ in resolvedStore },
-            pdf2mdScriptPathResolver: pdf2mdScriptPathResolver,
-            htmlMarkdownExtractorFactory: htmlMarkdownExtractorFactory,
-            htmlBackendResolver: htmlBackendResolver,
-            podcastBackendResolver: podcastBackendResolver,
-            interactiveUsageRecorder: interactiveUsageRecorder)
-        session.store.readPool = childServices.readPool
-    }
-
-    public func updateDescriptor(_ descriptor: WikiDescriptor) { session.updateDescriptor(descriptor) }
-    public func previewBlobVacuum() { session.previewBlobVacuum() }
-    public func applyBlobVacuum() { session.applyBlobVacuum() }
-    public func previewVacuumAll() { session.previewVacuumAll() }
-    public func applyVacuumAll() { session.applyVacuumAll() }
-    public func upgradeSearchIndex() async { await session.upgradeSearchIndex() }
-
-    public func searchTantivy(
-        query: String,
-        kinds: [TantivyDocumentKind] = [],
-        limit: Int = 20
-    ) async -> [TantivyShadowSearchResult]? {
-        await session.searchTantivy(query: query, kinds: kinds, limit: limit)
-    }
-
-    public func shutdown() async {
-        await session.shutdownSearchRuntime()
-        do {
-            try await profile.shutdown()
-        } catch {
-            DebugLog.store("Per-wiki profile shutdown failed: \(error)")
-        }
-    }
 }
 
 /// Concrete per-wiki profile rows. The store row is a complete replacement for

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -2,6 +2,7 @@
 import Cordis
 import CordisLoader
 import Foundation
+import Observation
 import WikiFSCore
 
 /// Assembly-independent factory signatures shared by extraction plugins and
@@ -111,6 +112,121 @@ public struct DaemonPluginCatalogFactories: Sendable {
 
     public init(base: BasePluginCatalogFactories) {
         self.base = base
+    }
+}
+
+/// Typed process services resolved once from the app process profile.
+public struct AppProcessRendererService: Sendable {
+    public init() {}
+}
+
+public struct AppProcessServices: Sendable {
+    public let agentProvider: any AgentProviderServices
+    public let extraction: any ExtractionServices
+    public let queue: any QueueEngineClient
+    public let transport: DaemonTransportServices
+    public let renderer: any Sendable
+
+    public static func resolve(from profile: BootedProfile) async throws -> AppProcessServices {
+        AppProcessServices(
+            agentProvider: try await profile.context.require(ProcessServiceKeys.agentProvider),
+            extraction: try await profile.context.require(ProcessServiceKeys.extraction),
+            queue: try await profile.context.require(ProcessServiceKeys.queue),
+            transport: try await profile.context.require(ProcessServiceKeys.transport),
+            renderer: try await profile.context.require(ProcessServiceKeys.renderer))
+    }
+}
+
+/// Owns asynchronous app process-profile startup and shutdown.
+@MainActor
+@Observable
+public final class AppProcessProfileOwner {
+    public enum Readiness: Equatable, Sendable {
+        case idle
+        case loading
+        case ready
+        case failed(String)
+    }
+
+    public typealias Boot = @Sendable () async throws -> BootedProfile
+
+    public private(set) var readiness: Readiness = .idle
+    public private(set) var profile: BootedProfile?
+    public private(set) var services: AppProcessServices?
+    @ObservationIgnored private let boot: Boot
+    @ObservationIgnored private var startupTask: Task<Void, Never>?
+    @ObservationIgnored private var shutdownStarted = false
+
+    public init(boot: @escaping Boot) {
+        self.boot = boot
+    }
+
+    public convenience init(
+        agentProvider: any AgentProviderServices,
+        extraction: any ExtractionServices,
+        queue: any QueueEngineClient,
+        transport: DaemonTransportServices,
+        renderer: any Sendable
+    ) {
+        self.init {
+            let factories = ProcessPluginCatalogFactories(
+                makeAgentProvider: { ProcessRuntimeLease(service: agentProvider) {} },
+                makeExtraction: { ProcessRuntimeLease(service: extraction) {} },
+                makeQueue: { ProcessRuntimeLease(service: queue) {} },
+                makeTransport: { ProcessRuntimeLease(service: transport) {} },
+                makeRenderer: { ProcessRuntimeLease(service: renderer) {} })
+            return try await CordisBoot.boot(.init(
+                catalog: try ProcessPluginCatalog.build(factories: factories),
+                layers: [PatchFile(entries: ProductionProfileEntries.appProcess())]))
+        }
+    }
+
+    public func start() {
+        guard readiness == .idle, !shutdownStarted else { return }
+        readiness = .loading
+        startupTask = Task { [weak self, boot] in
+            do {
+                let profile = try await boot()
+                let services = try await AppProcessServices.resolve(from: profile)
+                guard let self, !Task.isCancelled, !self.shutdownStarted else {
+                    try await profile.shutdown()
+                    return
+                }
+                self.profile = profile
+                self.services = services
+                self.readiness = .ready
+            } catch is CancellationError {
+                // Shutdown owns cancellation and leaves the owner unavailable.
+            } catch {
+                guard let self, !self.shutdownStarted else { return }
+                self.readiness = .failed(String(describing: error))
+            }
+        }
+    }
+
+    public func awaitSettled() async {
+        await startupTask?.value
+    }
+
+    public func shutdown() async {
+        guard !shutdownStarted else {
+            await startupTask?.value
+            return
+        }
+        shutdownStarted = true
+        let task = startupTask
+        task?.cancel()
+        await task?.value
+        startupTask = nil
+        services = nil
+        if let profile {
+            do {
+                try await profile.shutdown()
+            } catch {
+                DebugLog.store("App process profile shutdown failed: \(error)")
+            }
+        }
+        profile = nil
     }
 }
 

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -12,6 +12,53 @@ public enum ExtractionPluginFactory {
     public typealias LocalExtractor = @Sendable () async -> any MarkdownExtractor
 }
 
+/// One process-scoped service and the cleanup that owns its concrete runtime.
+public struct ProcessRuntimeLease<Service: Sendable>: Sendable {
+    public let service: Service
+    public let dispose: @Sendable () async throws -> Void
+
+    public init(service: Service, dispose: @escaping @Sendable () async throws -> Void) {
+        self.service = service
+        self.dispose = dispose
+    }
+}
+
+public enum ProcessServiceKeys {
+    public static let agentProvider = ServiceKey<any AgentProviderServices>(label: "process.agent-provider")
+    public static let extraction = ServiceKey<any ExtractionServices>(label: "process.extraction")
+    public static let queue = ServiceKey<any QueueEngineClient>(label: "process.queue")
+    public static let transport = ServiceKey<DaemonTransportServices>(label: "process.transport")
+    public static let renderer = ServiceKey<any Sendable>(label: "process.renderer")
+}
+
+public struct ProcessPluginCatalogFactories: Sendable {
+    public typealias AgentProviderFactory = @Sendable () async throws -> ProcessRuntimeLease<any AgentProviderServices>
+    public typealias ExtractionFactory = @Sendable () async throws -> ProcessRuntimeLease<any ExtractionServices>
+    public typealias QueueFactory = @Sendable () async throws -> ProcessRuntimeLease<any QueueEngineClient>
+    public typealias TransportFactory = @Sendable () async throws -> ProcessRuntimeLease<DaemonTransportServices>
+    public typealias RendererFactory = @Sendable () async throws -> ProcessRuntimeLease<any Sendable>
+
+    public let makeAgentProvider: AgentProviderFactory
+    public let makeExtraction: ExtractionFactory
+    public let makeQueue: QueueFactory?
+    public let makeTransport: TransportFactory?
+    public let makeRenderer: RendererFactory?
+
+    public init(
+        makeAgentProvider: @escaping AgentProviderFactory,
+        makeExtraction: @escaping ExtractionFactory,
+        makeQueue: QueueFactory? = nil,
+        makeTransport: TransportFactory? = nil,
+        makeRenderer: RendererFactory? = nil
+    ) {
+        self.makeAgentProvider = makeAgentProvider
+        self.makeExtraction = makeExtraction
+        self.makeQueue = makeQueue
+        self.makeTransport = makeTransport
+        self.makeRenderer = makeRenderer
+    }
+}
+
 public struct BasePluginCatalogFactories: Sendable {
     public let agentProviderServices: any AgentProviderServices
     public let makePDFExtractor: ExtractionPluginFactory.LocalExtractor
@@ -93,6 +140,23 @@ public struct AppServices: Sendable {
 /// Concrete per-wiki profile rows. The store row is a complete replacement for
 /// the machine-independent placeholder shipped in `wikifs-base`.
 public enum ProductionProfileEntries {
+    public static func appProcess() -> [Entry] {
+        [
+            Entry(id: EntryID("process-agent-provider"), plugin: ProcessRuntimePlugins.agentProviderID),
+            Entry(id: EntryID("process-extraction"), plugin: ProcessRuntimePlugins.extractionID),
+            Entry(id: EntryID("process-queue"), plugin: ProcessRuntimePlugins.queueID),
+            Entry(id: EntryID("process-transport"), plugin: ProcessRuntimePlugins.transportID),
+            Entry(id: EntryID("process-renderer"), plugin: ProcessRuntimePlugins.rendererID),
+        ]
+    }
+
+    public static func daemonProcess() -> [Entry] {
+        [
+            Entry(id: EntryID("process-agent-provider"), plugin: ProcessRuntimePlugins.agentProviderID),
+            Entry(id: EntryID("process-extraction"), plugin: ProcessRuntimePlugins.extractionID),
+        ]
+    }
+
     public static func app(databaseURL: URL, wikiID: WikiID) -> [Entry] {
         base(databaseURL: databaseURL, wikiID: wikiID) + [
             Entry(id: EntryID("renderer-services"), plugin: RendererServicesPlugin.id),
@@ -135,6 +199,53 @@ public enum ProductionProfileEntries {
             Entry(id: EntryID("transport"), plugin: TransportPlugin.id),
             Entry(id: EntryID("integrations"), plugin: IntegrationsPlugin.id),
         ]
+    }
+}
+
+public enum ProcessRuntimePlugins {
+    public static let agentProviderID = PluginID("process.agent-provider")
+    public static let extractionID = PluginID("process.extraction")
+    public static let queueID = PluginID("process.queue")
+    public static let transportID = PluginID("process.transport")
+    public static let rendererID = PluginID("process.renderer")
+
+    public static func definitions(_ factories: ProcessPluginCatalogFactories) -> [PluginDefinition] {
+        var definitions = [
+            definition(id: agentProviderID, key: ProcessServiceKeys.agentProvider, factory: factories.makeAgentProvider),
+            definition(id: extractionID, key: ProcessServiceKeys.extraction, factory: factories.makeExtraction),
+        ]
+        if let factory = factories.makeQueue {
+            definitions.append(definition(id: queueID, key: ProcessServiceKeys.queue, factory: factory))
+        }
+        if let factory = factories.makeTransport {
+            definitions.append(definition(id: transportID, key: ProcessServiceKeys.transport, factory: factory))
+        }
+        if let factory = factories.makeRenderer {
+            definitions.append(definition(id: rendererID, key: ProcessServiceKeys.renderer, factory: factory))
+        }
+        return definitions
+    }
+
+    private static func definition<Service: Sendable>(
+        id: PluginID,
+        key: ServiceKey<Service>,
+        factory: @escaping @Sendable () async throws -> ProcessRuntimeLease<Service>
+    ) -> PluginDefinition {
+        PluginDefinition(id: id, provisions: [ServiceDependency(key)]) {
+            try ComponentDefinition(
+                label: id.rawValue,
+                provisions: [ServiceDependency(key)]) { activation in
+                    let lease = try await factory()
+                    _ = try await activation.supply(key, value: lease.service)
+                    _ = try await activation.effect { _ in try await lease.dispose() }
+                }
+        }
+    }
+}
+
+public enum ProcessPluginCatalog {
+    public static func build(factories: ProcessPluginCatalogFactories) throws -> PluginCatalog {
+        try PluginCatalog(ProcessRuntimePlugins.definitions(factories))
     }
 }
 

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -1,5 +1,7 @@
 #if os(macOS)
 import Cordis
+import CordisLoader
+import Foundation
 import WikiFSCore
 
 /// Assembly-independent factory signatures shared by extraction plugins and
@@ -62,6 +64,77 @@ public struct DaemonPluginCatalogFactories: Sendable {
 
     public init(base: BasePluginCatalogFactories) {
         self.base = base
+    }
+}
+
+/// Typed services resolved once from a booted profile. Consumers receive this
+/// facade rather than a Cordis context or a legacy runtime assembly.
+public struct AppServices: Sendable {
+    public let profile: BootedProfile
+    public let store: any WikiStore
+    public let readPool: WikiReadPool
+    public let extractionBackends: ExtractionBackendRegistry
+    public let searchProviders: SearchProviderRegistry
+
+    public static func resolve(from profile: BootedProfile) async throws -> AppServices {
+        AppServices(
+            profile: profile,
+            store: try await profile.context.require(StoreServiceKeys.store),
+            readPool: try await profile.context.require(StoreServiceKeys.readPool),
+            extractionBackends: try await profile.context.require(ExtractionServiceKeys.backends),
+            searchProviders: try await profile.context.require(SearchServiceKeys.providers))
+    }
+
+    public func shutdown() async throws {
+        try await profile.shutdown()
+    }
+}
+
+/// Concrete per-wiki profile rows. The store row is a complete replacement for
+/// the machine-independent placeholder shipped in `wikifs-base`.
+public enum ProductionProfileEntries {
+    public static func app(databaseURL: URL, wikiID: WikiID) -> [Entry] {
+        base(databaseURL: databaseURL, wikiID: wikiID) + [
+            Entry(id: EntryID("renderer-services"), plugin: RendererServicesPlugin.id),
+            Entry(id: EntryID("daemon-transport"), plugin: DaemonTransportPlugin.id),
+            Entry(id: EntryID("url-fetch"), plugin: URLFetchIntegrationPlugin.id),
+            Entry(id: EntryID("tantivy"), plugin: TantivySearchPlugin.id),
+            Entry(id: EntryID("embeddings"), plugin: EmbeddingsSearchPlugin.id),
+        ]
+    }
+
+    public static func daemon(databaseURL: URL, wikiID: WikiID) -> [Entry] {
+        base(databaseURL: databaseURL, wikiID: wikiID) + [
+            Entry(id: EntryID("embeddings"), plugin: EmbeddingsSearchPlugin.id),
+        ]
+    }
+
+    public static func cli() -> [Entry] {
+        [
+            Entry(id: EntryID("search"), plugin: SearchPlugin.id),
+            Entry(id: EntryID("tantivy"), plugin: TantivySearchPlugin.id),
+        ]
+    }
+
+    private static func base(databaseURL: URL, wikiID: WikiID) -> [Entry] {
+        [
+            Entry(id: EntryID("store"), plugin: StorePlugin.id, config: [
+                "databasePath": .string(databaseURL.path),
+                "wikiID": .string(wikiID.rawValue),
+            ]),
+            Entry(id: EntryID("sessions"), plugin: SessionsPlugin.id),
+            Entry(id: EntryID("chats-persistence"), plugin: ChatsPersistencePlugin.id),
+            Entry(id: EntryID("llm-runtime"), plugin: LlmRuntimePlugin.id),
+            Entry(id: EntryID("tools"), plugin: ToolsPlugin.id),
+            Entry(id: EntryID("system-prompt"), plugin: SystemPromptPlugin.id),
+            Entry(id: EntryID("agent-loop"), plugin: AgentLoopPlugin.id),
+            Entry(id: EntryID("extraction"), plugin: ExtractionPlugin.id),
+            Entry(id: EntryID("pdf2md"), plugin: Pdf2mdExtractionPlugin.id),
+            Entry(id: EntryID("search"), plugin: SearchPlugin.id),
+            Entry(id: EntryID("renderers"), plugin: RenderersPlugin.id),
+            Entry(id: EntryID("transport"), plugin: TransportPlugin.id),
+            Entry(id: EntryID("integrations"), plugin: IntegrationsPlugin.id),
+        ]
     }
 }
 

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -161,6 +161,14 @@ public final class AppProcessProfileOwner {
         self.boot = boot
     }
 
+    public convenience init(factories: ProcessPluginCatalogFactories) {
+        self.init {
+            try await CordisBoot.boot(.init(
+                catalog: try ProcessPluginCatalog.build(factories: factories),
+                layers: [PatchFile(entries: ProductionProfileEntries.appProcess())]))
+        }
+    }
+
     public convenience init(
         agentProvider: any AgentProviderServices,
         extraction: any ExtractionServices,
@@ -168,17 +176,12 @@ public final class AppProcessProfileOwner {
         transport: DaemonTransportServices,
         renderer: any Sendable
     ) {
-        self.init {
-            let factories = ProcessPluginCatalogFactories(
-                makeAgentProvider: { ProcessRuntimeLease(service: agentProvider) {} },
-                makeExtraction: { ProcessRuntimeLease(service: extraction) {} },
-                makeQueue: { ProcessRuntimeLease(service: queue) {} },
-                makeTransport: { ProcessRuntimeLease(service: transport) {} },
-                makeRenderer: { ProcessRuntimeLease(service: renderer) {} })
-            return try await CordisBoot.boot(.init(
-                catalog: try ProcessPluginCatalog.build(factories: factories),
-                layers: [PatchFile(entries: ProductionProfileEntries.appProcess())]))
-        }
+        self.init(factories: ProcessPluginCatalogFactories(
+            makeAgentProvider: { ProcessRuntimeLease(service: agentProvider) {} },
+            makeExtraction: { ProcessRuntimeLease(service: extraction) {} },
+            makeQueue: { ProcessRuntimeLease(service: queue) {} },
+            makeTransport: { ProcessRuntimeLease(service: transport) {} },
+            makeRenderer: { ProcessRuntimeLease(service: renderer) {} }))
     }
 
     public func start() {

--- a/Sources/WikiFSEngine/ProfileWikiSession.swift
+++ b/Sources/WikiFSEngine/ProfileWikiSession.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import CordisLoader
 import Foundation
 import Observation
 import WikiFSCore
@@ -53,7 +54,10 @@ public protocol WikiSessionProtocol: AnyObject, Observable, Sendable {
 
 @MainActor
 @Observable
-public final class WikiSession: WikiSessionProtocol {
+public final class ProfileWikiSession: WikiSessionProtocol {
+    /// The booted child profile owned by production sessions. Synchronous test
+    /// fixtures inject already-booted services and therefore leave this nil.
+    @ObservationIgnored private let profile: BootedProfile?
     /// The wiki's stable ULID. Guaranteed non-nil (a session only exists while
     /// a wiki is open). Views read `session.wikiID` instead of the old
     /// `activeWikiID ?? ""`.
@@ -180,8 +184,11 @@ public final class WikiSession: WikiSessionProtocol {
         htmlMarkdownExtractorFactory: @escaping @MainActor () -> (any HtmlMarkdownExtractor)? = { nil },
         htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend? = { nil },
         podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend? = { nil },
-        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in }
+        interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in },
+        profile: BootedProfile? = nil,
+        readPool: WikiReadPool? = nil
     ) throws {
+        self.profile = profile
         self.wikiID = wikiID
         self.extractionCoordinator = extractionCoordinator
         self.queueEngine = queueEngine
@@ -205,7 +212,7 @@ public final class WikiSession: WikiSessionProtocol {
         // model's `.external`→reload subscription (in its init) sees it. The
         // File Provider signaler and the change bridge subscribe to the
         // same bus from the app layer. See `plans/event-bus.md`.
-        let searchBus = WikiEventBus(wikiID: wikiID)
+        let searchBus = store.eventBus ?? WikiEventBus(wikiID: wikiID)
         store.eventBus = searchBus
         let contentSource = StoreBackedTantivyContentSource(store: store)
         model = WikiStoreModel(store: store)
@@ -221,7 +228,9 @@ public final class WikiSession: WikiSessionProtocol {
         // Off-main snapshot reads (debounced search) go through a read-only
         // pool over the same file. Only for real file-backed DBs — a second
         // connection to an in-memory DB would see a different, empty database.
-        if FileManager.default.fileExists(atPath: url.path) {
+        if let readPool {
+            model.readPool = readPool
+        } else if FileManager.default.fileExists(atPath: url.path) {
             model.readPool = WikiReadPool(databaseURL: url)
         }
         self.store = model
@@ -374,6 +383,13 @@ public final class WikiSession: WikiSessionProtocol {
 
     public func shutdown() async {
         await shutdownSearchRuntime()
+        guard let profile else { return }
+        do {
+            try await profile.shutdown()
+        } catch {
+            DebugLog.store("Per-wiki profile shutdown failed: \(error)")
+        }
     }
 }
+
 #endif

--- a/Sources/WikiFSEngine/QueueRuntimeFactory.swift
+++ b/Sources/WikiFSEngine/QueueRuntimeFactory.swift
@@ -2,7 +2,7 @@ import Cordis
 import Foundation
 import WikiFSCore
 
-public enum QueueRuntimeAssemblyError: Error, Equatable, Sendable {
+public enum QueueRuntimeFactoryError: Error, Equatable, Sendable {
     case missingService(ServiceDescriptor)
     case activationFailed(component: String, failure: CordisFailure)
     case assemblyAndCleanupFailed(
@@ -10,7 +10,7 @@ public enum QueueRuntimeAssemblyError: Error, Equatable, Sendable {
         cleanup: CordisFailure)
 }
 
-public struct QueueRuntimeAssembly: Sendable {
+public struct QueueRuntimeFactory: Sendable {
     public typealias IngestionProviderFactory = @Sendable (QueueStore) async throws -> any QueueIngestionProvider
 
     internal enum Component: String, CaseIterable, Sendable {
@@ -73,13 +73,13 @@ public struct QueueRuntimeAssembly: Sendable {
 
             for component in Component.allCases {
                 guard let handle = handles[component] else {
-                    throw QueueRuntimeAssemblyError.activationFailed(
+                    throw QueueRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: CordisFailure("component was not registered"))
                 }
                 let state = try await handle.awaitSettled()
                 if case .failed(_, let failure) = state {
-                    throw QueueRuntimeAssemblyError.activationFailed(
+                    throw QueueRuntimeFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: failure)
                 }
@@ -97,7 +97,7 @@ public struct QueueRuntimeAssembly: Sendable {
             do {
                 try await context.dispose()
             } catch let cleanupError {
-                throw QueueRuntimeAssemblyError.assemblyAndCleanupFailed(
+                throw QueueRuntimeFactoryError.assemblyAndCleanupFailed(
                     assembly: assemblyFailure,
                     cleanup: CordisFailure(cleanupError))
             }
@@ -110,7 +110,7 @@ public struct QueueRuntimeAssembly: Sendable {
         from context: CordisContext
     ) async throws -> Value {
         guard let value = try await context.find(key) else {
-            throw QueueRuntimeAssemblyError.missingService(
+            throw QueueRuntimeFactoryError.missingService(
                 ServiceDependency(key).descriptor)
         }
         return value

--- a/Sources/WikiFSEngine/SearchCompositionOwner.swift
+++ b/Sources/WikiFSEngine/SearchCompositionOwner.swift
@@ -27,14 +27,15 @@ public final class SearchCompositionOwner {
         contentSource: any TantivyContentSource,
         changeStreamFactory: any SearchChangeStreamFactory,
         startupPrerequisite: Task<Void, Never>? = nil,
-        services: MutableSearchServices = MutableSearchServices()
+        services: MutableSearchServices = MutableSearchServices(),
+        makeRuntime: SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
     ) {
         self.registry = registry
         self.startupPrerequisite = startupPrerequisite
-        self.runtime = SearchRuntimeAssembly.runtimeFactory(
-            identity: identity,
-            contentSource: contentSource,
-            changeStreamFactory: changeStreamFactory)
+        self.runtime = makeRuntime(
+            identity,
+            contentSource,
+            changeStreamFactory)
         self.services = services
     }
 

--- a/Sources/WikiFSEngine/SearchCompositionOwner.swift
+++ b/Sources/WikiFSEngine/SearchCompositionOwner.swift
@@ -28,7 +28,7 @@ public final class SearchCompositionOwner {
         changeStreamFactory: any SearchChangeStreamFactory,
         startupPrerequisite: Task<Void, Never>? = nil,
         services: MutableSearchServices = MutableSearchServices(),
-        makeRuntime: SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+        makeRuntime: SearchRuntimeFactory.Factory = SearchRuntimeCompositionFactory.runtimeFactory
     ) {
         self.registry = registry
         self.startupPrerequisite = startupPrerequisite

--- a/Sources/WikiFSEngine/SearchCompositionOwner.swift
+++ b/Sources/WikiFSEngine/SearchCompositionOwner.swift
@@ -17,7 +17,7 @@ public final class SearchCompositionOwner {
 
     private let registry: SearchRuntimeRegistry
     private let startupPrerequisite: Task<Void, Never>?
-    private let assembly: SearchRuntimeAssembly
+    private let runtime: SearchRuntimeFactory
     private var state: State = .idle
     private var startupError: (any Error)?
 
@@ -31,7 +31,7 @@ public final class SearchCompositionOwner {
     ) {
         self.registry = registry
         self.startupPrerequisite = startupPrerequisite
-        self.assembly = SearchRuntimeAssembly(
+        self.runtime = SearchRuntimeAssembly.runtimeFactory(
             identity: identity,
             contentSource: contentSource,
             changeStreamFactory: changeStreamFactory)
@@ -61,12 +61,12 @@ public final class SearchCompositionOwner {
         switch state {
         case .idle:
             state = .stopped
-            assembly.changeStreamFactory.finish()
+            runtime.changeStreamFactory.finish()
         case .starting(let task, let installation):
             state = .stopped
             await services.invalidate(installation)
             task.cancel()
-            assembly.changeStreamFactory.finish()
+            runtime.changeStreamFactory.finish()
             await task.value
         case .installed(let lease, let installation):
             state = .stopped
@@ -81,7 +81,7 @@ public final class SearchCompositionOwner {
         do {
             if let startupPrerequisite { await startupPrerequisite.value }
             guard isAdmitted(installation), !Task.isCancelled else { return }
-            let lease = try await registry.assemble(assembly)
+            let lease = try await registry.assemble(runtime)
             guard isAdmitted(installation), !Task.isCancelled else {
                 await lease.dispose()
                 return
@@ -95,13 +95,13 @@ public final class SearchCompositionOwner {
             state = .installed(lease, installation)
             startupError = nil
         } catch is CancellationError {
-            assembly.changeStreamFactory.finish()
+            runtime.changeStreamFactory.finish()
         } catch {
             guard isAdmitted(installation) else { return }
             startupError = error
             state = .idle
-            assembly.changeStreamFactory.finish()
-            DebugLog.store("SearchCompositionOwner: runtime assembly failed: \(error)")
+            runtime.changeStreamFactory.finish()
+            DebugLog.store("SearchCompositionOwner: runtime composition failed: \(error)")
         }
     }
 

--- a/Sources/WikiFSEngine/SearchPlugins.swift
+++ b/Sources/WikiFSEngine/SearchPlugins.swift
@@ -26,7 +26,7 @@ public enum TantivySearchPlugin {
     public static let key = SearchProviderKey(kind: .lexical, providerID: "tantivy")
 
     public static func definition(
-        makeRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
+        makeRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeCompositionFactory.runtimeFactory
     ) -> PluginDefinition {
         adapterDefinition(
             id: id,

--- a/Sources/WikiFSEngine/SearchPlugins.swift
+++ b/Sources/WikiFSEngine/SearchPlugins.swift
@@ -26,19 +26,14 @@ public enum TantivySearchPlugin {
     public static let key = SearchProviderKey(kind: .lexical, providerID: "tantivy")
 
     public static func definition(
-        makeAssembly: @escaping TantivySearchProvider.Factory = { identity, source, streamFactory in
-            SearchRuntimeAssembly(
-                identity: identity,
-                contentSource: source,
-                changeStreamFactory: streamFactory)
-        }
+        makeRuntime: @escaping SearchRuntimeFactory.Factory = SearchRuntimeAssembly.runtimeFactory
     ) -> PluginDefinition {
         adapterDefinition(
             id: id,
             label: "Tantivy lexical search",
             provider: RegisteredSearchProvider(
                 key: key,
-                adapter: .tantivy(TantivySearchProvider(makeAssembly: makeAssembly))))
+                adapter: .tantivy(TantivySearchProvider(makeRuntime: makeRuntime))))
     }
 }
 #endif

--- a/Sources/WikiFSEngine/SearchRuntimeAssembly.swift
+++ b/Sources/WikiFSEngine/SearchRuntimeAssembly.swift
@@ -47,6 +47,21 @@ public struct SearchRuntimeAssembly: Sendable {
         self.changeStreamFactory = changeStreamFactory
     }
 
+    public static func runtimeFactory(
+        identity: SearchRuntimeIdentity,
+        contentSource: any TantivyContentSource,
+        changeStreamFactory: any SearchChangeStreamFactory
+    ) -> SearchRuntimeFactory {
+        let assembly = Self(
+            identity: identity,
+            contentSource: contentSource,
+            changeStreamFactory: changeStreamFactory)
+        return SearchRuntimeFactory(
+            identity: identity,
+            changeStreamFactory: changeStreamFactory,
+            assemble: { context in try await assembly.assemble(in: context) })
+    }
+
     public func assemble(in childContext: CordisContext) async throws -> SearchRuntimeHandle {
         try await assemble(in: childContext, registrationOrder: Component.allCases)
     }

--- a/Sources/WikiFSEngine/SearchRuntimeCompositionFactory.swift
+++ b/Sources/WikiFSEngine/SearchRuntimeCompositionFactory.swift
@@ -4,13 +4,13 @@ import Foundation
 import WikiFSCore
 import WikiFSSearch
 
-public enum SearchRuntimeAssemblyError: Error, Equatable, Sendable {
+public enum SearchRuntimeCompositionFactoryError: Error, Equatable, Sendable {
     case missingService(ServiceDescriptor)
     case activationFailed(component: String, failure: CordisFailure)
     case assemblyAndCleanupFailed(assembly: CordisFailure, cleanup: CordisFailure)
 }
 
-public struct SearchRuntimeAssembly: Sendable {
+public struct SearchRuntimeCompositionFactory: Sendable {
     public enum ServiceLabels {
         public static let identity = "search.identity"
         public static let contentSource = "search.content-source"
@@ -77,12 +77,12 @@ public struct SearchRuntimeAssembly: Sendable {
             }
             for component in Component.allCases {
                 guard let handle = handles[component] else {
-                    throw SearchRuntimeAssemblyError.activationFailed(
+                    throw SearchRuntimeCompositionFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: CordisFailure("component was not registered"))
                 }
                 if case .failed(_, let failure) = try await handle.awaitSettled() {
-                    throw SearchRuntimeAssemblyError.activationFailed(
+                    throw SearchRuntimeCompositionFactoryError.activationFailed(
                         component: component.rawValue,
                         failure: failure)
                 }
@@ -96,7 +96,7 @@ public struct SearchRuntimeAssembly: Sendable {
             do {
                 try await childContext.dispose()
             } catch let cleanupError {
-                throw SearchRuntimeAssemblyError.assemblyAndCleanupFailed(
+                throw SearchRuntimeCompositionFactoryError.assemblyAndCleanupFailed(
                     assembly: assemblyFailure,
                     cleanup: CordisFailure(cleanupError))
             }
@@ -109,7 +109,7 @@ public struct SearchRuntimeAssembly: Sendable {
         from context: CordisContext
     ) async throws -> Value {
         guard let value = try await context.find(key) else {
-            throw SearchRuntimeAssemblyError.missingService(ServiceDependency(key).descriptor)
+            throw SearchRuntimeCompositionFactoryError.missingService(ServiceDependency(key).descriptor)
         }
         return value
     }

--- a/Sources/WikiFSEngine/SearchRuntimeFactory.swift
+++ b/Sources/WikiFSEngine/SearchRuntimeFactory.swift
@@ -1,0 +1,33 @@
+#if os(macOS)
+import Cordis
+import WikiFSCore
+import WikiFSSearch
+
+/// Assembly-independent request for one per-wiki Tantivy runtime.
+public struct SearchRuntimeFactory: Sendable {
+    public typealias Factory = @Sendable (
+        SearchRuntimeIdentity,
+        any TantivyContentSource,
+        any SearchChangeStreamFactory
+    ) -> SearchRuntimeFactory
+
+    public let identity: SearchRuntimeIdentity
+    public let changeStreamFactory: any SearchChangeStreamFactory
+    private let assembleOperation: @Sendable (CordisContext) async throws -> SearchRuntimeHandle
+
+    public init(
+        identity: SearchRuntimeIdentity,
+        changeStreamFactory: any SearchChangeStreamFactory,
+        assemble: @escaping @Sendable (CordisContext) async throws -> SearchRuntimeHandle
+    ) {
+        self.identity = identity
+        self.changeStreamFactory = changeStreamFactory
+        self.assembleOperation = assemble
+    }
+
+    public func assemble(in context: CordisContext) async throws -> SearchRuntimeHandle {
+        try await assembleOperation(context)
+    }
+
+}
+#endif

--- a/Sources/WikiFSEngine/SearchRuntimeRegistry.swift
+++ b/Sources/WikiFSEngine/SearchRuntimeRegistry.swift
@@ -66,8 +66,15 @@ public actor SearchRuntimeRegistry {
     }
 
     public func assemble(_ assembly: SearchRuntimeAssembly) async throws -> SearchRuntimeLease {
+        try await assemble(SearchRuntimeFactory(
+            identity: assembly.identity,
+            changeStreamFactory: assembly.changeStreamFactory,
+            assemble: { context in try await assembly.assemble(in: context) }))
+    }
+
+    public func assemble(_ runtime: SearchRuntimeFactory) async throws -> SearchRuntimeLease {
         guard !shuttingDown else { throw SearchRuntimeRegistryError.shuttingDown }
-        let wikiID = assembly.identity.wikiID
+        let wikiID = runtime.identity.wikiID
         guard active[wikiID] == nil, starting[wikiID] == nil else {
             throw SearchRuntimeRegistryError.wikiAlreadyActive(wikiID)
         }
@@ -90,7 +97,7 @@ public actor SearchRuntimeRegistry {
             throw SearchRuntimeRegistryError.shuttingDown
         }
         starting[wikiID]?.childContext = child
-        let handle = try await assembly.assemble(in: child)
+        let handle = try await runtime.assemble(in: child)
         guard !shuttingDown else {
             try await handle.dispose()
             throw SearchRuntimeRegistryError.shuttingDown

--- a/Sources/WikiFSEngine/SearchRuntimeRegistry.swift
+++ b/Sources/WikiFSEngine/SearchRuntimeRegistry.swift
@@ -65,7 +65,7 @@ public actor SearchRuntimeRegistry {
         rootContext = CordisContext()
     }
 
-    public func assemble(_ assembly: SearchRuntimeAssembly) async throws -> SearchRuntimeLease {
+    public func assemble(_ assembly: SearchRuntimeCompositionFactory) async throws -> SearchRuntimeLease {
         try await assemble(SearchRuntimeFactory(
             identity: assembly.identity,
             changeStreamFactory: assembly.changeStreamFactory,

--- a/Sources/WikiFSEngine/SearchServiceKeys.swift
+++ b/Sources/WikiFSEngine/SearchServiceKeys.swift
@@ -21,26 +21,20 @@ public struct SearchProviderKey: Hashable, Sendable, CustomStringConvertible {
 }
 
 #if os(macOS)
-/// Lazy factory for the existing per-wiki Tantivy runtime composition.
+/// Lazy factory for one per-wiki Tantivy runtime composition.
 public struct TantivySearchProvider: Sendable {
-    public typealias Factory = @Sendable (
-        SearchRuntimeIdentity,
-        any TantivyContentSource,
-        any SearchChangeStreamFactory
-    ) -> SearchRuntimeAssembly
+    private let makeRuntime: SearchRuntimeFactory.Factory
 
-    private let makeAssembly: Factory
-
-    public init(makeAssembly: @escaping Factory) {
-        self.makeAssembly = makeAssembly
+    public init(makeRuntime: @escaping SearchRuntimeFactory.Factory) {
+        self.makeRuntime = makeRuntime
     }
 
-    public func assembly(
+    public func runtime(
         identity: SearchRuntimeIdentity,
         contentSource: any TantivyContentSource,
         changeStreamFactory: any SearchChangeStreamFactory
-    ) -> SearchRuntimeAssembly {
-        makeAssembly(identity, contentSource, changeStreamFactory)
+    ) -> SearchRuntimeFactory {
+        makeRuntime(identity, contentSource, changeStreamFactory)
     }
 }
 #endif

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -3,6 +3,10 @@ import Foundation
 import Observation
 import WikiFSCore
 
+public enum SessionLoadingError: Error, Equatable, Sendable {
+    case processProfileUnavailable(String)
+}
+
 /// Owns the live `WikiSession` cache for multi-window SwiftUI
 /// (`plans/multi-window-ui.md` Phase 2b). Each window's `RootScene` calls
 /// ``session(for:descriptor:)`` to resolve (or create) the session for its
@@ -31,7 +35,7 @@ public final class SessionManager {
         case failed(String)
     }
 
-    public typealias AsyncSessionLoader = @MainActor @Sendable (WikiID, WikiDescriptor) async throws -> WikiSession
+    public typealias AsyncSessionLoader = @MainActor @Sendable (WikiID, WikiDescriptor) async throws -> any WikiSessionProtocol
 
     /// Observable readiness for the future per-wiki child-profile boot path.
     public private(set) var readiness: [WikiID: SessionReadiness] = [:]
@@ -39,7 +43,7 @@ public final class SessionManager {
 
     /// Live sessions keyed by wiki ID. A wiki open in multiple windows
     /// shares ONE session (one store, one bus, one gate).
-    public private(set) var sessions: [WikiID: WikiSession] = [:]
+    public private(set) var sessions: [WikiID: any WikiSessionProtocol] = [:]
     /// Number of live `RootScene` owners for each cached session. A renderer
     /// window does not own a lease; it resolves through the session retained by
     /// the wiki window that activated it.
@@ -179,7 +183,7 @@ public final class SessionManager {
     /// The injected loader is the target child-profile boot path. Until app and
     /// daemon owners are rewired, the default preserves legacy synchronous
     /// construction while exposing the same async readiness contract.
-    public func readySession(for wikiID: WikiID, descriptor: WikiDescriptor) async throws -> WikiSession {
+    public func readySession(for wikiID: WikiID, descriptor: WikiDescriptor) async throws -> any WikiSessionProtocol {
         if let existing = sessions[wikiID] {
             existing.updateDescriptor(descriptor)
             sessionLeaseCounts[wikiID, default: 0] += 1
@@ -213,7 +217,7 @@ public final class SessionManager {
     ///   message) and rethrown. There is no in-memory fallback (#881) — a
     ///   failed open leaves `sessions[wikiID]` unset, and the caller renders
     ///   an error view instead of an empty wiki.
-    public func session(for wikiID: WikiID, descriptor: WikiDescriptor) throws -> WikiSession {
+    public func session(for wikiID: WikiID, descriptor: WikiDescriptor) throws -> any WikiSessionProtocol {
         if let existing = sessions[wikiID] {
             // Refresh the descriptor in case the registry mutated (rename /
             // set home page) since this session was created.
@@ -284,7 +288,7 @@ public final class SessionManager {
         session.store.flushPendingSaves()
         let token = UUID()
         let task = Task { @MainActor [weak self] in
-            await session.shutdownSearchRuntime()
+            await session.shutdown()
             guard self?.searchReleaseTasks[wikiID]?.token == token else { return }
             self?.searchReleaseTasks[wikiID] = nil
         }
@@ -321,7 +325,7 @@ public final class SessionManager {
     public var activeWikiIDs: Set<WikiID> { Set(sessions.keys) }
 
     /// All live sessions (for bridge flush routing).
-    public var allSessions: [WikiSession] { Array(sessions.values) }
+    public var allSessions: [any WikiSessionProtocol] { Array(sessions.values) }
 
     /// Fan out one authoritative machine-renderer reload to every live wiki
     /// projection. Closed/inactive wikis own no session and therefore reload
@@ -335,7 +339,7 @@ public final class SessionManager {
     /// The frontmost session, if any. Resolved from ``frontmostWikiID`` —
     /// `VacuumCommands` uses this to target the correct wiki for menu-bar
     /// Vacuum/Lint/Activity Log actions.
-    public var frontmostSession: WikiSession? {
+    public var frontmostSession: (any WikiSessionProtocol)? {
         guard let id = frontmostWikiID else { return nil }
         return sessions[id]
     }

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -24,6 +24,19 @@ import WikiFSCore
 @MainActor
 @Observable
 public final class SessionManager {
+    public enum SessionReadiness: Equatable, Sendable {
+        case idle
+        case loading
+        case ready
+        case failed(String)
+    }
+
+    public typealias AsyncSessionLoader = @MainActor @Sendable (WikiID, WikiDescriptor) async throws -> WikiSession
+
+    /// Observable readiness for the future per-wiki child-profile boot path.
+    public private(set) var readiness: [WikiID: SessionReadiness] = [:]
+    @ObservationIgnored private let asyncSessionLoader: AsyncSessionLoader?
+
     /// Live sessions keyed by wiki ID. A wiki open in multiple windows
     /// shares ONE session (one store, one bus, one gate).
     public private(set) var sessions: [WikiID: WikiSession] = [:]
@@ -137,7 +150,8 @@ public final class SessionManager {
         htmlBackendResolver: @escaping @MainActor () -> HtmlExtractionBackend? = { nil },
         podcastBackendResolver: @escaping @MainActor () -> PodcastTranscriptionBackend? = { nil },
         interactiveUsageRecorder: @escaping (@MainActor (SessionUsage) -> Void) = { _ in },
-        makeStore: @escaping @Sendable (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) }
+        makeStore: @escaping @Sendable (URL) throws -> WikiStore = { try StoreBackend.current.makeStore(databaseURL: $0) },
+        asyncSessionLoader: AsyncSessionLoader? = nil
     ) {
         self.containerDirectory = containerDirectory
         self.extractionCoordinator = extractionCoordinator
@@ -151,9 +165,44 @@ public final class SessionManager {
         self.podcastBackendResolver = podcastBackendResolver
         self.interactiveUsageRecorder = interactiveUsageRecorder
         self.makeStore = makeStore
+        self.asyncSessionLoader = asyncSessionLoader
     }
 
     // MARK: - Session lifecycle
+
+    public func readiness(for wikiID: WikiID) -> SessionReadiness {
+        readiness[wikiID] ?? .idle
+    }
+
+    /// Await the per-wiki session composition boundary.
+    ///
+    /// The injected loader is the target child-profile boot path. Until app and
+    /// daemon owners are rewired, the default preserves legacy synchronous
+    /// construction while exposing the same async readiness contract.
+    public func readySession(for wikiID: WikiID, descriptor: WikiDescriptor) async throws -> WikiSession {
+        if let existing = sessions[wikiID] {
+            existing.updateDescriptor(descriptor)
+            sessionLeaseCounts[wikiID, default: 0] += 1
+            readiness[wikiID] = .ready
+            return existing
+        }
+        readiness[wikiID] = .loading
+        do {
+            let session = if let asyncSessionLoader {
+                try await asyncSessionLoader(wikiID, descriptor)
+            } else {
+                try self.session(for: wikiID, descriptor: descriptor)
+            }
+            sessions[wikiID] = session
+            if sessionLeaseCounts[wikiID] == nil { sessionLeaseCounts[wikiID] = 1 }
+            openErrors.removeValue(forKey: wikiID)
+            readiness[wikiID] = .ready
+            return session
+        } catch {
+            readiness[wikiID] = .failed(String(describing: error))
+            throw error
+        }
+    }
 
     /// Get or create a session for `wikiID`. If a session already exists for
     /// this wiki (open in another window), returns the existing instance —

--- a/Sources/WikiFSEngine/SessionManager.swift
+++ b/Sources/WikiFSEngine/SessionManager.swift
@@ -225,9 +225,9 @@ public final class SessionManager {
             sessionLeaseCounts[wikiID, default: 0] += 1
             return existing
         }
-        let newSession: WikiSession
+        let newSession: ProfileWikiSession
         do {
-            newSession = try WikiSession(
+            newSession = try ProfileWikiSession(
                 wikiID: wikiID,
                 descriptor: descriptor,
                 containerDirectory: containerDirectory,

--- a/Sources/WikiFSEngine/WikiSession.swift
+++ b/Sources/WikiFSEngine/WikiSession.swift
@@ -27,8 +27,33 @@ import WikiFSCore
 ///
 /// See `plans/dissolve-wikimanager.md` for the full dissolution rationale.
 @MainActor
+public protocol WikiSessionProtocol: AnyObject, Observable, Sendable {
+    var wikiID: WikiID { get }
+    var descriptor: WikiDescriptor { get }
+    var store: WikiStoreModel { get }
+    var agentLauncher: AgentLauncher { get }
+    var extractionCoordinator: ExtractionCoordinator { get }
+    var queueEngine: any QueueEngineClient { get }
+    var extractionProvider: any QueueExtractionProvider { get }
+    var generationGate: GenerationGate { get }
+    var searchServices: any SearchServices { get }
+    var pendingBlobVacuum: BlobVacuumReport? { get set }
+    var pendingVacuumAll: VacuumReport? { get set }
+    var pendingWikiLink: (url: URL, openInNewTab: Bool)? { get set }
+
+    func updateDescriptor(_ descriptor: WikiDescriptor)
+    func previewBlobVacuum()
+    func applyBlobVacuum()
+    func previewVacuumAll()
+    func applyVacuumAll()
+    func upgradeSearchIndex() async
+    func searchTantivy(query: String, kinds: [TantivyDocumentKind], limit: Int) async -> [TantivyShadowSearchResult]?
+    func shutdown() async
+}
+
+@MainActor
 @Observable
-public final class WikiSession {
+public final class WikiSession: WikiSessionProtocol {
     /// The wiki's stable ULID. Guaranteed non-nil (a session only exists while
     /// a wiki is open). Views read `session.wikiID` instead of the old
     /// `activeWikiID ?? ""`.
@@ -345,6 +370,10 @@ public final class WikiSession {
 
     public func shutdownSearchRuntime() async {
         await searchCompositionOwner.shutdown()
+    }
+
+    public func shutdown() async {
+        await shutdownSearchRuntime()
     }
 }
 #endif

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -103,7 +103,7 @@ final class WikiDaemon: @unchecked Sendable {
         let acpCredentialStore = KeychainACPCredentialStore()
         let extractionOwner = ExtractionCompositionOwner(
             assemble: extractionAssembly ?? {
-                try await ExtractionRuntimeAssembly(
+                try await ExtractionRuntimeFactory(
                     readConfiguration: { ExtractionConfig.load(from: containerDirectory) },
                     readCredential: { extractionCredentialStore.secret($0) },
                     resolveACP: { configuration in

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -20,14 +20,11 @@ final class WikiDaemon: @unchecked Sendable {
     private let makeStore: (URL) throws -> WikiStore
     private let daemonChatDiagnostics = DaemonChatDiagnostics()
     #if canImport(WikiFSEngine)
-    /// Stable daemon-scoped facade. It remains unavailable until the isolated
-    /// provider composition has assembled, so XPC/store hosting never depends
-    /// on Cordis availability.
-    private let agentProviderServices = MutableAgentProviderServices()
-    /// Retains the provider composition context for the daemon lifetime.
-    private var agentProviderRuntimeHandle: AgentProviderRuntimeHandle?
-    /// Owns the single daemon-scoped extraction context and stable facade.
-    private let extractionCompositionOwner: ExtractionCompositionOwner
+    /// Production owns provider, extraction, and per-wiki store lifetimes here.
+    /// Tests that use the synchronous initializer retain the legacy fallback.
+    private let profileOwner: DaemonProcessProfileOwner?
+    private let legacyAgentProviderServices: MutableAgentProviderServices?
+    private let legacyExtractionCompositionOwner: ExtractionCompositionOwner?
     #endif
 
     // MARK: - State (accessed on `queue`)
@@ -99,9 +96,12 @@ final class WikiDaemon: @unchecked Sendable {
         self.makeStore = makeStore
         self.registry = WikiRegistry.load(from: containerDirectory)
         #if canImport(WikiFSEngine)
+        self.profileOwner = nil
+        let providerServices = MutableAgentProviderServices()
+        self.legacyAgentProviderServices = providerServices
         let extractionCredentialStore = KeychainExtractionCredentialStore()
         let acpCredentialStore = KeychainACPCredentialStore()
-        self.extractionCompositionOwner = ExtractionCompositionOwner(
+        let extractionOwner = ExtractionCompositionOwner(
             assemble: extractionAssembly ?? {
                 try await ExtractionRuntimeAssembly(
                     readConfiguration: { ExtractionConfig.load(from: containerDirectory) },
@@ -113,41 +113,66 @@ final class WikiDaemon: @unchecked Sendable {
                             acpCredentialStore: acpCredentialStore)
                     },
                     httpFetcher: URLSessionRequestFetcher(),
-                    makeLocalExtractor: {
-                        await MainActor.run { LocalPdf2MarkdownExtractor() }
-                    })
+                    makeLocalExtractor: { await MainActor.run { LocalPdf2MarkdownExtractor() } })
                     .assemble()
             })
-        let providerServices = agentProviderServices
-        let providerAssembly = AgentProviderRuntimeAssembly(
-            readConfiguration: {
-                AgentProvidersConfig.loadOrSeed(from: containerDirectory)
-            },
-            resolveCommand: { providers in
-                let searchPath = await PathPreflight.loginShellPATH()
-                return Dictionary(uniqueKeysWithValues: providers.compactMap { provider in
-                    AgentLauncher.resolveCommand(for: provider, searchPath: searchPath)
-                        .map { (provider.id, $0) }
-                })
-            },
-            readCredential: { providerID in
-                KeychainACPCredentialStore().apiKey(forProvider: providerID.rawValue)
-            },
-            resolvePermissionPolicy: { _ in .bypass })
-        Task { await extractionCompositionOwner.start() }
-        Task { [weak self, providerAssembly, providerServices] in
-            do {
-                let handle = try await providerAssembly.assemble()
-                await providerServices.install(handle.services)
-                self?.queue.sync {
-                    self?.agentProviderRuntimeHandle = handle
-                }
-            } catch {
-                DebugLog.agent("wikid: agent provider runtime assembly failed. Agent commands are unavailable: \(error)")
-            }
-        }
+        self.legacyExtractionCompositionOwner = extractionOwner
+        Task { await extractionOwner.start() }
         #endif
     }
+
+    #if canImport(WikiFSEngine)
+    init(
+        containerDirectory: URL,
+        profileOwner: DaemonProcessProfileOwner,
+        makeStore: @escaping (URL) throws -> WikiStore = { try GRDBWikiStore(databaseURL: $0) }
+    ) {
+        self.containerDirectory = containerDirectory
+        self.makeStore = makeStore
+        self.registry = WikiRegistry.load(from: containerDirectory)
+        self.profileOwner = profileOwner
+        self.legacyAgentProviderServices = nil
+        self.legacyExtractionCompositionOwner = nil
+    }
+
+    func start() async throws {
+        if let profileOwner { _ = try await profileOwner.start() }
+    }
+
+    func prepareWiki(_ wikiID: WikiID) async throws {
+        guard let profileOwner else { return }
+        let services = try await profileOwner.wiki(wikiID: wikiID)
+        guard let store = services.store as? GRDBWikiStore else {
+            throw QueueRPCError(code: .unavailable, message: "Daemon profile did not provide a GRDB store")
+        }
+        queue.sync {
+            wireEventBus(on: store, wikiID: wikiID)
+            cacheStore(store, wikiID: wikiID)
+        }
+    }
+
+    func removeWikiProfile(_ wikiID: WikiID) async {
+        await profileOwner?.removeWiki(wikiID)
+    }
+
+    private func processServices() async throws -> DaemonProcessServices? {
+        try await profileOwner?.services()
+    }
+
+    private func runtimeServices() async throws -> (
+        provider: any AgentProviderServices,
+        extraction: any ExtractionServices
+    ) {
+        if let services = try await processServices() {
+            return (services.agentProvider, services.extraction)
+        }
+        guard let provider = legacyAgentProviderServices,
+              let extraction = legacyExtractionCompositionOwner?.services else {
+            throw QueueRPCError(code: .unavailable, message: "Daemon runtime services are unavailable")
+        }
+        return (provider, extraction)
+    }
+    #endif
 
     func shutdown() async {
         let task = queue.sync { () -> Task<Void, Never> in
@@ -165,13 +190,10 @@ final class WikiDaemon: @unchecked Sendable {
                 if let chatHost = self.queue.sync(execute: { self._chatHost }) {
                     await chatHost.shutdown()
                 }
-                await self.extractionCompositionOwner.shutdown()
-                if let handle = self.queue.sync(execute: { self.agentProviderRuntimeHandle }) {
-                    do {
-                        try await handle.dispose()
-                    } catch {
-                        DebugLog.agent("wikid: provider runtime disposal failed: \(error)")
-                    }
+                if let profileOwner = self.profileOwner {
+                    await profileOwner.shutdown()
+                } else if let extractionOwner = self.legacyExtractionCompositionOwner {
+                    await extractionOwner.shutdown()
                 }
                 #endif
             }
@@ -584,7 +606,8 @@ final class WikiDaemon: @unchecked Sendable {
     }
 
     private func buildQueueResources() async throws -> DaemonQueueResources {
-        let extractionServices = extractionCompositionOwner.services
+        let runtime = try await runtimeServices()
+        let extractionServices = runtime.extraction
         let coordinator = await MainActor.run {
             ExtractionCoordinator(services: extractionServices)
         }
@@ -608,7 +631,7 @@ final class WikiDaemon: @unchecked Sendable {
             resolveProviderConfig: {
                 AgentProvidersConfig.loadOrSeed(from: dir)
             },
-            providerServices: agentProviderServices)
+            providerServices: runtime.provider)
 
         let outputChannel = QueueWorkerOutputChannel(store: queueStore)
         let extractionFactory = QueueExtractionWorkerFactory(
@@ -672,7 +695,8 @@ final class WikiDaemon: @unchecked Sendable {
             return host
         }
 
-        let extractionServices = extractionCompositionOwner.services
+        let runtime = try await runtimeServices()
+        let extractionServices = runtime.extraction
         let coordinator = await MainActor.run {
             ExtractionCoordinator(services: extractionServices)
         }
@@ -694,7 +718,7 @@ final class WikiDaemon: @unchecked Sendable {
                 self?.pushChatEnvelope(envelope)
             },
             diagnosticTrace: daemonChatDiagnostics,
-            providerServices: agentProviderServices)
+            providerServices: runtime.provider)
 
         return queue.sync {
             if let existing = _chatHost {
@@ -711,8 +735,9 @@ final class WikiDaemon: @unchecked Sendable {
     func startChatData(request: Data) async -> Data {
         #if canImport(WikiFSEngine)
         do {
-            let host = try await ensureChatHost()
             let req = try JSONDecoder().decode(ChatStartRequest.self, from: request)
+            try await prepareWiki(req.wikiID)
+            let host = try await ensureChatHost()
             let chatID = try await host.startChat(
                 wikiID: req.wikiID, firstMessage: req.firstMessage,
                 providerId: req.providerId,
@@ -733,8 +758,9 @@ final class WikiDaemon: @unchecked Sendable {
     func submitChatTurnData(request: Data) async -> Data {
         #if canImport(WikiFSEngine)
         do {
-            let host = try await ensureChatHost()
             let req = try JSONDecoder().decode(ChatSubmitRequest.self, from: request)
+            try await prepareWiki(req.wikiID)
+            let host = try await ensureChatHost()
             let chatID = try await host.submitTurn(req)
             let reply = ChatSubmitReply(chatID: chatID, error: nil)
             return (DebugLog.trying("JSONEncoder.encode", operation: { try JSONEncoder().encode(reply) })) ?? Data()
@@ -751,8 +777,9 @@ final class WikiDaemon: @unchecked Sendable {
     func continueChatData(request: Data) async -> Data {
         #if canImport(WikiFSEngine)
         do {
-            let host = try await ensureChatHost()
             let req = try JSONDecoder().decode(ChatContinueRequest.self, from: request)
+            try await prepareWiki(req.wikiID)
+            let host = try await ensureChatHost()
             try await host.continueChat(wikiID: req.wikiID, chatID: req.chatID, message: req.message)
             let reply = ChatErrorReply(error: nil)
             return (DebugLog.trying("JSONEncoder.encode", operation: { try JSONEncoder().encode(reply) })) ?? Data()

--- a/Sources/wikid/main.swift
+++ b/Sources/wikid/main.swift
@@ -87,7 +87,13 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
     }
 
     func deleteWiki(id: String, reply: @escaping (Bool) -> Void) {
-        reply(daemon.deleteWiki(id: WikiID(rawValue: id)))
+        let sendableReply = SendableBoolReply(reply: reply)
+        Task { [daemon] in
+            let wikiID = WikiID(rawValue: id)
+            let deleted = daemon.deleteWiki(id: wikiID)
+            if deleted { await daemon.removeWikiProfile(wikiID) }
+            sendableReply.reply(deleted)
+        }
     }
 
     func renameWiki(id: String, name: String, reply: @escaping (Bool) -> Void) {
@@ -99,16 +105,39 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
     }
 
     func openStore(wikiID: String, reply: @escaping (Bool) -> Void) {
-        reply(daemon.openStore(wikiID: WikiID(rawValue: wikiID)))
+        let sendableReply = SendableBoolReply(reply: reply)
+        Task { [daemon] in
+            let id = WikiID(rawValue: wikiID)
+            do {
+                try await daemon.prepareWiki(id)
+                sendableReply.reply(daemon.openStore(wikiID: id))
+            } catch {
+                DebugLog.store("wikid: profile boot failed while opening \(wikiID): \(error)")
+                sendableReply.reply(false)
+            }
+        }
     }
 
     func closeStore(wikiID: String, reply: @escaping () -> Void) {
-        daemon.closeStore(wikiID: WikiID(rawValue: wikiID))
-        reply()
+        let sendableReply = SendableVoidReply(reply: reply)
+        Task { [daemon] in
+            daemon.closeStore(wikiID: WikiID(rawValue: wikiID))
+            sendableReply.reply()
+        }
     }
 
     func changeToken(wikiID: String, reply: @escaping (String) -> Void) {
-        reply(daemon.changeToken(wikiID: WikiID(rawValue: wikiID)))
+        let sendableReply = SendableStringReply(reply: reply)
+        Task { [daemon] in
+            let id = WikiID(rawValue: wikiID)
+            do {
+                try await daemon.prepareWiki(id)
+                sendableReply.reply(daemon.changeToken(wikiID: id))
+            } catch {
+                DebugLog.store("wikid: profile boot failed while reading change token for \(wikiID): \(error)")
+                sendableReply.reply(WikiDaemon.errorTokenSentinel)
+            }
+        }
     }
 
     // MARK: - Workload: event sink registration (Phase 0)
@@ -143,6 +172,7 @@ final class WikiDaemonExporter: NSObject, WikiDaemonProtocol, @unchecked Sendabl
             } catch {
                 throw QueueRPCError(code: .invalidRequest, message: "Queue request could not be decoded")
             }
+            try await daemon.prepareWiki(decoded.wikiID)
             let result = try await daemon.performQueueOperation { engine in
                 try await engine.enqueue(decoded)
             }
@@ -541,6 +571,13 @@ private struct SendableBoolReply: @unchecked Sendable {
     let reply: (Bool) -> Void
 }
 
+/// Wraps an XPC `@escaping (String) -> Void` reply. XPC reply closures are
+/// thread-safe, immutable, and called exactly once by the exporter task.
+// swiftlint:disable:next unchecked_sendable
+private struct SendableStringReply: @unchecked Sendable {
+    let reply: (String) -> Void
+}
+
 // MARK: - Main
 
 // Resolve the App Group container path. The daemon reaches the SHARED group
@@ -590,7 +627,11 @@ source=\(WikiIdentifiers.appGroupIDSource.rawValue) \
 container=\(containerDirectory.path)
 """)
 
-let daemon = WikiDaemon(containerDirectory: containerDirectory)
+let profileOwner = try DaemonProcessProfileOwner.production(
+    containerDirectory: containerDirectory,
+    makeLocalExtractor: { await MainActor.run { LocalPdf2MarkdownExtractor() } })
+let daemon = WikiDaemon(containerDirectory: containerDirectory, profileOwner: profileOwner)
+try await daemon.start()
 let processLifetime = DaemonProcessLifetimeCoordinator(
     shutdown: {
         await daemon.shutdown()
@@ -627,12 +668,6 @@ DebugLog.store("wikid: XPC service started, serving on \(WikiDaemonServiceName)"
 daemon.startHeartbeat()
 
 listener.resume()
-
-// Unreachable in production — `listener.resume()` above never returns. Kept as
-// a fallback for non-XPC execution contexts (tests, direct invocation for
-// debugging), where `service()` returns a listener whose `resume()` does not
-// block.
-RunLoop.current.run()
 
 #else // Linux
 

--- a/Tests/CordisTests/CordisBoundaryScriptTests.swift
+++ b/Tests/CordisTests/CordisBoundaryScriptTests.swift
@@ -3,12 +3,13 @@ import Testing
 
 @Suite("Cordis boundary script", .serialized, .timeLimit(.minutes(1)))
 struct CordisBoundaryScriptTests {
-    @Test("current source tree satisfies the boundary baseline")
-    func currentTreeSatisfiesBoundaryBaseline() async throws {
+    @Test("current source tree satisfies strict boundaries", arguments: [[], ["--strict"]])
+    func currentTreeSatisfiesStrictBoundaries(arguments: [String]) async throws {
         let root = repositoryRoot()
         let process = Process()
         process.currentDirectoryURL = root
         process.executableURL = root.appendingPathComponent("scripts/check-cordis-boundaries")
+        process.arguments = arguments
         let standardError = Pipe()
         process.standardError = standardError
 

--- a/Tests/CordisTests/CordisPolicyTests.swift
+++ b/Tests/CordisTests/CordisPolicyTests.swift
@@ -78,6 +78,7 @@ struct CordisSourcePolicyTests {
             "Sources/WikiFSEngine/SearchRuntimeAssembly.swift",
             "Sources/WikiFSEngine/SearchRuntimeFactory.swift",
             "Sources/WikiFSEngine/ProductionPluginCatalogs.swift",
+            "Sources/WikiFSEngine/ProfileWikiSession.swift",
             "Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift",
             "Sources/WikiFSEngine/SearchRuntimeRegistry.swift",
             // Phase 4.1 store-domain composition boundary: typed keys and the

--- a/Tests/CordisTests/CordisPolicyTests.swift
+++ b/Tests/CordisTests/CordisPolicyTests.swift
@@ -72,14 +72,14 @@ struct CordisSourcePolicyTests {
         let root = repositoryRoot()
         let sources = root.appendingPathComponent("Sources", isDirectory: true)
         let approved = Set([
-            "Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift",
-            "Sources/WikiFSEngine/QueueRuntimeAssembly.swift",
-            "Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift",
-            "Sources/WikiFSEngine/SearchRuntimeAssembly.swift",
+            "Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift",
+            "Sources/WikiFSEngine/QueueRuntimeFactory.swift",
+            "Sources/WikiFSEngine/ExtractionRuntimeFactory.swift",
+            "Sources/WikiFSEngine/SearchRuntimeCompositionFactory.swift",
             "Sources/WikiFSEngine/SearchRuntimeFactory.swift",
             "Sources/WikiFSEngine/ProductionPluginCatalogs.swift",
             "Sources/WikiFSEngine/ProfileWikiSession.swift",
-            "Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift",
+            "Sources/WikiFSEngine/DaemonTransportRuntimeFactory.swift",
             "Sources/WikiFSEngine/SearchRuntimeRegistry.swift",
             // Phase 4.1 store-domain composition boundary: typed keys and the
             // plugin that owns store construction plus reversible bus bridging.
@@ -128,7 +128,7 @@ struct CordisSourcePolicyTests {
             // Phase 5a diagnostic composition boundary: resolves loader data
             // without exposing a Cordis context to command implementations.
             "Sources/WikiCtlCore/DumpConfigCommand.swift",
-            "Sources/WikiFS/Renderer/RendererRuntimeAssembly.swift",
+            "Sources/WikiFS/Renderer/RendererRuntimeFactory.swift",
         ])
         let forbiddenPatterns = [
             "import Cordis", "CordisContext", "ActivationContext", "ServiceKey<",

--- a/Tests/CordisTests/CordisPolicyTests.swift
+++ b/Tests/CordisTests/CordisPolicyTests.swift
@@ -76,6 +76,8 @@ struct CordisSourcePolicyTests {
             "Sources/WikiFSEngine/QueueRuntimeAssembly.swift",
             "Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift",
             "Sources/WikiFSEngine/SearchRuntimeAssembly.swift",
+            "Sources/WikiFSEngine/SearchRuntimeFactory.swift",
+            "Sources/WikiFSEngine/ProductionPluginCatalogs.swift",
             "Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift",
             "Sources/WikiFSEngine/SearchRuntimeRegistry.swift",
             // Phase 4.1 store-domain composition boundary: typed keys and the
@@ -121,6 +123,7 @@ struct CordisSourcePolicyTests {
             "Sources/WikiFSEngine/IntegrationServiceKeys.swift",
             "Sources/WikiFSEngine/IntegrationPlugins.swift",
             "Sources/WikiCtlCore/CLITantivyLegResolver.swift",
+            "Sources/WikiCtlCore/CLIPluginCatalog.swift",
             // Phase 5a diagnostic composition boundary: resolves loader data
             // without exposing a Cordis context to command implementations.
             "Sources/WikiCtlCore/DumpConfigCommand.swift",

--- a/Tests/WikiFSAppTests/AppQueueIngestionProviderStagingTests.swift
+++ b/Tests/WikiFSAppTests/AppQueueIngestionProviderStagingTests.swift
@@ -15,7 +15,7 @@ import WikiFSTypes
 /// `runHtmlExtraction` path.
 ///
 /// The seam is `internal static` so tests don't need to stand up the full
-/// staging path (which requires a real `WikiSession` + `AgentLauncher` +
+/// staging path (which requires a real `ProfileWikiSession` + `AgentLauncher` +
 /// `FileProviderFacade`). The actual staging call site in `runIngestion`
 /// delegates to this seam.
 ///

--- a/Tests/WikiFSAppTests/InstalledRendererHostTests.swift
+++ b/Tests/WikiFSAppTests/InstalledRendererHostTests.swift
@@ -166,7 +166,7 @@ struct InstalledRendererHostTests {
     private func makeRuntime(
         layout: RendererPackageStoreLayout
     ) async throws -> RendererRuntimeHandle {
-        try await RendererRuntimeAssembly(
+        try await RendererRuntimeFactory(
             layout: layout,
             bundledPackageSource: { BundledRendererPackages.excalidrawResourceURL() },
             reviewedBundledIdentity: .init(

--- a/Tests/WikiFSAppTests/PageDetailViewHostedTests.swift
+++ b/Tests/WikiFSAppTests/PageDetailViewHostedTests.swift
@@ -134,9 +134,9 @@ struct PageDetailViewHostedTests {
         #expect(foundWebView, "Navigation-opened page should render the READER (WKWebView present).")
     }
 
-    // MARK: - Minimal WikiSession for mount (session is only read in button
+    // MARK: - Minimal ProfileWikiSession for mount (session is only read in button
     // closures that don't fire during .onAppear; a minimal instance is enough)
-    private func makeMinimalSession() throws -> WikiSession {
+    private func makeMinimalSession() throws -> ProfileWikiSession {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("page-detail-session-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -144,7 +144,7 @@ struct PageDetailViewHostedTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        return try WikiSession(
+        return try ProfileWikiSession(
             wikiID: descriptor.id,
             descriptor: descriptor,
             containerDirectory: dir,
@@ -154,7 +154,7 @@ struct PageDetailViewHostedTests {
     }
 }
 
-/// Minimal stubs mirroring `WikiSessionTests` (private there, so duplicated
+/// Minimal stubs mirroring `ProfileWikiSessionTests` (private there, so duplicated
 /// here). PageDetailView never exercises extraction during `.onAppear`.
 @MainActor
 private final class StubExtractor: MarkdownExtractor {

--- a/Tests/WikiFSAppTests/QueueEngineClientConformanceTests.swift
+++ b/Tests/WikiFSAppTests/QueueEngineClientConformanceTests.swift
@@ -14,7 +14,7 @@ import Testing
 /// to `QueueEngineClient` or this test fails.
 ///
 /// Methods intentionally NOT in the protocol:
-/// - `start()` — awaited by `QueueRuntimeAssembly` before it publishes a client
+/// - `start()` — awaited by `QueueRuntimeFactory` before it publishes a client
 /// - `shutdownForHandoff()` — called only by the runtime owner
 /// - `clearTranscript(for:)` — not called from the app
 ///

--- a/Tests/WikiFSAppTests/RendererRuntimeFactoryTests.swift
+++ b/Tests/WikiFSAppTests/RendererRuntimeFactoryTests.swift
@@ -5,10 +5,10 @@ import WikiFSCore
 @testable import WikiFS
 
 @Suite("Renderer runtime assembly", .serialized, .timeLimit(.minutes(2)))
-struct RendererRuntimeAssemblyTests {
+struct RendererRuntimeFactoryTests {
     @Test("fixed renderer service labels remain stable")
     func serviceLabelsAreStable() {
-        #expect(RendererRuntimeAssembly.ServiceLabels.all == [
+        #expect(RendererRuntimeFactory.ServiceLabels.all == [
             "renderer.package-store-layout",
             "renderer.machine-index-store",
             "renderer.package-validator-factory",
@@ -24,7 +24,7 @@ struct RendererRuntimeAssemblyTests {
         let fixture = try Fixture(name: "shuffled")
         defer { fixture.cleanup() }
         let handle = try await fixture.assembly.assemble(
-            registrationOrder: RendererRuntimeAssembly.Component.allCases.reversed())
+            registrationOrder: RendererRuntimeFactory.Component.allCases.reversed())
         let preparation = try await handle.services.bootstrapBundledPackage()
 
         #expect(preparation.machineIndex.records.count == 1)
@@ -136,7 +136,7 @@ struct RendererRuntimeAssemblyTests {
         let rendererFiles = try FileManager.default.contentsOfDirectory(
             at: root.appending(path: "Sources/WikiFS/Renderer"),
             includingPropertiesForKeys: nil)
-        let approved = Set(["RendererRuntimeAssembly.swift"])
+        let approved = Set(["RendererRuntimeFactory.swift"])
         for file in rendererFiles where file.pathExtension == "swift" && !approved.contains(file.lastPathComponent) {
             let source = try String(contentsOf: file, encoding: .utf8)
             #expect(!source.contains("CordisContext"))
@@ -164,12 +164,12 @@ private actor PreparationRelay {
 
 private struct Fixture: Sendable {
     let root: URL
-    let assembly: RendererRuntimeAssembly
+    let assembly: RendererRuntimeFactory
 
     init(name: String) throws {
         root = URL.temporaryDirectory.appending(path: "renderer-runtime-\(name)-\(UUID().uuidString)")
         let layout = try RendererPackageStoreLayout(appGroupContainerRoot: root)
-        assembly = RendererRuntimeAssembly(
+        assembly = RendererRuntimeFactory(
             layout: layout,
             bundledPackageSource: { BundledRendererPackages.excalidrawResourceURL() },
             reviewedBundledIdentity: .init(

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -77,7 +77,7 @@ struct RendererSettingsManagementViewTests {
             catch { Issue.record("Renderer settings install fixture cleanup failed.") }
         }
         let layout = try RendererPackageStoreLayout(appGroupContainerRoot: root)
-        let handle = try await RendererRuntimeAssembly(
+        let handle = try await RendererRuntimeFactory(
             layout: layout,
             bundledPackageSource: { BundledRendererPackages.excalidrawResourceURL() },
             reviewedBundledIdentity: .init(

--- a/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
+++ b/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
@@ -360,7 +360,7 @@ struct WikiAppWebViewTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = try WikiSession(
+        let session = try ProfileWikiSession(
             wikiID: descriptor.id,
             descriptor: descriptor,
             containerDirectory: dir,
@@ -467,7 +467,7 @@ private func makePageDetailModel() throws -> WikiStoreModel {
 }
 
 @MainActor
-private func makePageDetailSession() throws -> WikiSession {
+private func makePageDetailSession() throws -> ProfileWikiSession {
     let dir = FileManager.default.temporaryDirectory
         .appendingPathComponent("page-detail-session-\(UUID().uuidString)", isDirectory: true)
     try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -475,7 +475,7 @@ private func makePageDetailSession() throws -> WikiSession {
     let coordinator = ExtractionCoordinator(
         containerDirectory: dir,
         localExtractorFactory: { StubExtractor() })
-    return try WikiSession(
+    return try ProfileWikiSession(
         wikiID: descriptor.id,
         descriptor: descriptor,
         containerDirectory: dir,

--- a/Tests/WikiFSAppTests/WikiChangeBridgeTests.swift
+++ b/Tests/WikiFSAppTests/WikiChangeBridgeTests.swift
@@ -32,13 +32,13 @@ struct WikiChangeBridgeTests {
     /// Helper: create a session for a wiki + return it.
     private func makeSession(
         wikiID: WikiID, descriptor: WikiDescriptor, dir: URL
-    ) throws -> WikiSession {
+    ) throws -> ProfileWikiSession {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
         let queueEngine = try! makeTestQueueEngine()
         let provider = StubExtractionProvider()
-        return try WikiSession(
+        return try ProfileWikiSession(
             wikiID: wikiID,
             descriptor: descriptor,
             containerDirectory: dir,

--- a/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite("Agent provider composition boundary")
 struct AgentProviderCompositionBoundaryTests {
     @Test("app queue and wiki sessions receive one stable facade")
-    func appQueueAndWikiSessionsReceiveSameFacade() throws {
+    func appQueueAndProfileWikiSessionsReceiveSameFacade() throws {
         let app = try sourceText("Sources/WikiFS/Window/WikiFSApp.swift")
         let composition = try sourceText("Sources/WikiFS/Renderer/RendererCompositionOwner.swift")
         let settings = try sourceText("Sources/WikiFS/Settings/AgentsSettingsView.swift")

--- a/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
@@ -25,9 +25,9 @@ struct AgentProviderCompositionBoundaryTests {
         let chat = try sourceText("Sources/wikid/DaemonChatHost.swift")
         let runtime = try sourceText("Sources/wikid/LauncherChatAgentRuntime.swift")
 
-        #expect(daemon.contains("MutableAgentProviderServices()"))
-        #expect(daemon.contains("await providerServices.install(handle.services)"))
-        #expect(daemon.contains("providerServices: agentProviderServices"))
+        #expect(daemon.contains("let runtime = try await runtimeServices()"))
+        #expect(daemon.contains("providerServices: runtime.provider"))
+        #expect(daemon.contains("profileOwner?.services()"))
         #expect(queue.contains("providerServices: providerServices"))
         #expect(chat.contains("providerServices: providerServices"))
         #expect(runtime.contains("providerServices: providerServices"))

--- a/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
@@ -5,17 +5,19 @@ import Testing
 struct AgentProviderCompositionBoundaryTests {
     @Test("app queue and wiki sessions receive one stable facade")
     func appQueueAndWikiSessionsReceiveSameFacade() throws {
-        let source = try sourceText("Sources/WikiFS/Window/WikiFSApp.swift")
+        let app = try sourceText("Sources/WikiFS/Window/WikiFSApp.swift")
+        let composition = try sourceText("Sources/WikiFS/Renderer/RendererCompositionOwner.swift")
         let settings = try sourceText("Sources/WikiFS/Settings/AgentsSettingsView.swift")
 
-        #expect(source.contains("let providerServices = MutableAgentProviderServices()"))
-        #expect(source.contains("providerServices: providerServices"))
-        #expect(source.contains("await providerServices.install(handle.services)"))
-        #expect(source.contains("agentProviderRuntimeHandle = handle"))
-        #expect(source.contains("providerServices: agentProviderServices"))
+        #expect(composition.contains("let providerServices = MutableAgentProviderServices()"))
+        #expect(composition.contains("await providerServices.install(handle.services)"))
+        #expect(app.contains("let providerServices = processComposition.providerServices"))
+        #expect(app.contains("providerServices: providerServices"))
+        #expect(app.contains("providerServices: agentProviderServices"))
         #expect(settings.contains("providerServices.discoverCatalog("))
         #expect(!settings.contains("ACPProviderModelProbe("))
-        #expect(!source.contains("CordisContext"))
+        #expect(!app.contains("CordisContext"))
+        #expect(!app.contains("AgentProviderRuntimeAssembly("))
     }
 
     @Test("daemon queue and chat receive one stable facade")

--- a/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/AgentProviderCompositionBoundaryTests.swift
@@ -17,7 +17,7 @@ struct AgentProviderCompositionBoundaryTests {
         #expect(settings.contains("providerServices.discoverCatalog("))
         #expect(!settings.contains("ACPProviderModelProbe("))
         #expect(!app.contains("CordisContext"))
-        #expect(!app.contains("AgentProviderRuntimeAssembly("))
+        #expect(!app.contains("AgentProviderRuntimeFactory("))
     }
 
     @Test("daemon queue and chat receive one stable facade")
@@ -51,7 +51,7 @@ struct AgentProviderCompositionBoundaryTests {
     func onlyProviderAssemblyConstructsRuntime() throws {
         let root = repositoryRoot()
         let sourceRoot = root.appendingPathComponent("Sources")
-        let approvedPath = "WikiFSEngine/AgentProviderRuntimeAssembly.swift"
+        let approvedPath = "WikiFSEngine/AgentProviderRuntimeFactory.swift"
         let enumerator = try #require(
             FileManager.default.enumerator(
                 at: sourceRoot,
@@ -73,7 +73,7 @@ struct AgentProviderCompositionBoundaryTests {
     @Test("provider assembly excludes app and process owners")
     func providerAssemblyExcludesAppAndProcessOwners() throws {
         let source = try sourceText(
-            "Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift")
+            "Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift")
         for forbidden in [
             "SwiftUI",
             "WikiStoreModel",

--- a/Tests/WikiFSTests/AgentProviderRuntimeFactoryTests.swift
+++ b/Tests/WikiFSTests/AgentProviderRuntimeFactoryTests.swift
@@ -4,11 +4,11 @@ import Testing
 @testable import WikiFSEngine
 
 @Suite("Cordis agent provider runtime assembly", .serialized, .timeLimit(.minutes(1)))
-struct AgentProviderRuntimeAssemblyTests {
+struct AgentProviderRuntimeFactoryTests {
     @Test("shuffled registration builds one opaque runtime")
     func shuffledRegistrationBuildsOpaqueRuntime() async throws {
         let handle = try await makeAssembly().assemble(
-            registrationOrder: AgentProviderRuntimeAssembly.Component.allCases.shuffled())
+            registrationOrder: AgentProviderRuntimeFactory.Component.allCases.shuffled())
 
         #expect(await handle.services.readiness())
         try await handle.dispose()
@@ -30,7 +30,7 @@ struct AgentProviderRuntimeAssemblyTests {
 
     @Test("missing registration fails with a typed component error")
     func missingRegistrationFailsTyped() async throws {
-        let incomplete = AgentProviderRuntimeAssembly.Component.allCases.filter {
+        let incomplete = AgentProviderRuntimeFactory.Component.allCases.filter {
             $0 != .credentialReader
         }
 
@@ -38,11 +38,11 @@ struct AgentProviderRuntimeAssemblyTests {
             _ = try await makeAssembly().assemble(registrationOrder: incomplete)
             Issue.record("Expected provider runtime assembly to fail")
         } catch {
-            guard case .activationFailed(let component, _) = error as? AgentProviderRuntimeAssemblyError else {
+            guard case .activationFailed(let component, _) = error as? AgentProviderRuntimeFactoryError else {
                 Issue.record("Expected a typed provider runtime activation failure, got \(error)")
                 return
             }
-            #expect(component == AgentProviderRuntimeAssembly.Component.credentialReader.rawValue)
+            #expect(component == AgentProviderRuntimeFactory.Component.credentialReader.rawValue)
         }
     }
 
@@ -63,7 +63,7 @@ struct AgentProviderRuntimeAssemblyTests {
                 description: nil)],
             currentModelID: ModelID(rawValue: "test-model"),
             thinkingCapability: nil)
-        let assembly = AgentProviderRuntimeAssembly(
+        let assembly = AgentProviderRuntimeFactory(
             readConfiguration: { AgentProvidersConfig(providers: []) },
             resolveCommand: { providers in
                 #expect(providers == [provider])
@@ -82,7 +82,7 @@ struct AgentProviderRuntimeAssemblyTests {
                 return expected
             })
         let handle = try await assembly.assemble(
-            registrationOrder: AgentProviderRuntimeAssembly.Component.allCases.shuffled())
+            registrationOrder: AgentProviderRuntimeFactory.Component.allCases.shuffled())
 
         let observation = try await handle.services.discoverCatalog(for: provider)
 
@@ -95,7 +95,7 @@ struct AgentProviderRuntimeAssemblyTests {
 
     @Test("catalog discovery rejects a missing resolved command")
     func catalogDiscoveryRejectsMissingCommand() async throws {
-        let handle = try await AgentProviderRuntimeAssembly(
+        let handle = try await AgentProviderRuntimeFactory(
             readConfiguration: { AgentProvidersConfig(providers: []) },
             resolveCommand: { _ in [:] },
             readCredential: { _ in nil },
@@ -130,7 +130,7 @@ struct AgentProviderRuntimeAssemblyTests {
     func assemblyContainsOnlyApprovedHeadlessBoundaries() throws {
         let source = try String(
             contentsOf: repositoryRoot()
-                .appendingPathComponent("Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift"),
+                .appendingPathComponent("Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift"),
             encoding: .utf8)
         let requiredServices = [
             "agent-provider.configuration-reader",
@@ -159,8 +159,8 @@ struct AgentProviderRuntimeAssemblyTests {
         }
     }
 
-    private func makeAssembly() -> AgentProviderRuntimeAssembly {
-        AgentProviderRuntimeAssembly(
+    private func makeAssembly() -> AgentProviderRuntimeFactory {
+        AgentProviderRuntimeFactory(
             readConfiguration: {
                 AgentProvidersConfig(providers: [
                     AgentProvider(

--- a/Tests/WikiFSTests/AppProfileBootTests.swift
+++ b/Tests/WikiFSTests/AppProfileBootTests.swift
@@ -25,11 +25,22 @@ struct AppProfileBootTests {
         entries.append(Entry(
             id: ProfileBootFixture.listenerEntryID,
             plugin: ProfileBootFixture.listenerPluginID))
+        let processDisposals = ProfileProcessDisposalRecorder()
+        let processEntries = ProfileBootFixture.processEntries(includeAppServices: true)
+        let process = try await CordisBoot.boot(.init(
+            catalog: try ProfileBootFixture.processCatalog(includeAppServices: true, recorder: processDisposals),
+            layers: [PatchFile(entries: processEntries)]))
         let booted = try await CordisBoot.boot(.init(
             catalog: try ProfileBootFixture.appCatalog(recorder: recorder),
-            layers: [PatchFile(entries: entries)]))
+            layers: [PatchFile(entries: entries)],
+            parent: process.context))
         #expect(await booted.tree.mountedEntryIDs.count == entries.count)
         try await ProfileBootFixture.assertRequiredServices(in: booted.context)
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.agentProvider))
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.extraction))
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.queue))
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.transport))
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.renderer))
         let store = try #require(try await booted.context.find(StoreServiceKeys.store))
         let page = try store.createPage(title: "Committed app profile page")
 
@@ -57,6 +68,9 @@ struct AppProfileBootTests {
         #expect(await recorder.events.count == countAfterDisposal)
 
         try await booted.shutdown()
+        #expect(await processDisposals.count == 0)
+        try await process.shutdown()
+        #expect(await processDisposals.count == 3)
     }
 }
 #endif

--- a/Tests/WikiFSTests/AppProfileBootTests.swift
+++ b/Tests/WikiFSTests/AppProfileBootTests.swift
@@ -54,7 +54,7 @@ struct AppProfileBootTests {
 
     @Test("per-wiki facade boots from child and process profile services")
     @MainActor
-    func profileWikiSessionCoversSessionSurface() async throws {
+    func profileProfileWikiSessionCoversSessionSurface() async throws {
         let directory = try ProfileBootFixture.directory(named: "profile-wiki-session")
         defer {
             do {

--- a/Tests/WikiFSTests/AppProfileBootTests.swift
+++ b/Tests/WikiFSTests/AppProfileBootTests.swift
@@ -7,6 +7,50 @@ import Testing
 
 @Suite("App profile boot", .serialized, .timeLimit(.minutes(1)))
 struct AppProfileBootTests {
+    @Test("process owner exposes readiness, services, and shutdown")
+    @MainActor
+    func processOwnerReadinessAndShutdown() async throws {
+        let disposals = ProfileProcessDisposalRecorder()
+        let gate = ProfileBootGate()
+        let owner = AppProcessProfileOwner {
+            await gate.wait()
+            return try await CordisBoot.boot(.init(
+                catalog: try ProfileBootFixture.processCatalog(includeAppServices: true, recorder: disposals),
+                layers: [PatchFile(entries: ProfileBootFixture.processEntries(includeAppServices: true))]))
+        }
+
+        #expect(owner.readiness == .idle)
+        owner.start()
+        #expect(owner.readiness == .loading)
+        await gate.open()
+        await owner.awaitSettled()
+        #expect(owner.readiness == .ready)
+        #expect(owner.profile != nil)
+        #expect(owner.services != nil)
+
+        await owner.shutdown()
+        #expect(owner.profile == nil)
+        #expect(owner.services == nil)
+        #expect(await disposals.count == 3)
+        await owner.shutdown()
+        #expect(await disposals.count == 3)
+    }
+
+    @Test("process owner reports boot failure")
+    @MainActor
+    func processOwnerReportsFailure() async {
+        let owner = AppProcessProfileOwner {
+            throw ProfileBootFailure.expected
+        }
+        owner.start()
+        await owner.awaitSettled()
+        guard case .failed(let message) = owner.readiness else {
+            Issue.record("expected failed readiness")
+            return
+        }
+        #expect(message.contains("expected"))
+    }
+
     @Test("production-shaped app profile activates services and owns store listener")
     func appProfileActivatesServicesAndOwnsStoreListener() async throws {
         let directory = try ProfileBootFixture.directory(named: "app-profile")

--- a/Tests/WikiFSTests/AppProfileBootTests.swift
+++ b/Tests/WikiFSTests/AppProfileBootTests.swift
@@ -3,6 +3,7 @@ import Cordis
 import CordisLoader
 import Foundation
 import Testing
+import WikiFSCore
 @testable import WikiFSEngine
 
 @Suite("App profile boot", .serialized, .timeLimit(.minutes(1)))
@@ -49,6 +50,64 @@ struct AppProfileBootTests {
             return
         }
         #expect(message.contains("expected"))
+    }
+
+    @Test("per-wiki facade boots from child and process profile services")
+    @MainActor
+    func profileWikiSessionCoversSessionSurface() async throws {
+        let directory = try ProfileBootFixture.directory(named: "profile-wiki-session")
+        defer {
+            do {
+                try FileManager.default.removeItem(at: directory)
+            } catch {
+                Issue.record("could not remove profile wiki session fixture: \(error)")
+            }
+        }
+        let disposals = ProfileProcessDisposalRecorder()
+        let process = try await CordisBoot.boot(.init(
+            catalog: try ProfileBootFixture.processCatalog(includeAppServices: true, recorder: disposals),
+            layers: [PatchFile(entries: ProfileBootFixture.processEntries(includeAppServices: true))]))
+        let processServices = try await AppProcessServices.resolve(from: process)
+        let wikiID = WikiID(rawValue: "profile-wiki-session")
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let descriptor = WikiDescriptor(
+            id: wikiID,
+            displayName: "Profile Wiki",
+            createdAt: timestamp,
+            lastUsedAt: timestamp)
+        let facade = try await ProfileWikiSession.boot(
+            wikiID: wikiID,
+            descriptor: descriptor,
+            containerDirectory: directory,
+            catalog: try ProfileBootFixture.appCatalog(),
+            processProfile: process,
+            processServices: processServices,
+            extractionProvider: ProfileBootFixture.extractionProvider())
+
+        #expect(facade.wikiID == wikiID)
+        #expect(facade.descriptor.displayName == "Profile Wiki")
+        #expect(facade.store.readPool != nil)
+        #expect(facade.descriptor.homePageID != nil)
+        let renamed = WikiDescriptor(
+            id: wikiID,
+            displayName: "Renamed Profile Wiki",
+            createdAt: timestamp,
+            lastUsedAt: timestamp)
+        facade.updateDescriptor(renamed)
+        #expect(facade.descriptor.displayName == "Renamed Profile Wiki")
+        let link = try #require(URL(string: "wiki://profile-wiki-session/Home"))
+        facade.pendingWikiLink = (link, true)
+        #expect(facade.pendingWikiLink?.url == link)
+        #expect(facade.pendingWikiLink?.openInNewTab == true)
+        facade.previewBlobVacuum()
+        #expect(facade.pendingBlobVacuum != nil)
+        facade.applyBlobVacuum()
+        #expect(facade.pendingBlobVacuum == nil)
+
+        await facade.shutdown()
+        #expect(await disposals.count == 0)
+        try await process.shutdown()
+        #expect(await disposals.count == 3)
     }
 
     @Test("production-shaped app profile activates services and owns store listener")

--- a/Tests/WikiFSTests/AppProfileBootTests.swift
+++ b/Tests/WikiFSTests/AppProfileBootTests.swift
@@ -26,7 +26,7 @@ struct AppProfileBootTests {
             id: ProfileBootFixture.listenerEntryID,
             plugin: ProfileBootFixture.listenerPluginID))
         let booted = try await CordisBoot.boot(.init(
-            catalog: try ProfileBootFixture.catalog(recorder: recorder),
+            catalog: try ProfileBootFixture.appCatalog(recorder: recorder),
             layers: [PatchFile(entries: entries)]))
         #expect(await booted.tree.mountedEntryIDs.count == entries.count)
         try await ProfileBootFixture.assertRequiredServices(in: booted.context)

--- a/Tests/WikiFSTests/CordisBootIntegrationTests.swift
+++ b/Tests/WikiFSTests/CordisBootIntegrationTests.swift
@@ -30,10 +30,10 @@ struct CordisBootIntegrationTests {
             ])
 
         let first = try await CordisBoot.boot(.init(
-            catalog: try ProfileBootFixture.catalog(),
+            catalog: try ProfileBootFixture.daemonCatalog(),
             layers: [PatchFile(entries: firstEntries)]))
         let second = try await CordisBoot.boot(.init(
-            catalog: try ProfileBootFixture.catalog(),
+            catalog: try ProfileBootFixture.daemonCatalog(),
             layers: [PatchFile(entries: secondEntries)]))
         let firstStore = try #require(try await first.context.find(StoreServiceKeys.store))
         let secondStore = try #require(try await second.context.find(StoreServiceKeys.store))

--- a/Tests/WikiFSTests/DaemonProfileBootTests.swift
+++ b/Tests/WikiFSTests/DaemonProfileBootTests.swift
@@ -2,6 +2,7 @@
 import CordisLoader
 import Foundation
 import Testing
+import WikiFSCore
 @testable import WikiFSEngine
 
 @Suite("Daemon profile boot", .serialized, .timeLimit(.minutes(1)))
@@ -43,6 +44,48 @@ struct DaemonProfileBootTests {
         try await booted.shutdown()
         #expect(await processDisposals.count == 0)
         try await process.shutdown()
+        #expect(await processDisposals.count == 2)
+    }
+
+    @Test("daemon owner retains process and one child per wiki, then shuts down once")
+    func daemonOwnerCachesProfilesAndDisposesIdempotently() async throws {
+        let directory = try ProfileBootFixture.directory(named: "daemon-owner")
+        defer {
+            do { try FileManager.default.removeItem(at: directory) }
+            catch { Issue.record("could not remove daemon owner fixture: \(error)") }
+        }
+        let wikiID = WikiID(rawValue: "daemon-owner-wiki")
+        let processDisposals = ProfileProcessDisposalRecorder()
+        let processCatalog = try ProfileBootFixture.processCatalog(
+            includeAppServices: false,
+            recorder: processDisposals)
+        let daemonCatalog = try ProfileBootFixture.daemonCatalog()
+        let owner = DaemonProcessProfileOwner(
+            boot: {
+                try await CordisBoot.boot(.init(
+                    catalog: processCatalog,
+                    layers: [PatchFile(entries: ProfileBootFixture.processEntries(includeAppServices: false))]))
+            },
+            bootWiki: { requestedWikiID, process in
+                let entries = ProfileBootFixture.entries(
+                    databaseURL: directory.appendingPathComponent("\(requestedWikiID.rawValue).sqlite"),
+                    wikiID: requestedWikiID.rawValue,
+                    includeAppProviders: false)
+                return try await CordisBoot.boot(.init(
+                    catalog: daemonCatalog,
+                    layers: [PatchFile(entries: entries)],
+                    parent: process.context))
+            })
+
+        let firstProcess = try await owner.start()
+        let secondProcess = try await owner.services()
+        #expect(ObjectIdentifier(firstProcess.agentProvider as AnyObject) == ObjectIdentifier(secondProcess.agentProvider as AnyObject))
+        let firstWiki = try await owner.wiki(wikiID: wikiID)
+        let secondWiki = try await owner.wiki(wikiID: wikiID)
+        #expect(ObjectIdentifier(firstWiki.store as AnyObject) == ObjectIdentifier(secondWiki.store as AnyObject))
+
+        await owner.shutdown()
+        await owner.shutdown()
         #expect(await processDisposals.count == 2)
     }
 }

--- a/Tests/WikiFSTests/DaemonProfileBootTests.swift
+++ b/Tests/WikiFSTests/DaemonProfileBootTests.swift
@@ -21,7 +21,7 @@ struct DaemonProfileBootTests {
             wikiID: "daemon-profile-test",
             includeAppProviders: false)
         let booted = try await CordisBoot.boot(.init(
-            catalog: try ProfileBootFixture.catalog(),
+            catalog: try ProfileBootFixture.daemonCatalog(),
             layers: [PatchFile(entries: entries)]))
 
         #expect(await booted.tree.mountedEntryIDs.count == entries.count)
@@ -30,6 +30,7 @@ struct DaemonProfileBootTests {
         let transport = try #require(try await booted.context.find(TransportServiceKeys.transport))
         #expect(await renderers.providerIDs().isEmpty)
         #expect(await transport.providerIDs().isEmpty)
+        _ = try ProfileBootFixture.cliCatalog()
 
         try await booted.shutdown()
     }

--- a/Tests/WikiFSTests/DaemonProfileBootTests.swift
+++ b/Tests/WikiFSTests/DaemonProfileBootTests.swift
@@ -20,12 +20,20 @@ struct DaemonProfileBootTests {
             databaseURL: directory.appendingPathComponent("wiki.sqlite"),
             wikiID: "daemon-profile-test",
             includeAppProviders: false)
+        let processDisposals = ProfileProcessDisposalRecorder()
+        let processEntries = ProfileBootFixture.processEntries(includeAppServices: false)
+        let process = try await CordisBoot.boot(.init(
+            catalog: try ProfileBootFixture.processCatalog(includeAppServices: false, recorder: processDisposals),
+            layers: [PatchFile(entries: processEntries)]))
         let booted = try await CordisBoot.boot(.init(
             catalog: try ProfileBootFixture.daemonCatalog(),
-            layers: [PatchFile(entries: entries)]))
+            layers: [PatchFile(entries: entries)],
+            parent: process.context))
 
         #expect(await booted.tree.mountedEntryIDs.count == entries.count)
         try await ProfileBootFixture.assertRequiredServices(in: booted.context)
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.agentProvider))
+        _ = try #require(try await booted.context.find(ProcessServiceKeys.extraction))
         let renderers = try #require(try await booted.context.find(RendererServiceKeys.renderers))
         let transport = try #require(try await booted.context.find(TransportServiceKeys.transport))
         #expect(await renderers.providerIDs().isEmpty)
@@ -33,6 +41,9 @@ struct DaemonProfileBootTests {
         _ = try ProfileBootFixture.cliCatalog()
 
         try await booted.shutdown()
+        #expect(await processDisposals.count == 0)
+        try await process.shutdown()
+        #expect(await processDisposals.count == 2)
     }
 }
 #endif

--- a/Tests/WikiFSTests/DaemonTransportBoundaryPolicyTests.swift
+++ b/Tests/WikiFSTests/DaemonTransportBoundaryPolicyTests.swift
@@ -16,7 +16,7 @@ struct DaemonTransportBoundaryPolicyTests {
         let forbidden = [
             "WikiDaemonConnection", "NSXPCConnection", "WikiDaemonProtocol",
             "WikiDaemonEventSink", "DaemonWorkloadClient", "XPCQueueEngineProxy",
-            "QueueStore", "WikiStore", "WikiStoreModel", "WikiSession", "SessionManager",
+            "QueueStore", "WikiStore", "WikiStoreModel", "ProfileWikiSession", "SessionManager",
             "SwiftUI", "AppKit",
         ]
         for path in paths {

--- a/Tests/WikiFSTests/DaemonTransportBoundaryPolicyTests.swift
+++ b/Tests/WikiFSTests/DaemonTransportBoundaryPolicyTests.swift
@@ -11,7 +11,7 @@ struct DaemonTransportBoundaryPolicyTests {
         let paths = [
             "Sources/WikiFSEngine/DaemonTransportRuntime.swift",
             "Sources/WikiFSEngine/DaemonTransportCompositionOwner.swift",
-            "Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift",
+            "Sources/WikiFSEngine/DaemonTransportRuntimeFactory.swift",
         ]
         let forbidden = [
             "WikiDaemonConnection", "NSXPCConnection", "WikiDaemonProtocol",

--- a/Tests/WikiFSTests/DaemonTransportRuntimeAssemblyTests.swift
+++ b/Tests/WikiFSTests/DaemonTransportRuntimeAssemblyTests.swift
@@ -225,7 +225,7 @@ struct DaemonTransportRuntimeAssemblyTests {
         ] { #expect(assemblySource.contains(label)) }
         for forbidden in [
             "SwiftUI", "DaemonHealthMonitor", "QueueEngineHotSwap", "LocalQueueRuntimeController",
-            "QueueStore", "WikiStore", "WikiStoreModel", "WikiSession", "SessionManager",
+            "QueueStore", "WikiStore", "WikiStoreModel", "ProfileWikiSession", "SessionManager",
             "ChatDaemonCoordinator", "WikiDaemonProtocol", "WikiDaemonEventSink",
             "WikiDaemonConnection", "NSXPCConnection",
         ] { #expect(!assemblySource.contains(forbidden)) }

--- a/Tests/WikiFSTests/DaemonTransportRuntimeFactoryTests.swift
+++ b/Tests/WikiFSTests/DaemonTransportRuntimeFactoryTests.swift
@@ -4,29 +4,29 @@ import Testing
 @testable import WikiFSEngine
 
 @Suite("Cordis daemon transport runtime", .serialized, .timeLimit(.minutes(1)))
-struct DaemonTransportRuntimeAssemblyTests {
+struct DaemonTransportRuntimeFactoryTests {
     @Test("shuffled registration builds ready transport services")
     func shuffledRegistrationBuildsReadyTransportServices() async throws {
         let factory = FakeTransportFactory()
         let handle = try await assembly(factory).assemble(
-            registrationOrder: DaemonTransportRuntimeAssembly.Component.allCases.shuffled())
+            registrationOrder: DaemonTransportRuntimeFactory.Component.allCases.shuffled())
         #expect(await handle.services.availability() == .idle)
         try await handle.dispose()
     }
 
     @Test("missing registration fails with typed component error")
     func missingRegistrationFailsWithTypedComponentError() async throws {
-        let order = DaemonTransportRuntimeAssembly.Component.allCases.filter { $0 != .configuration }
+        let order = DaemonTransportRuntimeFactory.Component.allCases.filter { $0 != .configuration }
         let factory = FakeTransportFactory()
         do {
             _ = try await assembly(factory).assemble(registrationOrder: order)
             Issue.record("Expected assembly failure")
         } catch {
-            guard case .activationFailed(let component, _) = error as? DaemonTransportRuntimeAssemblyError else {
+            guard case .activationFailed(let component, _) = error as? DaemonTransportRuntimeFactoryError else {
                 Issue.record("Expected typed component failure, got \(error)")
                 return
             }
-            #expect(component == DaemonTransportRuntimeAssembly.Component.configuration.rawValue)
+            #expect(component == DaemonTransportRuntimeFactory.Component.configuration.rawValue)
         }
     }
 
@@ -146,7 +146,7 @@ struct DaemonTransportRuntimeAssemblyTests {
     @Test("acceptance deadline expires candidate and retries")
     func acceptanceDeadlineExpiresCandidateAndRetries() async throws {
         let factory = FakeTransportFactory()
-        let handle = try await DaemonTransportRuntimeAssembly(
+        let handle = try await DaemonTransportRuntimeFactory(
             connectionFactory: factory.factory,
             configuration: .init(
                 retryInterval: .seconds(3_600),
@@ -174,7 +174,7 @@ struct DaemonTransportRuntimeAssemblyTests {
     func shutdownRejectsLateProbeOrCandidateResult() async throws {
         let gate = ProbeGate()
         let factory = GatedTransportFactory(gate: gate)
-        let handle = try await DaemonTransportRuntimeAssembly(
+        let handle = try await DaemonTransportRuntimeFactory(
             connectionFactory: factory.factory,
             configuration: .init(
                 retryInterval: .seconds(3_600),
@@ -215,7 +215,7 @@ struct DaemonTransportRuntimeAssemblyTests {
     func transportAssemblyStaysOutsideUIQueuePersistenceAndWireBoundaries() throws {
         let root = repositoryRoot()
         let assemblySource = try String(
-            contentsOf: root.appendingPathComponent("Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift"),
+            contentsOf: root.appendingPathComponent("Sources/WikiFSEngine/DaemonTransportRuntimeFactory.swift"),
             encoding: .utf8)
         for label in [
             "daemon-transport.connection-factory",
@@ -231,8 +231,8 @@ struct DaemonTransportRuntimeAssemblyTests {
         ] { #expect(!assemblySource.contains(forbidden)) }
     }
 
-    private func assembly(_ factory: FakeTransportFactory) -> DaemonTransportRuntimeAssembly {
-        DaemonTransportRuntimeAssembly(
+    private func assembly(_ factory: FakeTransportFactory) -> DaemonTransportRuntimeFactory {
+        DaemonTransportRuntimeFactory(
             connectionFactory: factory.factory,
             configuration: .init(
                 retryInterval: .zero,

--- a/Tests/WikiFSTests/ExtractionCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/ExtractionCompositionBoundaryTests.swift
@@ -20,7 +20,8 @@ struct ExtractionCompositionBoundaryTests {
         let source = try productionSource("Sources/wikid/WikiDaemon.swift")
 
         #expect(source.occurrences(of: "ExtractionCompositionOwner(") == 1)
-        #expect(source.contains("let extractionServices = extractionCompositionOwner.services"))
+        #expect(source.contains("let runtime = try await runtimeServices()"))
+        #expect(source.contains("let extractionServices = runtime.extraction"))
         #expect(source.contains("extractionServices: extractionServices"))
         #expect(source.contains("ExtractionCoordinator(services: extractionServices)"))
         #expect(!source.contains("ExtractionCoordinator(\n                containerDirectory:"))
@@ -55,8 +56,8 @@ struct ExtractionCompositionBoundaryTests {
         #expect(appQueue.lowerBound < appExtraction.lowerBound)
 
         let daemonQueue = try #require(daemon.range(of: "daemonQueueHost.relinquish"))
-        let daemonExtraction = try #require(daemon.range(of: "extractionCompositionOwner.shutdown()"))
-        #expect(daemonQueue.lowerBound < daemonExtraction.lowerBound)
+        let daemonProfile = try #require(daemon.range(of: "profileOwner.shutdown()"))
+        #expect(daemonQueue.lowerBound < daemonProfile.lowerBound)
     }
 }
 

--- a/Tests/WikiFSTests/ExtractionCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/ExtractionCompositionBoundaryTests.swift
@@ -14,7 +14,7 @@ struct ExtractionCompositionBoundaryTests {
         #expect(app.contains("let extractionServices = processComposition.extractionServices"))
         #expect(app.contains("ExtractionCoordinator(services: extractionServices)"))
         #expect(app.contains("extractionServices: extractionServices"))
-        #expect(!app.contains("ExtractionRuntimeAssembly("))
+        #expect(!app.contains("ExtractionRuntimeFactory("))
         #expect(!app.contains("ExtractionCoordinator(\n            containerDirectory:"))
     }
 

--- a/Tests/WikiFSTests/ExtractionCompositionBoundaryTests.swift
+++ b/Tests/WikiFSTests/ExtractionCompositionBoundaryTests.swift
@@ -6,13 +6,16 @@ import Testing
 struct ExtractionCompositionBoundaryTests {
     @Test("app creates one facade before queue and session composition")
     func appUsesOneExtractionFacade() throws {
-        let source = try productionSource("Sources/WikiFS/Window/WikiFSApp.swift")
+        let app = try productionSource("Sources/WikiFS/Window/WikiFSApp.swift")
+        let composition = try productionSource("Sources/WikiFS/Renderer/RendererCompositionOwner.swift")
 
-        #expect(source.occurrences(of: "let extractionOwner = ExtractionCompositionOwner") == 1)
-        #expect(source.contains("let extractionServices = extractionOwner.services"))
-        #expect(source.contains("ExtractionCoordinator(services: extractionServices)"))
-        #expect(source.contains("extractionServices: extractionServices"))
-        #expect(!source.contains("ExtractionCoordinator(\n            containerDirectory:"))
+        #expect(composition.occurrences(of: "let extractionServices = MutableExtractionServices()") == 1)
+        #expect(composition.occurrences(of: "ExtractionCompositionOwner(services: extractionServices)") == 1)
+        #expect(app.contains("let extractionServices = processComposition.extractionServices"))
+        #expect(app.contains("ExtractionCoordinator(services: extractionServices)"))
+        #expect(app.contains("extractionServices: extractionServices"))
+        #expect(!app.contains("ExtractionRuntimeAssembly("))
+        #expect(!app.contains("ExtractionCoordinator(\n            containerDirectory:"))
     }
 
     @Test("daemon creates one facade for queue, ingestion, and chat")
@@ -49,11 +52,14 @@ struct ExtractionCompositionBoundaryTests {
     @Test("shutdown order stops queue before extraction disposal")
     func shutdownOrderIsExplicit() throws {
         let app = try productionSource("Sources/WikiFS/Window/WikiFSApp.swift")
+        let composition = try productionSource("Sources/WikiFS/Renderer/RendererCompositionOwner.swift")
         let daemon = try productionSource("Sources/wikid/WikiDaemon.swift")
 
-        let appQueue = try #require(app.range(of: "await localQueueRuntimeController.dispose()"))
-        let appExtraction = try #require(app.range(of: "await extractionCompositionOwner.shutdown()"))
-        #expect(appQueue.lowerBound < appExtraction.lowerBound)
+        #expect(app.contains("await processProfileOwner.shutdown()"))
+        #expect(!app.contains("localQueueRuntimeController.dispose()"))
+        #expect(!app.contains("extractionCompositionOwner.shutdown()"))
+        #expect(composition.contains("_ = await queueController.dispose()"))
+        #expect(composition.contains("await owner.shutdown()"))
 
         let daemonQueue = try #require(daemon.range(of: "daemonQueueHost.relinquish"))
         let daemonProfile = try #require(daemon.range(of: "profileOwner.shutdown()"))

--- a/Tests/WikiFSTests/ExtractionRuntimeAssemblyTests.swift
+++ b/Tests/WikiFSTests/ExtractionRuntimeAssemblyTests.swift
@@ -112,7 +112,7 @@ struct ExtractionRuntimeAssemblyTests {
             "extraction.services",
         ]
         let forbidden = [
-            "SwiftUI", "AppKit", "WebKit", "WikiStoreModel", "WikiSession",
+            "SwiftUI", "AppKit", "WebKit", "WikiStoreModel", "ProfileWikiSession",
             "SessionManager", "QueueStore", "NSXPCConnection",
         ]
 

--- a/Tests/WikiFSTests/ExtractionRuntimeFactoryTests.swift
+++ b/Tests/WikiFSTests/ExtractionRuntimeFactoryTests.swift
@@ -6,11 +6,11 @@ import Testing
 @testable import WikiFSEngine
 
 @Suite("Cordis extraction runtime assembly", .serialized, .timeLimit(.minutes(1)))
-struct ExtractionRuntimeAssemblyTests {
+struct ExtractionRuntimeFactoryTests {
     @Test("shuffled registration builds a ready runtime")
     func shuffledRegistrationBuildsReadyRuntime() async throws {
         let handle = try await makeAssembly().assemble(
-            registrationOrder: ExtractionRuntimeAssembly.Component.allCases.shuffled())
+            registrationOrder: ExtractionRuntimeFactory.Component.allCases.shuffled())
         let preparation = try await handle.services.prepare()
 
         #expect(preparation.backend == .localPdf2md)
@@ -20,7 +20,7 @@ struct ExtractionRuntimeAssemblyTests {
 
     @Test("missing registration fails with a typed component error")
     func missingRegistrationFailsTyped() async throws {
-        let incomplete = ExtractionRuntimeAssembly.Component.allCases.filter {
+        let incomplete = ExtractionRuntimeFactory.Component.allCases.filter {
             $0 != .credentialReader
         }
 
@@ -28,11 +28,11 @@ struct ExtractionRuntimeAssemblyTests {
             _ = try await makeAssembly().assemble(registrationOrder: incomplete)
             Issue.record("Expected extraction runtime assembly to fail")
         } catch {
-            guard case .activationFailed(let component, _) = error as? ExtractionRuntimeAssemblyError else {
+            guard case .activationFailed(let component, _) = error as? ExtractionRuntimeFactoryError else {
                 Issue.record("Expected a typed extraction activation failure, got \(error)")
                 return
             }
-            #expect(component == ExtractionRuntimeAssembly.Component.credentialReader.rawValue)
+            #expect(component == ExtractionRuntimeFactory.Component.credentialReader.rawValue)
         }
     }
 
@@ -99,7 +99,7 @@ struct ExtractionRuntimeAssemblyTests {
     func serviceLabelsAreComplete() throws {
         let source = try String(
             contentsOf: repositoryRoot()
-                .appendingPathComponent("Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift"),
+                .appendingPathComponent("Sources/WikiFSEngine/ExtractionRuntimeFactory.swift"),
             encoding: .utf8)
         let labels = [
             "extraction.configuration-reader",
@@ -123,8 +123,8 @@ struct ExtractionRuntimeAssemblyTests {
     private func makeAssembly(
         state: ExtractionRuntimeTestState = ExtractionRuntimeTestState(
             configuration: ExtractionConfig())
-    ) -> ExtractionRuntimeAssembly {
-        ExtractionRuntimeAssembly(
+    ) -> ExtractionRuntimeFactory {
+        ExtractionRuntimeFactory(
             readConfiguration: { state.configuration },
             readCredential: { _ in "test-secret" },
             resolveACP: { _ in nil },

--- a/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
+++ b/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
@@ -391,6 +391,7 @@ struct IdentifierBoundaryTypecheckTests {
             buildProducts.debugDirectory.appendingPathComponent("TantivySwift.build/include"),
             root.appendingPathComponent("Sources/CSQLite"),
             root.appendingPathComponent(".build/checkouts/GRDB.swift/Sources/GRDBSQLite"),
+            root.appendingPathComponent(".build/checkouts/Yams/Sources/CYaml/include"),
             root.appendingPathComponent(".build/artifacts/tantivy.swift/TantivyRS/libtantivy-rs.xcframework/macos-arm64_x86_64/Headers"),
             root.appendingPathComponent(".build/artifacts/tantivy.swift/TantivyRS/libtantivy-rs.xcframework/linux-x86_64/Headers"),
         ]

--- a/Tests/WikiFSTests/ProfileBootFixture.swift
+++ b/Tests/WikiFSTests/ProfileBootFixture.swift
@@ -17,12 +17,24 @@ enum ProfileBootFixture {
         return url
     }
 
-    static func catalog(recorder: ProfileStoreEventRecorder? = nil) throws -> PluginCatalog {
-        var definitions = fixtureDefinitions
-        if let recorder {
-            definitions.append(listenerDefinition(recorder: recorder))
-        }
-        return try PluginCatalog(definitions)
+    static func appCatalog(recorder: ProfileStoreEventRecorder? = nil) throws -> PluginCatalog {
+        let additionalDefinitions = recorder.map { [listenerDefinition(recorder: $0)] } ?? []
+        return try AppPluginCatalog.build(
+            factories: AppPluginCatalogFactories(
+                base: baseFactories,
+                makeRendererServices: { ProfileRendererServices() },
+                makeDefuddleExtractor: { ProfileHTMLExtractor() },
+                makeDaemonTransport: { fixtureTransportServices() },
+                makeURLFetcher: { ProfileIntegrationEntryPoint() }),
+            additionalDefinitions: additionalDefinitions)
+    }
+
+    static func daemonCatalog() throws -> PluginCatalog {
+        try DaemonPluginCatalog.build(factories: DaemonPluginCatalogFactories(base: baseFactories))
+    }
+
+    static func cliCatalog() throws -> PluginCatalog {
+        try CLIPluginCatalog.build()
     }
 
     static func entries(databaseURL: URL, wikiID: String, includeAppProviders: Bool) -> [Entry] {
@@ -66,31 +78,13 @@ enum ProfileBootFixture {
         _ = try #require(try await context.find(IntegrationServiceKeys.capabilities))
     }
 
-    private static var fixtureDefinitions: [PluginDefinition] {
-        [
-            StorePlugin.definition,
-            SessionsPlugin.definition,
-            ChatsPersistencePlugin.definition,
-            LlmRuntimePlugin.definition,
-            ACPModelAdapterPlugin.definition(services: UnavailableAgentProviderServices()),
-            ToolsPlugin.definition,
-            NoOpToolPlugin.definition,
-            SystemPromptPlugin.definition,
-            AgentLoopPlugin.definition,
-            ExtractionPlugin.definition,
-            Pdf2mdExtractionPlugin.definition { ProfilePDFExtractor() },
-            SearchPlugin.definition,
-            EmbeddingsSearchPlugin.definition(
-                configure: {},
-                selectedIdentifier: { "fixture-embedding" },
-                isAvailable: { false }),
-            RenderersPlugin.definition,
-            RendererServicesPlugin.definition { ProfileRendererServices() },
-            TransportPlugin.definition,
-            DaemonTransportPlugin.definition { fixtureTransportServices() },
-            IntegrationsPlugin.definition,
-            URLFetchIntegrationPlugin.definition { ProfileIntegrationEntryPoint() },
-        ]
+    private static var baseFactories: BasePluginCatalogFactories {
+        BasePluginCatalogFactories(
+            agentProviderServices: UnavailableAgentProviderServices(),
+            makePDFExtractor: { ProfilePDFExtractor() },
+            configureEmbeddings: {},
+            selectedEmbeddingIdentifier: { "fixture-embedding" },
+            embeddingsAvailable: { false })
     }
 
     private static func listenerDefinition(recorder: ProfileStoreEventRecorder) -> PluginDefinition {
@@ -130,6 +124,12 @@ private struct ProfilePDFExtractor: MarkdownExtractor {
         filename: String,
         onProgress: (@Sendable (String) -> Void)?
     ) async throws -> String { "fixture" }
+}
+
+private struct ProfileHTMLExtractor: HtmlMarkdownExtractor {
+    func extract(html: String) async -> HtmlExtractionResult? {
+        HtmlExtractionResult(markdown: "fixture", title: nil)
+    }
 }
 
 private struct ProfileRendererServices: Sendable {}

--- a/Tests/WikiFSTests/ProfileBootFixture.swift
+++ b/Tests/WikiFSTests/ProfileBootFixture.swift
@@ -67,6 +67,10 @@ enum ProfileBootFixture {
         try CLIPluginCatalog.build()
     }
 
+    static func extractionProvider() -> any QueueExtractionProvider {
+        ProfileQueueExtractionProvider()
+    }
+
     static func entries(databaseURL: URL, wikiID: String, includeAppProviders: Bool) -> [Entry] {
         var rows = [
             Entry(id: EntryID("store"), plugin: StorePlugin.id, config: [

--- a/Tests/WikiFSTests/ProfileBootFixture.swift
+++ b/Tests/WikiFSTests/ProfileBootFixture.swift
@@ -33,6 +33,36 @@ enum ProfileBootFixture {
         try DaemonPluginCatalog.build(factories: DaemonPluginCatalogFactories(base: baseFactories))
     }
 
+    static func processCatalog(includeAppServices: Bool, recorder: ProfileProcessDisposalRecorder) throws -> PluginCatalog {
+        let queueFactory: ProcessPluginCatalogFactories.QueueFactory? = includeAppServices ? { @Sendable in
+            let engine = try makeProfileQueueEngine()
+            return ProcessRuntimeLease<any QueueEngineClient>(service: engine) {
+                _ = await engine.shutdownForHandoff()
+            }
+        } : nil
+        let transportFactory: ProcessPluginCatalogFactories.TransportFactory? = includeAppServices ? { @Sendable in
+            let services = fixtureTransportServices()
+            return ProcessRuntimeLease(service: services) { await services.stop() }
+        } : nil
+        let rendererFactory: ProcessPluginCatalogFactories.RendererFactory? = includeAppServices ? { @Sendable in
+            ProcessRuntimeLease<any Sendable>(service: ProfileRendererServices()) { await recorder.record() }
+        } : nil
+        return try ProcessPluginCatalog.build(factories: ProcessPluginCatalogFactories(
+            makeAgentProvider: {
+                ProcessRuntimeLease(service: UnavailableAgentProviderServices()) { await recorder.record() }
+            },
+            makeExtraction: {
+                ProcessRuntimeLease(service: UnavailableExtractionServices()) { await recorder.record() }
+            },
+            makeQueue: queueFactory,
+            makeTransport: transportFactory,
+            makeRenderer: rendererFactory))
+    }
+
+    static func processEntries(includeAppServices: Bool) -> [Entry] {
+        includeAppServices ? ProductionProfileEntries.appProcess() : ProductionProfileEntries.daemonProcess()
+    }
+
     static func cliCatalog() throws -> PluginCatalog {
         try CLIPluginCatalog.build()
     }
@@ -106,6 +136,11 @@ enum ProfileBootFixture {
     }
 }
 
+actor ProfileProcessDisposalRecorder {
+    private(set) var count = 0
+    func record() { count += 1 }
+}
+
 actor ProfileStoreEventRecorder {
     private(set) var events: [ResourceChangeEvent] = []
     private(set) var observedCommittedState = false
@@ -134,6 +169,31 @@ private struct ProfileHTMLExtractor: HtmlMarkdownExtractor {
 
 private struct ProfileRendererServices: Sendable {}
 private struct ProfileIntegrationEntryPoint: Sendable {}
+
+private func makeProfileQueueEngine() throws -> QueueEngine {
+    let store = try QueueStore(databaseURL: URL(fileURLWithPath: ":memory:"))
+    let factory = QueueExtractionWorkerFactory(
+        provider: ProfileQueueExtractionProvider(),
+        emitProgress: { _, _ in })
+    return QueueEngine(store: store, workerFactory: factory)
+}
+
+private struct ProfileQueueExtractionProvider: QueueExtractionProvider {
+    func resolveExtraction(
+        wikiID: WikiID,
+        sourceID: SourceID,
+        backendOverride: ExtractionBackend?
+    ) async throws -> ExtractionResolution? { nil }
+
+    func persistExtraction(
+        wikiID: WikiID,
+        sourceID: SourceID,
+        markdown: String,
+        backend: ExtractionBackend,
+        modelVersion: String?,
+        technique: String?
+    ) async throws {}
+}
 
 private func fixtureTransportServices() -> DaemonTransportServices {
     DaemonTransportServices(

--- a/Tests/WikiFSTests/ProfileBootFixture.swift
+++ b/Tests/WikiFSTests/ProfileBootFixture.swift
@@ -136,6 +136,24 @@ enum ProfileBootFixture {
     }
 }
 
+enum ProfileBootFailure: Error {
+    case expected
+}
+
+actor ProfileBootGate {
+    private var isOpen = false
+
+    func wait() async {
+        while !isOpen {
+            await Task.yield()
+        }
+    }
+
+    func open() {
+        isOpen = true
+    }
+}
+
 actor ProfileProcessDisposalRecorder {
     private(set) var count = 0
     func record() { count += 1 }

--- a/Tests/WikiFSTests/QueueAssemblyContractTests.swift
+++ b/Tests/WikiFSTests/QueueAssemblyContractTests.swift
@@ -77,8 +77,8 @@ struct QueueAssemblyContractTests {
             contentsOf: root.appendingPathComponent("Sources/wikid/WikiDaemon.swift"),
             encoding: .utf8)
 
-        #expect(!app.contains("QueueRuntimeAssembly("))
-        #expect(composition.contains("QueueRuntimeAssembly("))
+        #expect(!app.contains("QueueRuntimeFactory("))
+        #expect(composition.contains("QueueRuntimeFactory("))
         #expect(app.contains("let queueEngine = runtimeController.client"))
         #expect(!app.contains("QueueWorkerOutputChannel(store:"))
         #expect(daemon.contains("let outputChannel = QueueWorkerOutputChannel(store: queueStore)"))

--- a/Tests/WikiFSTests/QueueAssemblyContractTests.swift
+++ b/Tests/WikiFSTests/QueueAssemblyContractTests.swift
@@ -70,11 +70,16 @@ struct QueueAssemblyContractTests {
         let app = try String(
             contentsOf: root.appendingPathComponent("Sources/WikiFS/Window/WikiFSApp.swift"),
             encoding: .utf8)
+        let composition = try String(
+            contentsOf: root.appendingPathComponent("Sources/WikiFS/Renderer/RendererCompositionOwner.swift"),
+            encoding: .utf8)
         let daemon = try String(
             contentsOf: root.appendingPathComponent("Sources/wikid/WikiDaemon.swift"),
             encoding: .utf8)
 
-        #expect(app.contains("QueueRuntimeAssembly("))
+        #expect(!app.contains("QueueRuntimeAssembly("))
+        #expect(composition.contains("QueueRuntimeAssembly("))
+        #expect(app.contains("let queueEngine = runtimeController.client"))
         #expect(!app.contains("QueueWorkerOutputChannel(store:"))
         #expect(daemon.contains("let outputChannel = QueueWorkerOutputChannel(store: queueStore)"))
         #expect(daemon.contains("outputChannel: outputChannel"))

--- a/Tests/WikiFSTests/QueueRuntimeFactoryTests.swift
+++ b/Tests/WikiFSTests/QueueRuntimeFactoryTests.swift
@@ -5,7 +5,7 @@ import Testing
 @testable import WikiFSEngine
 
 @Suite("Cordis queue runtime assembly", .serialized, .timeLimit(.minutes(1)))
-struct QueueRuntimeAssemblyTests {
+struct QueueRuntimeFactoryTests {
     @Test("shuffled registration builds one ready runtime")
     func shuffledRegistrationBuildsOneRuntime() async throws {
         let directory = makeQueueRuntimeTempDirectory()
@@ -13,7 +13,7 @@ struct QueueRuntimeAssemblyTests {
             databaseURL: directory.appendingPathComponent("queue.sqlite"))
 
         let handle = try await assembly.assemble(
-            registrationOrder: QueueRuntimeAssembly.Component.allCases.shuffled())
+            registrationOrder: QueueRuntimeFactory.Component.allCases.shuffled())
 
         #expect(await handle.engine.lifecycle == .running)
         #expect(try await handle.dispose() == .shutDown)
@@ -54,7 +54,7 @@ struct QueueRuntimeAssemblyTests {
         let directory = makeQueueRuntimeTempDirectory()
         let storeBox = QueueRuntimeStoreBox()
         let expectedFailure = QueueRuntimeTestFailure.injected
-        let assembly = QueueRuntimeAssembly(
+        let assembly = QueueRuntimeFactory(
             databaseURL: directory.appendingPathComponent("queue.sqlite"),
             extractionProvider: QueueRuntimeExtractionProvider(),
             makeIngestionProvider: { store in
@@ -66,11 +66,11 @@ struct QueueRuntimeAssemblyTests {
             _ = try await assembly.assemble()
             Issue.record("Expected queue runtime assembly to fail")
         } catch {
-            guard case .activationFailed(let component, let failure) = error as? QueueRuntimeAssemblyError else {
+            guard case .activationFailed(let component, let failure) = error as? QueueRuntimeFactoryError else {
                 Issue.record("Expected a typed queue runtime activation failure, got \(error)")
                 return
             }
-            #expect(component == QueueRuntimeAssembly.Component.ingestionProvider.rawValue)
+            #expect(component == QueueRuntimeFactory.Component.ingestionProvider.rawValue)
             #expect(failure.message == String(describing: expectedFailure))
         }
 
@@ -99,7 +99,7 @@ struct QueueRuntimeAssemblyTests {
     func assemblyRegistersOnlyApprovedBoundaries() async throws {
         let source = try String(
             contentsOf: repositoryRoot()
-                .appendingPathComponent("Sources/WikiFSEngine/QueueRuntimeAssembly.swift"),
+                .appendingPathComponent("Sources/WikiFSEngine/QueueRuntimeFactory.swift"),
             encoding: .utf8)
         let requiredServices = [
             "queue.store",
@@ -127,8 +127,8 @@ struct QueueRuntimeAssemblyTests {
         }
     }
 
-    private func makeAssembly(databaseURL: URL) -> QueueRuntimeAssembly {
-        QueueRuntimeAssembly(
+    private func makeAssembly(databaseURL: URL) -> QueueRuntimeFactory {
+        QueueRuntimeFactory(
             databaseURL: databaseURL,
             extractionProvider: QueueRuntimeExtractionProvider(),
             makeIngestionProvider: { _ in QueueRuntimeIngestionProvider() })

--- a/Tests/WikiFSTests/RendererMachineEventDeliveryTests.swift
+++ b/Tests/WikiFSTests/RendererMachineEventDeliveryTests.swift
@@ -186,7 +186,7 @@ struct RendererEventWakeTests {
 @Suite(.serialized, .timeLimit(.minutes(1)))
 @MainActor
 struct RendererMachineEventFanOutTests {
-    @Test func machineEventRefreshesTwoLiveWikiSessions() async throws {
+    @Test func machineEventRefreshesTwoLiveProfileWikiSessions() async throws {
         let fixture = try await DeliveryFixture("fanout")
         try await fixture.journal.append(fixture.record(sequence: 1))
         let first = WikiStoreModel(store: try StoreBackend.current.makeStore(databaseURL: fixture.root.appendingPathComponent("first.sqlite")))

--- a/Tests/WikiFSTests/SearchCordisBoundaryPolicyTests.swift
+++ b/Tests/WikiFSTests/SearchCordisBoundaryPolicyTests.swift
@@ -6,7 +6,7 @@ struct SearchCordisBoundaryPolicyTests {
     @Test("consumers receive facade only")
     func consumersReceiveFacadeOnly() throws {
         for path in [
-            "Sources/WikiFSEngine/WikiSession.swift",
+            "Sources/WikiFSEngine/ProfileWikiSession.swift",
             "Sources/WikiFSEngine/SessionManager.swift",
             "Sources/WikiFSCore/Store/WikiStoreModel.swift",
             "Sources/WikiFS/Window/RootScene.swift",
@@ -32,7 +32,7 @@ struct SearchCordisBoundaryPolicyTests {
     @Test("production uses shared assembly and no legacy construction")
     func legacyConstructionDoesNotReturn() throws {
         let sources = try [
-            "Sources/WikiFSEngine/WikiSession.swift",
+            "Sources/WikiFSEngine/ProfileWikiSession.swift",
             "Sources/WikiCtlCore/CLITantivyLegResolver.swift",
         ].map(read).joined(separator: "\n")
         #expect(!sources.contains("TantivySearchService("))

--- a/Tests/WikiFSTests/SearchCordisBoundaryPolicyTests.swift
+++ b/Tests/WikiFSTests/SearchCordisBoundaryPolicyTests.swift
@@ -20,7 +20,7 @@ struct SearchCordisBoundaryPolicyTests {
 
     @Test("raw application state is not a search service")
     func rawApplicationStateIsNotAService() throws {
-        let assembly = try read("Sources/WikiFSEngine/SearchRuntimeAssembly.swift")
+        let assembly = try read("Sources/WikiFSEngine/SearchRuntimeCompositionFactory.swift")
         for forbidden in [
             "ServiceKey<WikiStore", "ServiceKey<WikiEventBus", "ServiceKey<SQLite",
             "ServiceKey<GRDB", "ServiceKey<WikiReadPool",
@@ -38,7 +38,7 @@ struct SearchCordisBoundaryPolicyTests {
         #expect(!sources.contains("TantivySearchService("))
         #expect(!sources.contains("TantivyIndexer("))
         #expect(!sources.contains("TantivyShadowSync"))
-        #expect(!sources.contains("SearchRuntimeAssembly"))
+        #expect(!sources.contains("SearchRuntimeCompositionFactory"))
     }
 
     @Test("search lifecycle has no detached tasks")

--- a/Tests/WikiFSTests/SearchCordisBoundaryPolicyTests.swift
+++ b/Tests/WikiFSTests/SearchCordisBoundaryPolicyTests.swift
@@ -38,7 +38,7 @@ struct SearchCordisBoundaryPolicyTests {
         #expect(!sources.contains("TantivySearchService("))
         #expect(!sources.contains("TantivyIndexer("))
         #expect(!sources.contains("TantivyShadowSync"))
-        #expect(sources.contains("SearchRuntimeAssembly"))
+        #expect(!sources.contains("SearchRuntimeAssembly"))
     }
 
     @Test("search lifecycle has no detached tasks")

--- a/Tests/WikiFSTests/SearchRuntimeCompositionFactoryTests.swift
+++ b/Tests/WikiFSTests/SearchRuntimeCompositionFactoryTests.swift
@@ -7,15 +7,15 @@ import Testing
 import WikiFSSearch
 
 @Suite("Cordis search runtime", .serialized, .timeLimit(.minutes(1)))
-struct SearchRuntimeAssemblyTests {
+struct SearchRuntimeCompositionFactoryTests {
     @Test("service labels are stable")
     func serviceLabelsAreStable() {
-        #expect(SearchRuntimeAssembly.ServiceLabels.identity == "search.identity")
-        #expect(SearchRuntimeAssembly.ServiceLabels.contentSource == "search.content-source")
-        #expect(SearchRuntimeAssembly.ServiceLabels.changeStreamFactory == "search.change-stream-factory")
-        #expect(SearchRuntimeAssembly.ServiceLabels.indexer == "search.indexer")
-        #expect(SearchRuntimeAssembly.ServiceLabels.runtime == "search.runtime")
-        #expect(SearchRuntimeAssembly.ServiceLabels.services == "search.services")
+        #expect(SearchRuntimeCompositionFactory.ServiceLabels.identity == "search.identity")
+        #expect(SearchRuntimeCompositionFactory.ServiceLabels.contentSource == "search.content-source")
+        #expect(SearchRuntimeCompositionFactory.ServiceLabels.changeStreamFactory == "search.change-stream-factory")
+        #expect(SearchRuntimeCompositionFactory.ServiceLabels.indexer == "search.indexer")
+        #expect(SearchRuntimeCompositionFactory.ServiceLabels.runtime == "search.runtime")
+        #expect(SearchRuntimeCompositionFactory.ServiceLabels.services == "search.services")
     }
 
     @Test("shuffled registration builds, rebuilds, and queries")
@@ -28,7 +28,7 @@ struct SearchRuntimeAssemblyTests {
         let child = try await root.child()
         let handle = try await fixture.assembly.assemble(
             in: child,
-            registrationOrder: SearchRuntimeAssembly.Component.allCases.shuffled())
+            registrationOrder: SearchRuntimeCompositionFactory.Component.allCases.shuffled())
 
         let results = try await handle.services.search(query: "private child", kinds: [.page], limit: 5)
         #expect(results.map(\.ulid) == ["page-1"])
@@ -116,14 +116,14 @@ struct SearchRuntimeAssemblyTests {
     @Test("invalid identity fails inside assembly")
     func invalidIdentityFailsInsideAssembly() async throws {
         let fixture = try Fixture()
-        let invalid = SearchRuntimeAssembly(
+        let invalid = SearchRuntimeCompositionFactory(
             identity: SearchRuntimeIdentity(wikiID: WikiID(rawValue: ""), containerDirectory: fixture.directory),
             contentSource: fixture.source,
             changeStreamFactory: FinishedSearchChangeStreamFactory())
         let root = CordisContext()
         let child = try await root.child()
 
-        await #expect(throws: SearchRuntimeAssemblyError.self) {
+        await #expect(throws: SearchRuntimeCompositionFactoryError.self) {
             try await invalid.assemble(in: child)
         }
         try await root.dispose()
@@ -144,7 +144,7 @@ struct SearchRuntimeAssemblyTests {
                 change: .updated,
                 seq: 10),
         ])
-        let assembly = SearchRuntimeAssembly(
+        let assembly = SearchRuntimeCompositionFactory(
             identity: fixture.assembly.identity,
             contentSource: fixture.source,
             changeStreamFactory: factory)
@@ -266,8 +266,8 @@ private struct Fixture {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 
-    var assembly: SearchRuntimeAssembly {
-        SearchRuntimeAssembly(
+    var assembly: SearchRuntimeCompositionFactory {
+        SearchRuntimeCompositionFactory(
             identity: SearchRuntimeIdentity(wikiID: wikiID, containerDirectory: directory),
             contentSource: source,
             changeStreamFactory: FinishedSearchChangeStreamFactory())

--- a/Tests/WikiFSTests/SessionManagerTests.swift
+++ b/Tests/WikiFSTests/SessionManagerTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import WikiFSCore
 @testable import WikiFSEngine
 
-/// `SessionManager` tests: verifies the `[wikiID: WikiSession]` cache semantics
+/// `SessionManager` tests: verifies the `[wikiID: ProfileWikiSession]` cache semantics
 /// — create-or-get deduplication, release-removes-from-cache, flush-all, and
 /// per-session gate isolation (structural — distinct `GenerationGate`
 /// instances across different wiki IDs).

--- a/Tests/WikiFSTests/SessionManagerTests.swift
+++ b/Tests/WikiFSTests/SessionManagerTests.swift
@@ -14,6 +14,7 @@ import Testing
 @MainActor
 @Suite
 struct SessionManagerTests {
+    private struct AsyncReadinessFailure: Error {}
 
     private func tempDirectory() -> URL {
         let dir = FileManager.default.temporaryDirectory
@@ -46,6 +47,43 @@ struct SessionManagerTests {
     }
 
     // MARK: - session(for:descriptor:)
+
+    @Test func asyncReadinessUsesLegacyPathUntilChildProfileLoaderIsInstalled() async throws {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let manager = makeSessionManager(dir: dir)
+        let descriptor = try #require(registry.wikis.first)
+
+        #expect(manager.readiness(for: descriptor.id) == .idle)
+        let session = try await manager.readySession(for: descriptor.id, descriptor: descriptor)
+
+        #expect(session === manager.sessions[descriptor.id])
+        #expect(manager.readiness(for: descriptor.id) == .ready)
+    }
+
+    @Test func asyncReadinessRecordsFailure() async throws {
+        let dir = tempDirectory()
+        let registry = makeSeededRegistry(dir: dir)
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+        let manager = SessionManager(
+            containerDirectory: dir,
+            extractionCoordinator: coordinator,
+            queueEngine: try makeTestQueueEngine(),
+            extractionProvider: StubExtractionProvider(),
+            pdf2mdScriptPathResolver: { nil },
+            makeStore: { _ in throw AsyncReadinessFailure() })
+        let descriptor = try #require(registry.wikis.first)
+
+        await #expect(throws: AsyncReadinessFailure.self) {
+            _ = try await manager.readySession(for: descriptor.id, descriptor: descriptor)
+        }
+        guard case .failed = manager.readiness(for: descriptor.id) else {
+            Issue.record("expected failed session readiness")
+            return
+        }
+    }
 
     @Test func testSessionForCreatesSessionWithStore() {
         let dir = tempDirectory()

--- a/Tests/WikiFSTests/WikiRegistryClientTests.swift
+++ b/Tests/WikiFSTests/WikiRegistryClientTests.swift
@@ -9,7 +9,7 @@ import Testing
 /// hermetically against a temp dir with no App Group access.
 ///
 /// The per-wiki *session* lifecycle (store opening, launchers, vacuum) is
-/// covered by `WikiSessionTests`. The registry client itself never opens a
+/// covered by `ProfileWikiSessionTests`. The registry client itself never opens a
 /// store except for seeding/import validation.
 @MainActor
 struct WikiRegistryClientTests {

--- a/Tests/WikiFSTests/WikiSessionTests.swift
+++ b/Tests/WikiFSTests/WikiSessionTests.swift
@@ -4,12 +4,12 @@ import Testing
 @testable import WikiFSCore
 @testable import WikiFSEngine
 
-/// `WikiSession` tests: per-session store lifecycle, vacuum state, search
+/// `ProfileWikiSession` tests: per-session store lifecycle, vacuum state, search
 /// upgrade, and per-session launcher/gate isolation. Each session opens its own
 /// DB over an injected temp dir, so these run hermetically with no App Group
 /// access.
 @MainActor
-struct WikiSessionTests {
+struct ProfileWikiSessionTests {
 
     private func tempDirectory() -> URL {
         let dir = FileManager.default.temporaryDirectory
@@ -36,7 +36,7 @@ struct WikiSessionTests {
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
 
-        let session = try! WikiSession(
+        let session = try! ProfileWikiSession(
             wikiID: descriptor.id,
             descriptor: descriptor,
             containerDirectory: dir,
@@ -60,14 +60,14 @@ struct WikiSessionTests {
             containerDirectory: dirA,
             localExtractorFactory: { StubExtractor() })
 
-        let sessionA = try! WikiSession(
+        let sessionA = try! ProfileWikiSession(
             wikiID: registryA.wikis.first!.id,
             descriptor: registryA.wikis.first!,
             containerDirectory: dirA,
             extractionCoordinator: coordinator,
             queueEngine: try! makeTestQueueEngine(),
             extractionProvider: StubExtractionProvider())
-        let sessionB = try! WikiSession(
+        let sessionB = try! ProfileWikiSession(
             wikiID: registryB.wikis.first!.id,
             descriptor: registryB.wikis.first!,
             containerDirectory: dirB,
@@ -96,14 +96,14 @@ struct WikiSessionTests {
             containerDirectory: dirA,
             localExtractorFactory: { StubExtractor() })
 
-        let sessionA = try! WikiSession(
+        let sessionA = try! ProfileWikiSession(
             wikiID: registryA.wikis.first!.id,
             descriptor: registryA.wikis.first!,
             containerDirectory: dirA,
             extractionCoordinator: coordinator,
             queueEngine: try! makeTestQueueEngine(),
             extractionProvider: StubExtractionProvider())
-        let sessionB = try! WikiSession(
+        let sessionB = try! ProfileWikiSession(
             wikiID: registryB.wikis.first!.id,
             descriptor: registryB.wikis.first!,
             containerDirectory: dirB,
@@ -130,7 +130,7 @@ struct WikiSessionTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = try! WikiSession(
+        let session = try! ProfileWikiSession(
             wikiID: registry.wikis.first!.id,
             descriptor: registry.wikis.first!,
             containerDirectory: dir,
@@ -155,7 +155,7 @@ struct WikiSessionTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = try! WikiSession(
+        let session = try! ProfileWikiSession(
             wikiID: registry.wikis.first!.id,
             descriptor: registry.wikis.first!,
             containerDirectory: dir,
@@ -182,7 +182,7 @@ struct WikiSessionTests {
         let coordinator = ExtractionCoordinator(
             containerDirectory: dir,
             localExtractorFactory: { StubExtractor() })
-        let session = try! WikiSession(
+        let session = try! ProfileWikiSession(
             wikiID: registry.wikis.first!.id,
             descriptor: registry.wikis.first!,
             containerDirectory: dir,
@@ -198,7 +198,7 @@ struct WikiSessionTests {
 
     // MARK: - Store-open failure (issue #881 — no in-memory fallback)
 
-    /// When the on-disk store cannot be opened, `WikiSession.init` MUST throw
+    /// When the on-disk store cannot be opened, `ProfileWikiSession.init` MUST throw
     /// instead of silently degrading to an in-memory store (the old behavior
     /// showed an empty wiki and made users think their data was gone).
     @Test func testInitThrowsWhenStoreOpenFails_NoInMemoryFallback() {
@@ -212,7 +212,7 @@ struct WikiSessionTests {
         struct StoreOpenFailure: Error {}
         // `makeStore` always throws — simulates a corrupt / unopenable DB.
         #expect(throws: StoreOpenFailure.self) {
-            _ = try WikiSession(
+            _ = try ProfileWikiSession(
                 wikiID: descriptor.id,
                 descriptor: descriptor,
                 containerDirectory: dir,

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -10,19 +10,25 @@ The default check verifies the current violation baseline. The `--strict` option
 
 ## Stage 2 status
 
-Stage 2 is not complete. No assembly or `WikiSession` file was deleted.
+Stage 2 remains in progress. No assembly or `WikiSession` file was deleted.
 
-Steps 1–8 are complete. The production catalogs now own executable-side factory injection.
+Steps 1–9 are complete. The production catalogs own executable-side factory injection and typed service resolution.
 
-Step 9 is complete. `AppServices` resolves typed services from a `BootedProfile` and keeps the Cordis context behind the facade.
+The process-lifetime gap is complete. Process profiles now own provider, extraction, queue, transport, and renderer runtime services.
 
-Step 12 is partly complete. The CLI Tantivy path now boots `CLIPluginCatalog`, resolves the Tantivy provider, and shuts down the profile.
+Per-wiki profiles now boot in a child Cordis context. The child resolves process services from its parent context.
 
-Steps 10–11 are not complete. `SessionManager` and `WikiSession` still use the legacy app composition path.
+The app and daemon profile tests boot this two-level graph. The tests also verify that child shutdown does not stop process services.
 
-The daemon part of step 12 is not complete. `WikiDaemon` still owns the provider and extraction assemblies.
+The async session-readiness gap is complete. `SessionManager.readySession(for:descriptor:)` exposes idle, loading, ready, and failed states.
 
-The current catalogs expose provider registries, not the final queue, extraction, transport, renderer, and agent operation facades. The app and daemon startup code still needs those facades and process owners before profile boot can replace the legacy lifetimes safely.
+The async accessor supports an injected child-profile loader. Its default path keeps the legacy synchronous session construction for this slice.
+
+Steps 10–11 remain incomplete because the app views still call the synchronous accessor. The next slice will install the child-profile loader and update those callers.
+
+The daemon part of step 12 remains incomplete. `WikiDaemon` still owns the provider and extraction assemblies.
+
+The CLI Tantivy path boots `CLIPluginCatalog`, resolves the Tantivy provider, and stops the profile.
 
 ## Remaining assemblies and callers
 

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -14,6 +14,8 @@ Stage 2 remains in progress. No assembly or `WikiSession` file was deleted.
 
 The app now starts an observable `AppProcessProfileOwner` alongside the legacy synchronous composition. The owner boots all five app process entries asynchronously, exposes idle/loading/ready/failed readiness plus the booted profile and typed process services, owns its startup task, and joins app termination shutdown. Fixture tests cover readiness, resolved services, failure, and idempotent disposal.
 
+`ProfileWikiSession` is the complete observable per-wiki facade for the next loader cutover. It boots an app child profile from the process profile, uses the child profile's store and read pool, uses inherited process extraction, queue, and provider services, and covers the full `WikiSession` surface: descriptor updates, store model, launcher, generation gate, search lifetime, vacuum state, and deferred wiki-link state. It temporarily delegates behavior to `WikiSession`, as this increment permits, so the boundary baseline now lists that approved compatibility construction site. Strict mode still rejects it. `SessionManager` and views are not rewired in this increment.
+
 Steps 1–9 are complete. The production catalogs own executable-side factory injection and typed service resolution.
 
 The process-lifetime gap is complete. Process profiles now own provider, extraction, queue, transport, and renderer runtime services.

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -4,13 +4,23 @@
 
 Stage 1 added `scripts/check-cordis-boundaries` and `make check-cordis`.
 
-The default check verifies the current violation baseline. The `--strict` option rejects all `RuntimeAssembly` references and all `WikiSession` construction sites.
+Stage 2 is complete. `ProfileWikiSession` is the sole per-wiki session implementation. Standalone factories own the six process-plugin runtime graphs.
 
-`CordisBoundaryScriptTests` runs the default check from Swift Testing.
+The source tree contains no `RuntimeAssembly` type or file. The app, daemon, and CLI start from profiles.
 
-## Stage 2 status
+The boundary check is strict by default. The `--strict` option is an alias for compatibility. Both modes reject all `RuntimeAssembly` references and all `WikiSession` construction sites.
 
-Stage 2 removed the privileged `WikiSession` implementation. Runtime assembly deletion remains in progress.
+`CordisBoundaryScriptTests` checks the default mode and the `--strict` alias from Swift Testing.
+
+## Stage 2 completion summary
+
+Commit 1 moved the six runtime graphs into standalone factories and converted their tests. Commit 2 removed the transitional boundary baseline and completed the Stage 2 policy updates.
+
+The required `make build`, `make test`, and `make check-cordis` gates pass. A recursive source grep returns no `RuntimeAssembly` matches.
+
+## Historical Stage 2 status
+
+The following sections record the state before the final deletion slice.
 
 The app now starts an observable `AppProcessProfileOwner` alongside the legacy synchronous composition. The owner boots all five app process entries asynchronously, exposes idle/loading/ready/failed readiness plus the booted profile and typed process services, owns its startup task, and joins app termination shutdown. Fixture tests cover readiness, resolved services, failure, and idempotent disposal.
 

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -12,6 +12,8 @@ The default check verifies the current violation baseline. The `--strict` option
 
 Stage 2 remains in progress. No assembly or `WikiSession` file was deleted.
 
+The app now starts an observable `AppProcessProfileOwner` alongside the legacy synchronous composition. The owner boots all five app process entries asynchronously, exposes idle/loading/ready/failed readiness plus the booted profile and typed process services, owns its startup task, and joins app termination shutdown. Fixture tests cover readiness, resolved services, failure, and idempotent disposal.
+
 Steps 1–9 are complete. The production catalogs own executable-side factory injection and typed service resolution.
 
 The process-lifetime gap is complete. Process profiles now own provider, extraction, queue, transport, and renderer runtime services.

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -12,7 +12,17 @@ The default check verifies the current violation baseline. The `--strict` option
 
 Stage 2 is not complete. No assembly or `WikiSession` file was deleted.
 
-A safe deletion requires executable-side plugin factories first. The current plugin definitions still use assembly-owned factory types.
+Steps 1–8 are complete. The production catalogs now own executable-side factory injection.
+
+Step 9 is complete. `AppServices` resolves typed services from a `BootedProfile` and keeps the Cordis context behind the facade.
+
+Step 12 is partly complete. The CLI Tantivy path now boots `CLIPluginCatalog`, resolves the Tantivy provider, and shuts down the profile.
+
+Steps 10–11 are not complete. `SessionManager` and `WikiSession` still use the legacy app composition path.
+
+The daemon part of step 12 is not complete. `WikiDaemon` still owns the provider and extraction assemblies.
+
+The current catalogs expose provider registries, not the final queue, extraction, transport, renderer, and agent operation facades. The app and daemon startup code still needs those facades and process owners before profile boot can replace the legacy lifetimes safely.
 
 ## Remaining assemblies and callers
 

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -39,7 +39,13 @@ Two compatibility paths remain for the final deletion slice:
 - `SessionManager.session(for:descriptor:)` still constructs `WikiSession` for tests and unsafe synchronous callers. Production `RootScene` does not use this path.
 - `ProfileWikiSession` still delegates application behavior to `WikiSession` until the final deletion slice moves that behavior into the facade.
 
-The daemon part of step 12 remains incomplete. `WikiDaemon` still owns the provider and extraction assemblies.
+The daemon part of step 12 is complete. `DaemonProcessProfileOwner` owns process-profile startup, per-wiki child profiles, and idempotent shutdown.
+
+`wikid` awaits the process profile before it resumes the XPC listener. Store RPC replies use asynchronous tasks to await child-profile readiness. Queue enqueue and chat start, submit, and continue requests also await the child profile.
+
+The daemon resolves provider and extraction services from the process profile. Each child profile supplies the per-wiki store, read pool, and event bus. A successful XPC wiki deletion also stops and removes the child profile.
+
+One daemon compatibility path remains. The synchronous `WikiDaemon` initializer still starts the legacy extraction owner for direct unit tests. Production `main.swift` does not use this initializer. The process-profile production factory still uses the provider and extraction assembly implementations as temporary plugin leases.
 
 The CLI Tantivy path boots `CLIPluginCatalog`, resolves the Tantivy provider, and stops the profile.
 

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -90,6 +90,39 @@ The CLI Tantivy path boots `CLIPluginCatalog`, resolves the Tantivy provider, an
 15. Make the boundary script strict by default and remove its baseline.
 16. Run `make build`, `make test`, and `scripts/check-cordis-boundaries --strict`.
 
+## Final-slice investigation
+
+The final-slice branch is `feature/cordis-5b-delete-privileged-core` at `8c7bf5fc`.
+The worktree was clean before the investigation.
+
+The current `AppServices` type is not a replacement for `WikiSession`.
+It resolves the raw store, read pool, extraction backend registry, and search provider registry.
+`WikiSession` also owns the observable store model, descriptor state, launcher, generation gate, and search lifetime.
+It also owns vacuum state and deferred wiki-link state for the app views.
+
+`WikiFSApp.init` creates all process owners synchronously.
+`CordisBoot.boot` is asynchronous.
+The app therefore needs an asynchronous process-profile readiness owner before it can resolve process services safely.
+
+All six runtime assembly types still have production callers and assembly-specific tests.
+The catalog defaults also reference `SearchRuntimeAssembly.runtimeFactory`.
+Deleting these files first would leave the tree incomplete.
+
+No production conversion or deletion was made during this investigation.
+The next safe sequence is:
+
+1. Add a retained asynchronous process-profile owner for the app.
+2. Add a per-wiki observable facade that owns the current `WikiSession` application state.
+3. Build that facade only from child-profile services and process-profile services.
+4. Change `SessionManager` and app views to use the facade.
+5. Change the daemon and CLI owners to use profiles.
+6. Move standalone factory implementations out of all runtime assembly files.
+7. Replace assembly-specific tests with plugin and profile tests.
+8. Delete `WikiSession.swift` and all runtime assembly files.
+9. Make the boundary script strict by default.
+10. Run all required gates after each commit.
+
 ## Verification at this checkpoint
 
 `make build` and `make test` passed after Stage 1. The full suite ran 3,563 tests in 357 suites.
+The final-slice investigation changed documentation only. Gate results for this documentation checkpoint follow in the commit history.

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -28,7 +28,16 @@ The async session-readiness gap is complete. `SessionManager.readySession(for:de
 
 The async accessor supports an injected child-profile loader. Its default path keeps the legacy synchronous session construction for this slice.
 
-Steps 10–11 remain incomplete because the app views still call the synchronous accessor. The next slice will install the child-profile loader and update those callers.
+Steps 10–11 are complete. `SessionManager` stores the `WikiSessionProtocol` abstraction and the production loader returns `ProfileWikiSession`.
+
+`RootScene` now awaits `readySession(for:descriptor:)`. App views and bridges use the session abstraction.
+
+The app process profile is the parent of each per-wiki child profile. Session shutdown disposes the child profile before process-profile shutdown.
+
+Two compatibility paths remain for the final deletion slice:
+
+- `SessionManager.session(for:descriptor:)` still constructs `WikiSession` for tests and unsafe synchronous callers. Production `RootScene` does not use this path.
+- `ProfileWikiSession` still delegates application behavior to `WikiSession` until the final deletion slice moves that behavior into the facade.
 
 The daemon part of step 12 remains incomplete. `WikiDaemon` still owns the provider and extraction assemblies.
 

--- a/plans/cordis-5b-status.md
+++ b/plans/cordis-5b-status.md
@@ -10,11 +10,11 @@ The default check verifies the current violation baseline. The `--strict` option
 
 ## Stage 2 status
 
-Stage 2 remains in progress. No assembly or `WikiSession` file was deleted.
+Stage 2 removed the privileged `WikiSession` implementation. Runtime assembly deletion remains in progress.
 
 The app now starts an observable `AppProcessProfileOwner` alongside the legacy synchronous composition. The owner boots all five app process entries asynchronously, exposes idle/loading/ready/failed readiness plus the booted profile and typed process services, owns its startup task, and joins app termination shutdown. Fixture tests cover readiness, resolved services, failure, and idempotent disposal.
 
-`ProfileWikiSession` is the complete observable per-wiki facade for the next loader cutover. It boots an app child profile from the process profile, uses the child profile's store and read pool, uses inherited process extraction, queue, and provider services, and covers the full `WikiSession` surface: descriptor updates, store model, launcher, generation gate, search lifetime, vacuum state, and deferred wiki-link state. It temporarily delegates behavior to `WikiSession`, as this increment permits, so the boundary baseline now lists that approved compatibility construction site. Strict mode still rejects it. `SessionManager` and views are not rewired in this increment.
+`ProfileWikiSession` is the sole per-wiki session implementation. It uses the child profile store, event bus, and read pool. It uses the process profile extraction, queue, and provider services. It owns descriptor updates, the store model, the launcher, the generation gate, search lifetime, vacuum state, and deferred wiki-link state. `SessionManager` constructs this type for synchronous test fixtures. A deprecated `WikiSession` type alias keeps test source compatibility, but no production code constructs that name.
 
 Steps 1–9 are complete. The production catalogs own executable-side factory injection and typed service resolution.
 
@@ -34,10 +34,7 @@ Steps 10–11 are complete. `SessionManager` stores the `WikiSessionProtocol` ab
 
 The app process profile is the parent of each per-wiki child profile. Session shutdown disposes the child profile before process-profile shutdown.
 
-Two compatibility paths remain for the final deletion slice:
-
-- `SessionManager.session(for:descriptor:)` still constructs `WikiSession` for tests and unsafe synchronous callers. Production `RootScene` does not use this path.
-- `ProfileWikiSession` still delegates application behavior to `WikiSession` until the final deletion slice moves that behavior into the facade.
+The per-wiki session compatibility paths are removed. The synchronous fixture path and the asynchronous profile path now construct `ProfileWikiSession`.
 
 The daemon part of step 12 is complete. `DaemonProcessProfileOwner` owns process-profile startup, per-wiki child profiles, and idempotent shutdown.
 

--- a/plans/cordis-full-architecture.md
+++ b/plans/cordis-full-architecture.md
@@ -1,12 +1,9 @@
 # Cordis Full Architecture — Design Record
 
-Status: in progress. Phases 1–4 complete (all 11 domain plugin seams), Phase 5a
-complete (bundles/profiles as data, dump-config), Phase 5b Stage 1 complete
-(boundary checker); Phase 5b Stage 2 — deleting `WikiSession` and the
-`*RuntimeAssembly.swift` files and rewiring the app/daemon/CLI entry points —
-is deliberately deferred as a staged follow-up: see
-`plans/cordis-5b-status.md` for the exact caller inventory and the ordered
-migration sequence.
+Status: complete for Phases 1–5b. Phase 5b Stage 2 landed: `WikiSession`
+and all `*RuntimeAssembly.swift` files are deleted, the app/daemon/CLI boot
+from profiles, and `scripts/check-cordis-boundaries` is strict by default.
+Migration sequence record: `plans/cordis-5b-status.md`.
 
 ## Goal
 
@@ -87,7 +84,7 @@ re-projection happens in the UI plugin, not the kernel.
 | `ctx.llm` | model adapter runtime | done (`wiki.llm-runtime` + `wiki.llm-acp-adapter`) |
 | `ctx.tools` | tool registry + execution waterfalls | done (`wiki.tools`) |
 | `ctx.systemPrompt` | prompt assembly | done (`wiki.system-prompt`) |
-| `ctx.agentLoop` / `ctx.agents` | queue worker, chat turn flow | seam done (`wiki.agent-loop`; dissolution of QueueEngine/ChatAgentRuntime deferred to 5b Stage 2) |
+| `ctx.agentLoop` / `ctx.agents` | queue worker, chat turn flow | done (`wiki.agent-loop`; QueueEngine/ChatAgentRuntime lifetimes now owned by process-profile leases) |
 | `ctx.search` | Tantivy + embeddings providers | done (`wiki.search` + adapters) |
 | `ctx.renderers` | renderer packages | done (`wiki.renderers` + adapter) |
 | `ctx.transport` | daemon XPC/RPC | done (`wiki.transport` + adapter) |

--- a/progress/2026-08-24T010000Z-cordis-5b-delete-privileged-core.md
+++ b/progress/2026-08-24T010000Z-cordis-5b-delete-privileged-core.md
@@ -1,0 +1,44 @@
+---
+timestamp: 2026-08-24T010000Z
+title: Cordis Phase 5b — delete the privileged core
+branch: feature/cordis-5b-delete-privileged-core
+status: complete
+---
+
+# Cordis Phase 5b — delete the privileged core
+
+## Progress
+
+Landed Phase 5b Stage 2 on `feature/cordis-5b-delete-privileged-core`
+(stacked on `feature/cordis-full-architecture`, PR #1138), in twelve gated
+commits (`ee95dae9` … `cabdbe4f`).
+
+- Production plugin catalogs for the app, daemon, and CLI with injected
+  factories; assembly-owned composition moved into standalone runtime
+  factories (`*RuntimeFactory.swift`).
+- Process-profile vs per-wiki profile lifetimes split: process services
+  (agent provider, extraction, queue, transport, renderer) are supplied as
+  typed leases from a process profile root; per-wiki store/sessions/search
+  boot as child contexts (`CordisBoot` parent-context support).
+- `SessionManager` gained async per-wiki readiness; `ProfileWikiSession` is
+  the sole session implementation (the legacy `WikiSession` type is
+  deleted); views use `WikiSessionProtocol`.
+- The app boots `AppProcessProfileOwner` (single composition path, no
+  assembly construction); `wikid` awaits process-profile readiness before
+  `NSXPCListener.resume()` and serves stores through retained per-wiki child
+  profiles; CLI search resolves through `CLIPluginCatalog`.
+- Deleted `WikiSession.swift` and all six `*RuntimeAssembly.swift` files;
+  `scripts/check-cordis-boundaries` is strict by default (no baseline) and
+  `grep -r "RuntimeAssembly" Sources/` returns nothing (AC.4).
+
+Full sequence and caller inventory: `plans/cordis-5b-status.md` (marked
+complete).
+
+## Verification
+
+- `make build` — passed (signed app bundle) after every commit.
+- `make test` — 3,572 tests in 360 suites passed.
+- `make check-cordis` — "Cordis boundaries verified" (strict by default).
+- `grep -r "RuntimeAssembly" Sources/` — no matches.
+- Store invariants (`StoreConcurrencyTests`,
+  `StoreEmissionExhaustivenessTests`) pass unmodified (AC.7).

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -12,7 +12,7 @@ elif [[ $# -ne 0 ]]; then
 fi
 
 runtime_matches="$({ grep -RIl --include='*.swift' 'RuntimeAssembly' Sources || true; } | LC_ALL=C sort)"
-session_matches="$({ grep -RIl --include='*.swift' 'WikiSession(' Sources || true; } | LC_ALL=C sort)"
+session_matches="$({ grep -RIlE --include='*.swift' '(^|[^[:alnum:]_])WikiSession\(' Sources || true; } | LC_ALL=C sort)"
 
 if $strict; then
   if [[ -n "$runtime_matches" ]]; then
@@ -40,8 +40,7 @@ Sources/WikiFSEngine/SearchPlugins.swift
 Sources/WikiFSEngine/SearchRuntimeAssembly.swift
 Sources/WikiFSEngine/SearchRuntimeRegistry.swift
 Sources/wikid/WikiDaemon.swift'
-expected_session_matches='Sources/WikiFSEngine/ProductionPluginCatalogs.swift
-Sources/WikiFSEngine/SessionManager.swift'
+expected_session_matches=''
 
 if [[ "$runtime_matches" != "$expected_runtime_matches" ]]; then
   echo "Cordis boundary baseline changed: RuntimeAssembly references differ." >&2

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -28,8 +28,8 @@ if $strict; then
 fi
 
 expected_runtime_matches='Sources/WikiCtlCore/CLIPluginCatalog.swift
+Sources/WikiFS/Renderer/RendererCompositionOwner.swift
 Sources/WikiFS/Renderer/RendererRuntimeAssembly.swift
-Sources/WikiFS/Window/WikiFSApp.swift
 Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift
 Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift
 Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -28,7 +28,6 @@ if $strict; then
 fi
 
 expected_runtime_matches='Sources/WikiCtlCore/CLIPluginCatalog.swift
-Sources/WikiCtlCore/CLITantivyLegResolver.swift
 Sources/WikiFS/Renderer/RendererRuntimeAssembly.swift
 Sources/WikiFS/Window/WikiFSApp.swift
 Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -40,7 +40,8 @@ Sources/WikiFSEngine/SearchPlugins.swift
 Sources/WikiFSEngine/SearchRuntimeAssembly.swift
 Sources/WikiFSEngine/SearchRuntimeRegistry.swift
 Sources/wikid/WikiDaemon.swift'
-expected_session_matches='Sources/WikiFSEngine/SessionManager.swift'
+expected_session_matches='Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+Sources/WikiFSEngine/SessionManager.swift'
 
 if [[ "$runtime_matches" != "$expected_runtime_matches" ]]; then
   echo "Cordis boundary baseline changed: RuntimeAssembly references differ." >&2

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -27,19 +27,7 @@ if $strict; then
   exit
 fi
 
-expected_runtime_matches='Sources/WikiCtlCore/CLIPluginCatalog.swift
-Sources/WikiFS/Renderer/RendererCompositionOwner.swift
-Sources/WikiFS/Renderer/RendererRuntimeAssembly.swift
-Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift
-Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift
-Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift
-Sources/WikiFSEngine/ProductionPluginCatalogs.swift
-Sources/WikiFSEngine/QueueRuntimeAssembly.swift
-Sources/WikiFSEngine/SearchCompositionOwner.swift
-Sources/WikiFSEngine/SearchPlugins.swift
-Sources/WikiFSEngine/SearchRuntimeAssembly.swift
-Sources/WikiFSEngine/SearchRuntimeRegistry.swift
-Sources/wikid/WikiDaemon.swift'
+expected_runtime_matches=''
 expected_session_matches=''
 
 if [[ "$runtime_matches" != "$expected_runtime_matches" ]]; then

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -27,19 +27,19 @@ if $strict; then
   exit
 fi
 
-expected_runtime_matches='Sources/WikiCtlCore/CLITantivyLegResolver.swift
+expected_runtime_matches='Sources/WikiCtlCore/CLIPluginCatalog.swift
+Sources/WikiCtlCore/CLITantivyLegResolver.swift
 Sources/WikiFS/Renderer/RendererRuntimeAssembly.swift
 Sources/WikiFS/Window/WikiFSApp.swift
 Sources/WikiFSEngine/AgentProviderRuntimeAssembly.swift
 Sources/WikiFSEngine/DaemonTransportRuntimeAssembly.swift
-Sources/WikiFSEngine/ExtractionPlugins.swift
 Sources/WikiFSEngine/ExtractionRuntimeAssembly.swift
+Sources/WikiFSEngine/ProductionPluginCatalogs.swift
 Sources/WikiFSEngine/QueueRuntimeAssembly.swift
 Sources/WikiFSEngine/SearchCompositionOwner.swift
 Sources/WikiFSEngine/SearchPlugins.swift
 Sources/WikiFSEngine/SearchRuntimeAssembly.swift
 Sources/WikiFSEngine/SearchRuntimeRegistry.swift
-Sources/WikiFSEngine/SearchServiceKeys.swift
 Sources/wikid/WikiDaemon.swift'
 expected_session_matches='Sources/WikiFSEngine/SessionManager.swift'
 

--- a/scripts/check-cordis-boundaries
+++ b/scripts/check-cordis-boundaries
@@ -3,10 +3,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-strict=false
-if [[ "${1:-}" == "--strict" ]]; then
-  strict=true
-elif [[ $# -ne 0 ]]; then
+if [[ $# -gt 1 || (${1:-} != "" && ${1:-} != "--strict") ]]; then
   echo "usage: scripts/check-cordis-boundaries [--strict]" >&2
   exit 2
 fi
@@ -14,31 +11,14 @@ fi
 runtime_matches="$({ grep -RIl --include='*.swift' 'RuntimeAssembly' Sources || true; } | LC_ALL=C sort)"
 session_matches="$({ grep -RIlE --include='*.swift' '(^|[^[:alnum:]_])WikiSession\(' Sources || true; } | LC_ALL=C sort)"
 
-if $strict; then
-  if [[ -n "$runtime_matches" ]]; then
-    echo "Cordis boundary violation: RuntimeAssembly remains in Sources/:" >&2
-    printf '%s\n' "$runtime_matches" >&2
-  fi
-  if [[ -n "$session_matches" ]]; then
-    echo "Cordis boundary violation: WikiSession is instantiated in Sources/:" >&2
-    printf '%s\n' "$session_matches" >&2
-  fi
-  [[ -z "$runtime_matches" && -z "$session_matches" ]]
-  exit
+if [[ -n "$runtime_matches" ]]; then
+  echo "Cordis boundary violation: RuntimeAssembly remains in Sources/:" >&2
+  printf '%s\n' "$runtime_matches" >&2
 fi
-
-expected_runtime_matches=''
-expected_session_matches=''
-
-if [[ "$runtime_matches" != "$expected_runtime_matches" ]]; then
-  echo "Cordis boundary baseline changed: RuntimeAssembly references differ." >&2
-  diff -u <(printf '%s\n' "$expected_runtime_matches") <(printf '%s\n' "$runtime_matches") >&2 || true
-  exit 1
+if [[ -n "$session_matches" ]]; then
+  echo "Cordis boundary violation: WikiSession is instantiated in Sources/:" >&2
+  printf '%s\n' "$session_matches" >&2
 fi
-if [[ "$session_matches" != "$expected_session_matches" ]]; then
-  echo "Cordis boundary baseline changed: WikiSession construction sites differ." >&2
-  diff -u <(printf '%s\n' "$expected_session_matches") <(printf '%s\n' "$session_matches") >&2 || true
-  exit 1
-fi
+[[ -z "$runtime_matches" && -z "$session_matches" ]]
 
-echo "Cordis boundary baseline verified (run with --strict for the Phase 5b end state)."
+echo "Cordis boundaries verified."


### PR DESCRIPTION
## Summary

Completes Phase 5b Stage 2 of the Cordis full-architecture plan (`plans/cordis-full-architecture.md`): deletes the privileged core — `WikiSession.swift` and all six `*RuntimeAssembly.swift` files — and boots the app, daemon, and CLI from profiles. **Stacked on #1138** (base branch: `feature/cordis-full-architecture`); merge that PR first.

## What changed

Landed in twelve gated commits (`ee95dae9` … `cabdbe4f`), each leaving `make build` + `make test` + `make check-cordis` green:

- **Production catalogs** — app/daemon/CLI plugin catalogs with injected factories; assembly composition moved into standalone `*RuntimeFactory.swift` types.
- **Lifetime split** — process-scoped services (agent provider, extraction, queue, transport, renderer) are typed leases supplied by a process profile root; per-wiki store/sessions/search boot as child contexts (new `CordisBoot` parent-context support). Boot tests assert child shutdown does not dispose process services and vice versa.
- **Sessions** — `SessionManager` gained async per-wiki readiness; `ProfileWikiSession` is the sole session implementation (built from child-profile store/event-bus/read-pool plus inherited process services); views consume `WikiSessionProtocol`.
- **App** — `AppProcessProfileOwner` is the single composition path; `WikiFSApp` no longer constructs any assembly.
- **Daemon** — `wikid` awaits process-profile readiness before `NSXPCListener.resume()`; per-wiki stores serve from retained child profiles; wiki deletion shuts down its child.
- **CLI** — search resolves through `CLIPluginCatalog` (already in the base PR; carried forward).
- **Deletion** — `WikiSession.swift` and all six `*RuntimeAssembly.swift` files deleted; `scripts/check-cordis-boundaries` is strict by default with no baseline.

## Acceptance criteria

- **AC.4 (no privileged core)**: ✅ `grep -r "RuntimeAssembly" Sources/` returns nothing; checker strict by default; `CordisBoundaryScriptTests` covers both modes.
- **AC.6 / AC.8**: ✅ app/daemon boot from profiles; `AppProfileBootTests` / `DaemonProfileBootTests` exercise the two-level process→wiki graph, including subscriber disposal isolation.
- **AC.7**: ✅ store suites pass unmodified.

## Testing

- `make build` — green (signed app bundle)
- `make test` — 3,572 tests in 360 suites pass
- `make check-cordis` — "Cordis boundaries verified" (strict)
- `grep -r "RuntimeAssembly" Sources/` — no matches

Full migration sequence and caller inventory: `plans/cordis-5b-status.md` (marked complete). Design record: `plans/cordis-full-architecture.md`.
