### PR TITLE
Enforce bounded content detection boundaries

### DIFF
--- a/Tests/WikiFSTests/ContentTypeDetectionArchitectureTests.swift
+++ b/Tests/WikiFSTests/ContentTypeDetectionArchitectureTests.swift
@@ -35,6 +35,122 @@ struct ContentTypeDetectionArchitectureTests {
         #expect(findings.isEmpty, "Independent MIME policy found:\n\(findings.joined(separator: "\n"))")
     }
 
+    @Test func allByteBearingWritersUseDetectionHintsOrDetectedResult() throws {
+        let root = try #require(locateRepoRoot())
+        struct WriterManifestEntry {
+            let path: String
+            let declarations: [(anchor: String, count: Int)]
+            let testFunctions: [String]
+        }
+        let inventory: [WriterManifestEntry] = [
+            .init(
+                path: "Sources/WikiFSCore/Store/GRDBWikiStore.swift",
+                declarations: [
+                    ("public func addSource(", 3),
+                    ("public func appendContentVersion(", 2),
+                    ("public func addSnapshotImage(", 2),
+                ],
+                testFunctions: [
+                    "GRDBAddAppendAndSnapshotImageRedetectAtFinalBoundary",
+                    "typedAddSourceUsesFilenameUTIFallback",
+                ]),
+            .init(
+                path: "Sources/WikiFSCore/Store/WikiStoreModel.swift",
+                declarations: [
+                    ("func storeMaterialized(", 1),
+                    ("private func storeSnapshot(", 1),
+                    ("private func performRefresh(", 1),
+                    ("public func addSource(filename: String, data: Data)", 1),
+                ],
+                testFunctions: [
+                    "localWebsiteZoteroAndMarkdownFolderShareDetectorPolicy",
+                    "snapshotStoresPageAndImagesWithSharedActivity",
+                    "websiteRefreshPreservesDeclaredMIMEHints",
+                ]),
+            .init(
+                path: "Sources/WikiCtlCore/SourceCommand.swift",
+                declarations: [
+                    ("public static func runAddURL(", 1),
+                    ("static func persistRefreshMaterial(", 1),
+                ],
+                testFunctions: ["sourceCommandAddAndRefreshPreserveDetectionPolicy"]),
+            .init(
+                path: "Sources/WikiFSCore/Sources/SourceMaterializer.swift",
+                declarations: [
+                    ("public struct LocalFileMaterializer", 1),
+                    ("public struct WebsiteMaterializer", 1),
+                    ("public struct ZoteroMaterializer", 1),
+                    ("public struct MarkdownFolderMaterializer", 1),
+                ],
+                testFunctions: ["localWebsiteZoteroAndMarkdownFolderShareDetectorPolicy"]),
+            .init(
+                path: "Sources/WikiFSCore/Integrations/WebsiteSnapshotExtractor.swift",
+                declarations: [("public static func detection(", 1)],
+                testFunctions: [
+                    "convertedMarkdownCarriesRelativeSrcs",
+                    "snapshotStoresPageAndImagesWithSharedActivity",
+                ]),
+        ]
+
+        var findings: [String] = []
+        for entry in inventory {
+            let source = try String(
+                contentsOf: root.appendingPathComponent(entry.path),
+                encoding: .utf8)
+            for declaration in entry.declarations {
+                let actual = source.components(separatedBy: declaration.anchor).count - 1
+                if actual != declaration.count {
+                    findings.append(
+                        "\(entry.path): expected \(declaration.count) occurrences of " +
+                        "\(declaration.anchor), found \(actual)")
+                }
+            }
+            for functionName in entry.testFunctions where try !testFunctionExists(named: functionName, under: root) {
+                findings.append("\(entry.path): missing behavioral test function \(functionName)")
+            }
+        }
+        #expect(findings.isEmpty, "Byte-bearing writer inventory changed:\n\(findings.joined(separator: "\n"))")
+    }
+
+    @Test func detectorRemainsPureAndCordisFree() throws {
+        let root = try #require(locateRepoRoot())
+        let detectorPath = "Sources/WikiFSCore/Sources/ContentSniff.swift"
+        let detector = try String(
+            contentsOf: root.appendingPathComponent(detectorPath),
+            encoding: .utf8)
+        #expect(!detector.contains("import Cordis"))
+        #expect(!detector.contains("ServiceKey"))
+        #expect(!detector.contains("ComponentDefinition"))
+
+        let sourceRoot = root.appendingPathComponent("Sources")
+        let enumerator = try #require(FileManager.default.enumerator(
+            at: sourceRoot,
+            includingPropertiesForKeys: nil))
+        var findings: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let relative = url.path.replacingOccurrences(of: root.path + "/", with: "")
+            let source = try String(contentsOf: url, encoding: .utf8)
+            let compact = source.lowercased()
+                .replacingOccurrences(of: "_", with: "")
+                .replacingOccurrences(of: "-", with: "")
+            let detectorReferences = [
+                "contenttypedetector",
+                "contenttypedetectionresult",
+                "contenttypedetectionhints",
+                "contentdetectionservice",
+                "mimedetectionservice",
+                "mimepolicyservice",
+            ]
+            let cordisConstructs = ["ServiceKey", "ComponentDefinition", "CordisContext"]
+            if relative != detectorPath,
+               detectorReferences.contains(where: compact.contains),
+               cordisConstructs.contains(where: source.contains) {
+                findings.append("\(relative): content detection coupled to Cordis")
+            }
+        }
+        #expect(findings.isEmpty, "Content detection must remain pure policy:\n\(findings.joined(separator: "\n"))")
+    }
+
     @Test func canonicalStoreBoundaryUsesTypedHintsAndNeutralMetadata() throws {
         let root = try #require(locateRepoRoot())
         let storeProtocol = try String(
@@ -59,6 +175,18 @@ struct ContentTypeDetectionArchitectureTests {
         #expect(!command.contains("zoteroItemKey: nil, zoteroItemTitle:"))
         #expect(sourceMaterializer.contains("externalItemID: String?"))
         #expect(sourceMaterializer.contains("externalItemTitle: String?"))
+    }
+
+    private func testFunctionExists(named functionName: String, under root: URL) throws -> Bool {
+        let testRoot = root.appendingPathComponent("Tests")
+        let enumerator = try #require(FileManager.default.enumerator(
+            at: testRoot,
+            includingPropertiesForKeys: nil))
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let source = try String(contentsOf: url, encoding: .utf8)
+            if source.contains("@Test func \(functionName)(") { return true }
+        }
+        return false
     }
 
     private func locateRepoRoot() -> URL? {

--- a/Tests/WikiFSTests/ContentTypeDetectorTests.swift
+++ b/Tests/WikiFSTests/ContentTypeDetectorTests.swift
@@ -41,6 +41,52 @@ struct ContentTypeDetectorTests {
         #expect(result.evidence.first?.origin == .binarySignature)
     }
 
+    @Test(arguments: signatures)
+    func commonSignaturesRejectTruncatedInputs(_ value: SignatureCase) {
+        let truncated = Data(value.bytes.prefix(1))
+        let result = ContentTypeDetector.detect(.init(data: truncated))
+        #expect(!result.evidence.contains { $0.origin == .binarySignature })
+        #expect(result.normalizedMIMEType != value.mimeType)
+    }
+
+    @Test(arguments: signatures)
+    func commonSignaturesRejectNearMisses(_ value: SignatureCase) {
+        var nearMiss = value.bytes
+        nearMiss[nearMiss.startIndex] ^= 0xFF
+        let result = ContentTypeDetector.detect(.init(data: nearMiss))
+        #expect(!result.evidence.contains { $0.origin == .binarySignature })
+        #expect(result.normalizedMIMEType != value.mimeType)
+    }
+
+    @Test(arguments: signatures)
+    func commonSignaturesOverrideConflictingHints(_ value: SignatureCase) {
+        let result = ContentTypeDetector.detect(.init(
+            data: value.bytes,
+            hints: .init(
+                declaredMIME: .init("text/plain", origin: .httpResponse),
+                filenameExtension: "txt")))
+        #expect(result.normalizedMIMEType == value.mimeType)
+        #expect(result.conflicts.contains { $0.conflictingEvidence.origin == .httpResponse })
+    }
+
+    @Test func conflictingHintsRetainEvidenceAndConflictOrigins() {
+        for origin in [DeclaredMIMEOrigin.httpResponse, .zoteroMetadata] {
+            let result = ContentTypeDetector.detect(.init(
+                data: Data("%PDF-1.7".utf8),
+                hints: .init(
+                    declaredMIME: .init("text/plain", origin: origin),
+                    filenameExtension: "txt",
+                    utiMIME: "text/plain")))
+            #expect(result.normalizedMIMEType == "application/pdf")
+            #expect(result.conflicts.map(\.conflictingEvidence.origin) == [
+                .utf8Text,
+                origin == .httpResponse ? .httpResponse : .zoteroMetadata,
+                .uti,
+                .filenameExtension,
+            ])
+        }
+    }
+
     @Test func binarySignatureOverridesDeclaredHTTPMIME() {
         let result = ContentTypeDetector.detect(.init(
             data: Data("%PDF-1.7".utf8),

--- a/Tests/WikiFSTests/ExtractionCompatibilityWriterTests.swift
+++ b/Tests/WikiFSTests/ExtractionCompatibilityWriterTests.swift
@@ -43,6 +43,79 @@ struct ExtractionCompatibilityWriterTests {
         #expect(provenance.producer == .tool(.transcript))
     }
 
+    @Test func sourceCommandAddAndRefreshPreserveDetectionPolicy() async throws {
+        struct PDFAsTextFetcher: URLFetchService.URLResourceFetcher {
+            func fetch(_ url: URL) async throws -> URLFetchService.FetchResponse {
+                .init(
+                    data: Data("%PDF-1.7".utf8),
+                    contentType: "text/plain",
+                    finalURL: URL(string: "https://example.com/report.txt")!)
+            }
+        }
+
+        let store = try TestStoreFactory.inMemory()
+        _ = try await SourceCommand.runAddURL(
+            "https://example.com/report.txt",
+            allowDuplicateURL: false,
+            in: store,
+            fetcher: PDFAsTextFetcher())
+        let added = try #require(try store.listSources().first)
+        #expect(added.mimeType == MimeType.pdf)
+
+        try SourceCommand.persistRefreshMaterial(
+            .contentVersion(
+                data: Data("%PDF-1.7 refreshed".utf8),
+                detectionHints: .init(
+                    declaredMIME: .init("text/plain", origin: .httpResponse),
+                    filenameExtension: "txt"),
+                provenance: .init(
+                    agentName: "website", activityKind: "fetch",
+                    plan: "https://example.com/report.txt")),
+            sourceID: added.id,
+            in: store)
+        let refreshed = try store.getSource(id: added.id)
+        let activeVersion = try #require(try store.activeContentVersion(sourceID: added.id))
+        #expect(refreshed.mimeType == MimeType.pdf)
+        #expect(activeVersion.mimeType == MimeType.pdf)
+    }
+
+    @Test func GRDBAddAppendAndSnapshotImageRedetectAtFinalBoundary() throws {
+        let store = try TestStoreFactory.inMemory()
+        let pdfBytes = Data("%PDF-1.7".utf8)
+        let hints = ContentTypeDetectionHints(
+            declaredMIME: .init("text/plain", origin: .httpResponse),
+            filenameExtension: "txt")
+
+        let typed = try store.addSource(
+            filename: "typed.txt", data: pdfBytes,
+            detectionHints: hints, ingestMetadata: nil, provenance: nil,
+            role: .primary, originalPath: nil, activityID: nil,
+            resolvedDisplayName: nil)
+        #expect(typed.mimeType == MimeType.pdf)
+        #expect(try store.activeContentVersion(sourceID: typed.id)?.mimeType == MimeType.pdf)
+
+        let appended = try store.appendContentVersion(
+            sourceID: typed.id,
+            data: Data("%PDF-1.7 appended".utf8),
+            detectionHints: hints,
+            provenance: nil)
+        #expect(appended.mimeType == MimeType.pdf)
+        #expect(try store.getSource(id: typed.id).mimeType == MimeType.pdf)
+
+        let activityID = try store.ensureFetchActivity(provenance: .init(
+            agentName: "website", activityKind: "fetch",
+            plan: "https://example.com/page"))
+        let snapshot = try store.addSnapshotImage(
+            filename: "snapshot.txt", data: pdfBytes,
+            detectionHints: hints,
+            originalPath: "snapshot.txt",
+            sourceURL: URL(string: "https://example.com/snapshot.txt")!,
+            activityID: activityID,
+            role: .media)
+        #expect(snapshot.mimeType == MimeType.pdf)
+        #expect(try store.activeContentVersion(sourceID: snapshot.id)?.mimeType == MimeType.pdf)
+    }
+
     @Test func wikictlContentRefreshPreservesDeclaredMIMEHints() throws {
         let store = try TestStoreFactory.inMemory()
         let summary = try source(store)

--- a/Tests/WikiFSTests/SourceMaterializerTests.swift
+++ b/Tests/WikiFSTests/SourceMaterializerTests.swift
@@ -48,6 +48,63 @@ struct SourceMaterializerTests {
 
     // MARK: - AC.1: WebsiteMaterializer + store provenance
 
+    @Test func localWebsiteZoteroAndMarkdownFolderShareDetectorPolicy() async throws {
+        let pdfBytes = Data("%PDF-1.7".utf8)
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detector-policy-\(UUID().uuidString).txt")
+        try pdfBytes.write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+
+        let local = try await LocalFileMaterializer(fileURL: localURL).materialize()
+        #expect(local.mimeType == MimeType.pdf)
+        #expect(local.detectionResult.evidence.contains { $0.origin == .filenameExtension })
+
+        let website = try await WebsiteMaterializer(
+            rawInput: "https://example.com/report.txt",
+            fetcher: FakeFetcher(response: .init(
+                data: pdfBytes,
+                contentType: "text/plain",
+                finalURL: URL(string: "https://example.com/report.txt")!)))
+            .materialize()
+        #expect(website.mimeType == MimeType.pdf)
+        #expect(website.detectionHints.declaredMIME?.origin == .httpResponse)
+        #expect(website.detectionResult.conflicts.contains {
+            $0.conflictingEvidence.origin == .httpResponse
+        })
+
+        let zoteroDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("detector-zotero-\(UUID().uuidString)", isDirectory: true)
+        let attachmentDirectory = zoteroDirectory
+            .appendingPathComponent("storage", isDirectory: true)
+            .appendingPathComponent("DETECTOR", isDirectory: true)
+        try FileManager.default.createDirectory(at: attachmentDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: zoteroDirectory) }
+        try pdfBytes.write(to: attachmentDirectory.appendingPathComponent("report.txt"))
+        let zotero = try await ZoteroMaterializer(
+            attachment: .init(
+                key: "DETECTOR", parentItem: "PARENT", linkMode: "imported_file",
+                filename: "report.txt", contentType: "text/plain", title: nil),
+            parentItem: .init(
+                key: "PARENT", version: 1, itemType: "document",
+                title: "Report", creatorSummary: nil, date: nil),
+            zoteroDir: zoteroDirectory)
+            .materialize()
+        #expect(zotero.mimeType == MimeType.pdf)
+        #expect(zotero.detectionHints.declaredMIME?.origin == .zoteroMetadata)
+        #expect(zotero.detectionResult.conflicts.contains {
+            $0.conflictingEvidence.origin == .zoteroMetadata
+        })
+
+        let folder = try await MarkdownFolderMaterializer(
+            filename: "report.txt", data: pdfBytes, mimeType: "text/plain")
+            .materialize()
+        #expect(folder.mimeType == MimeType.pdf)
+        #expect(folder.detectionHints.declaredMIME?.origin == .trustedGenerated)
+        #expect(folder.detectionResult.conflicts.contains {
+            $0.conflictingEvidence.origin == .trustedGenerated
+        })
+    }
+
     @Test func websiteProviderRecordsOriginURL() async throws {
         let fetcher = FakeFetcher(response: htmlResponse(
             "<html><head><title>Example</title></head><body><p>Hi</p></body></html>",

--- a/plans/centralized-mime-detection.md
+++ b/plans/centralized-mime-detection.md
@@ -49,6 +49,14 @@ The detector recognizes JSON, XML, SVG, HTML, XHTML, and plausible UTF-8 text. J
 
 `ContentArtifactValidator` validates JSON Canvas separately. It requires complete JSON with `nodes` and `edges` object arrays. Renderer matching repeats this bounded validation and fails closed for legacy or truncated input.
 
+## Architecture boundary
+
+`ContentTypeDetector` is a pure `WikiFSCore` policy. It is stateless, synchronous, and deterministic.
+
+The detector does not own resources or mutable operation state. It has no activation order or disposal work. Therefore, it is not a Cordis service.
+
+Cordis-composed ingestion services call the typed detector API as ordinary code. Architecture tests reject Cordis imports, service keys, and component definitions for content detection.
+
 ## Persistence
 
 Initial source writes, refresh versions, and snapshot image writes run the detector from their byte payload. The store writes the same normalized MIME to the active `source_versions` row and the `sources` mirror.


### PR DESCRIPTION
Summary: inventory production byte-bearing source writers; add direct conflict tests for providers, CLI, refresh, snapshots, and GRDB boundaries; test truncated and conflicting common signatures; enforce the pure WikiFSCore and Cordis-free boundary; document the architecture decision. Validation: all focused suites pass; make build passes; make test passes with 3,624 tests in 370 suites; repository hooks report zero lint violations. Closes #1128.