### PR TITLE
Fix Codex model selection from Provider Settings

### DIFF
--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -281,6 +281,14 @@ struct AgentsSettingsView: View {
 
     // MARK: - Bindings / helpers
 
+    /// Shared selection type for the provider-settings picker and all its tags.
+    /// A different tag type makes SwiftUI ignore the selected model.
+    typealias ModelPickerSelection = ModelID?
+
+    nonisolated static func modelPickerTag(for modelID: ModelID?) -> ModelPickerSelection {
+        modelID
+    }
+
     private func enabledBinding(for provider: AgentProvider) -> Binding<Bool> {
         Binding(
             get: { provider.enabled },
@@ -498,9 +506,9 @@ private struct ProviderDetailPane: View {
     private var defaultModelRow: some View {
         let cachedModels = config.cachedModels(forProvider: provider.id)
         Picker("Default Model", selection: modelBinding) {
-            Text("Agent default").tag("")
+            Text("Agent default").tag(AgentsSettingsView.modelPickerTag(for: nil))
             ForEach(cachedModels, id: \.modelId) { model in
-                Text(model.displayLabel).tag(model.modelId)
+                Text(model.displayLabel).tag(AgentsSettingsView.modelPickerTag(for: model.modelId))
             }
         }
     }
@@ -536,12 +544,12 @@ private struct ProviderDetailPane: View {
         }
     }
 
-    private var modelBinding: Binding<String> {
+    private var modelBinding: Binding<AgentsSettingsView.ModelPickerSelection> {
         Binding(
-            get: { config.selectedModelId(forProvider: provider.id)?.rawValue ?? "" },
-            set: { newID in
+            get: { config.selectedModelId(forProvider: provider.id) },
+            set: { modelID in
                 saveConfig(config.settingSelectedModel(
-                    newID.isEmpty ? nil : ModelID(rawValue: newID),
+                    modelID,
                     forProvider: provider.id))
             })
     }

--- a/Sources/WikiFSEngine/ACPModelConfigOptionResolver.swift
+++ b/Sources/WikiFSEngine/ACPModelConfigOptionResolver.swift
@@ -66,16 +66,39 @@ public extension ACPModelSelectionResolver {
             return .useAgentDefault
         }
         // Validate the selection against the agent's advertised option values —
-        // same defensive posture as the setModel stale-selection guard.
+        // same defensive posture as the setModel stale-selection guard. Picker
+        // model families append a thinking-effort annotation (for example,
+        // "gpt-5.6-luna[high]") even when the agent advertises only the base
+        // model. Prefer an exact advertised value, then try that base model.
         let advertisedValues = Self.configOptionValues(from: select.options)
-        guard advertisedValues.contains(selectedModelId) else {
+        let resolvedModelId: String
+        if advertisedValues.contains(selectedModelId) {
+            resolvedModelId = selectedModelId
+        } else if let baseModelId = Self.baseModelId(fromEffortVariant: selectedModelId),
+                  advertisedValues.contains(baseModelId) {
+            resolvedModelId = baseModelId
+        } else {
             return .useAgentDefault   // stale/unrecognized → don't 404 the agent
         }
         // Already the agent's current model → no-op round-trip.
-        if select.currentValue.value == selectedModelId {
+        if select.currentValue.value == resolvedModelId {
             return .useAgentDefault
         }
-        return .applyViaModelConfigOption(selectedValue: selectedModelId)
+        return .applyViaModelConfigOption(selectedValue: resolvedModelId)
+    }
+
+    /// Removes a well-formed trailing picker effort annotation from a model id.
+    /// The non-empty base and suffix checks keep arbitrary bracketed model ids
+    /// from being normalized accidentally.
+    static func baseModelId(fromEffortVariant modelId: String) -> String? {
+        guard modelId.last == "]",
+              let openingBracket = modelId.lastIndex(of: "["),
+              openingBracket != modelId.startIndex,
+              modelId.index(after: openingBracket) != modelId.index(before: modelId.endIndex)
+        else {
+            return nil
+        }
+        return String(modelId[..<openingBracket])
     }
 
     /// Flatten the SDK's `ungrouped`/`grouped` select options into the raw

--- a/Tests/WikiFSAppTests/AgentProviderModelPickerTests.swift
+++ b/Tests/WikiFSAppTests/AgentProviderModelPickerTests.swift
@@ -147,6 +147,31 @@ import WikiFSCore
         #expect(decision == .applyViaModelConfigOption(selectedValue: "haiku"))
     }
 
+    @Test func configOptionModel_effortVariantAppliesAdvertisedBase() {
+        let decision = ACPModelSelectionResolver.resolveConfigOptionModel(
+            selectedModelId: "gpt-5.6-luna[high]",
+            configOptions: [modelConfigOption(
+                current: "gpt-5.6-codex",
+                values: ["gpt-5.6-codex", "gpt-5.6-luna"])])
+        #expect(decision == .applyViaModelConfigOption(selectedValue: "gpt-5.6-luna"))
+    }
+
+    @Test func configOptionModel_exactEffortVariantTakesPrecedence() {
+        let decision = ACPModelSelectionResolver.resolveConfigOptionModel(
+            selectedModelId: "gpt-5.6-luna[high]",
+            configOptions: [modelConfigOption(
+                current: "gpt-5.6-luna[medium]",
+                values: ["gpt-5.6-luna", "gpt-5.6-luna[high]", "gpt-5.6-luna[medium]"])])
+        #expect(decision == .applyViaModelConfigOption(selectedValue: "gpt-5.6-luna[high]"))
+    }
+
+    @Test func configOptionModel_alreadyCurrentBaseSkipsEffortVariant() {
+        let decision = ACPModelSelectionResolver.resolveConfigOptionModel(
+            selectedModelId: "gpt-5.6-luna[high]",
+            configOptions: [modelConfigOption(current: "gpt-5.6-luna", values: ["gpt-5.6-luna"])])
+        #expect(decision == .useAgentDefault)
+    }
+
     @Test func configOptionModel_alreadyCurrentSkips() {
         // Selection matches the agent's current model → no-op round-trip.
         let decision = ACPModelSelectionResolver.resolveConfigOptionModel(

--- a/Tests/WikiFSAppTests/AgentsSettingsViewWarningTests.swift
+++ b/Tests/WikiFSAppTests/AgentsSettingsViewWarningTests.swift
@@ -14,6 +14,17 @@ import WikiFSCore
 @Suite("AgentsSettingsView modelWarning")
 struct AgentsSettingsViewWarningTests {
 
+    @Test func codexModelPickerUsesTypedSelectionTags() {
+        let modelID = ModelID(rawValue: "gpt-5.6-luna[high]")
+        let modelTag: AgentsSettingsView.ModelPickerSelection =
+            AgentsSettingsView.modelPickerTag(for: modelID)
+        let defaultTag: AgentsSettingsView.ModelPickerSelection =
+            AgentsSettingsView.modelPickerTag(for: nil)
+
+        #expect(modelTag == modelID)
+        #expect(defaultTag == nil)
+    }
+
     // MARK: - Returns nil when no warning is needed
 
     @Test func returnsNilWhenProviderDisabled() {


### PR DESCRIPTION
## Summary

- Fix the Provider Settings picker so a selected Codex model reaches its configuration binding and persists.
- Use `ModelID?` for both the picker selection and every picker tag.
- Map a picker effort variant to the base model that the ACP agent advertises.
- Keep exact advertised variant matches unchanged.
- Keep stale or malformed selections on the safe agent-default path.
- Add regression tests for the settings picker type contract and ACP model resolution.

## Root cause

The Provider Settings picker used a `Binding<String>`, but model rows used `ModelID` tags. SwiftUI requires the selection and tag types to match, so it silently ignored model rows. The settings mutation never ran.

After persistence, Codex effort variants also needed daemon-side normalization when the agent advertised only the base model.

## Tests

- `WIKIFS_APP_TESTS=1 swift test --filter AgentsSettingsViewWarningTests` (7 tests passed)
- `WIKIFS_APP_TESTS=1 swift test --filter AgentProviderModelPickerTests` (35 tests passed)
- `make test` (3,590 tests passed)
- LSP diagnostics for all changed files (no diagnostics)
- Pre-commit SwiftLint (0 violations)

Fixes #1142
