### PR TITLE
Fix persisted chat tab resolution

### DIFF
--- a/Sources/WikiFS/Chats/ChatDetailPresentation.swift
+++ b/Sources/WikiFS/Chats/ChatDetailPresentation.swift
@@ -7,7 +7,9 @@ import WikiFSCore
 struct ChatDetailPresentation {
     enum ContentState: Equatable {
         case internals
-        case missingChat
+        case loadingChat
+        case deletedChat
+        case failedToLoadChat(String)
         case chatSurface
     }
 
@@ -54,7 +56,7 @@ struct ChatDetailPresentation {
 
     static func make(
         chatID: ChatID?,
-        chatSummary: ChatSummary?,
+        chatResolution: ChatResolution?,
         showsInternals: Bool,
         remoteSession: RemoteState,
         persistedTranscriptItems: [PersistedChatTranscriptItem],
@@ -102,8 +104,17 @@ struct ChatDetailPresentation {
         let contentState: ContentState
         if showsInternals && controls.showsDebugControls {
             contentState = .internals
-        } else if chatID != nil && !isLiveChat && chatSummary == nil {
-            contentState = .missingChat
+        } else if chatID != nil && !isLiveChat {
+            switch chatResolution {
+            case .available:
+                contentState = .chatSurface
+            case .notFound:
+                contentState = .deletedChat
+            case .failed(let message):
+                contentState = .failedToLoadChat(message)
+            case nil:
+                contentState = .loadingChat
+            }
         } else {
             contentState = .chatSurface
         }

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -33,6 +33,8 @@ struct ChatDetailView: View {
     @State private var queuedMessages: [PendingQueuedMessage] = []
     @State private var diagnosticExportError: String?
     @State private var metadataState: MetadataHydrationState = .idle
+    @State private var chatResolution: ChatResolution?
+    @State private var chatResolutionRetryVersion = 0
     /// Durable data is refreshed by the keyed read task. Daemon snapshots only
     /// re-project this cache; they never cause a SQLite read from the inspector.
     @State private var durableChatMetadata: ChatMetadataInput?
@@ -44,7 +46,10 @@ struct ChatDetailView: View {
     }
 
     private var chatSummary: ChatSummary? {
-        store.chats.first { $0.id == chatID }
+        if case .available(let summary) = chatResolution {
+            return summary
+        }
+        return nil
     }
 
     private var remotePresentationState: ChatDetailPresentation.RemoteState {
@@ -63,7 +68,7 @@ struct ChatDetailView: View {
     private var presentation: ChatDetailPresentation {
         ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: chatSummary,
+            chatResolution: chatResolution,
             showsInternals: showsInternals,
             remoteSession: remotePresentationState,
             persistedTranscriptItems: persistedTranscriptItems,
@@ -131,6 +136,17 @@ struct ChatDetailView: View {
             }
             guard !runState.isAnswering, runState.isLive, !queuedMessages.isEmpty else { return }
             firePendingQueuedMessage()
+        }
+        .task(id: ChatResolutionTaskKey(
+            chatID: chatID,
+            messageVersion: store.messageVersion,
+            retryVersion: chatResolutionRetryVersion
+        )) {
+            guard let chatID, !isLiveChat else {
+                chatResolution = nil
+                return
+            }
+            chatResolution = store.resolveChat(id: chatID)
         }
         .task(id: ChatHydrationTaskKey(chatID: chatID, sessionID: remoteSession.instanceID)) {
             if let chatID {
@@ -259,8 +275,14 @@ struct ChatDetailView: View {
         case .internals:
             internalsContent
 
-        case .missingChat:
-            missingChatContent
+        case .loadingChat:
+            loadingChatContent
+
+        case .deletedChat:
+            deletedChatContent
+
+        case .failedToLoadChat(let message):
+            failedToLoadChatContent(message: message)
 
         case .chatSurface:
             chatSurfaceContent
@@ -277,11 +299,34 @@ struct ChatDetailView: View {
         .padding(ChatMetrics.contentInset)
     }
 
-    private var missingChatContent: some View {
+    private var loadingChatContent: some View {
         ContentUnavailableView {
-            Label("Chat Missing", systemImage: ResourceKind.chat.systemImageName)
+            Label("Loading Chat", systemImage: ResourceKind.chat.systemImageName)
         } description: {
-            Text("This chat is no longer available.")
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel("Loading chat")
+        }
+    }
+
+    private var deletedChatContent: some View {
+        ContentUnavailableView {
+            Label("Chat Deleted", systemImage: ResourceKind.chat.systemImageName)
+        } description: {
+            Text("This chat no longer exists in this wiki.")
+        }
+    }
+
+    private func failedToLoadChatContent(message: String) -> some View {
+        ContentUnavailableView {
+            Label("Couldn’t Load Chat", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Retry") {
+                chatResolution = nil
+                chatResolutionRetryVersion &+= 1
+            }
         }
     }
 
@@ -830,6 +875,12 @@ private struct ChatAnchorTaskKey: Hashable {
     let chatID: ChatID?
     let anchorVersion: Int
     let messageCount: Int
+}
+
+private struct ChatResolutionTaskKey: Hashable {
+    let chatID: ChatID?
+    let messageVersion: Int
+    let retryVersion: Int
 }
 
 private struct ChatHydrationTaskKey: Hashable {

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -23,6 +23,12 @@ public struct SearchUpgradeState: Identifiable {
     }
 }
 
+public enum ChatResolution: Equatable, Sendable {
+    case available(ChatSummary)
+    case notFound
+    case failed(String)
+}
+
 /// The app's single source of truth for wiki state and the in-flight editing
 /// session. `@MainActor @Observable` (uses `Observation`, NOT SwiftUI — this
 /// type is UI-framework-agnostic so it can be unit-tested directly).
@@ -4594,10 +4600,24 @@ public final class WikiStoreModel {
         }
     }
 
-    /// `@MainActor` wrapper for `getChat(id:)` (#830). Returns `nil` if the
-    /// chat doesn't exist or the read fails.
+    /// Resolves one chat authoritatively instead of inferring existence from
+    /// the cached `chats` projection. Only `.chatNotFound` means the chat was
+    /// deleted; database failures remain retryable errors.
+    public func resolveChat(id: ChatID) -> ChatResolution {
+        do {
+            return .available(try store.getChat(id: id))
+        } catch WikiStoreError.chatNotFound {
+            return .notFound
+        } catch {
+            DebugLog.store("WikiStoreModel.resolveChat failed for \(id.rawValue): \(error)")
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    /// Compatibility wrapper for callers that only need an optional summary.
     public func getChat(id: ChatID) -> ChatSummary? {
-        DebugLog.trying("getChat", operation: { try store.getChat(id: id) })
+        guard case .available(let summary) = resolveChat(id: id) else { return nil }
+        return summary
     }
 
     /// `@MainActor` wrapper for the per-chat model override write/clear (the

--- a/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
@@ -12,7 +12,7 @@ struct ChatDetailPresentationTests {
     @Test func contentStateShowsInternalsOnlyForRunningQueryDebugSurface() {
         let presentation = ChatDetailPresentation.make(
             chatID: ChatID(rawValue: "01J" + String(repeating: "A", count: 22)),
-            chatSummary: nil,
+            chatResolution: nil,
             showsInternals: true,
             remoteSession: .fixture(runState: .answering, runningKind: .query),
             persistedTranscriptItems: [],
@@ -25,10 +25,10 @@ struct ChatDetailPresentationTests {
         #expect(presentation.controls.showsDebugControls)
     }
 
-    @Test func contentStateShowsMissingForDeletedPersistedChat() {
+    @Test func unresolvedPersistedChatShowsLoadingUntilAuthoritativeLookupCompletes() {
         let presentation = ChatDetailPresentation.make(
             chatID: ChatID(rawValue: "01J" + String(repeating: "B", count: 22)),
-            chatSummary: nil,
+            chatResolution: nil,
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: [],
@@ -37,7 +37,37 @@ struct ChatDetailPresentationTests {
             isChatOperationConfigured: true
         )
 
-        #expect(presentation.contentState == .missingChat)
+        #expect(presentation.contentState == .loadingChat)
+    }
+
+    @Test func contentStateShowsDeletedOnlyAfterAuthoritativeNotFound() {
+        let presentation = ChatDetailPresentation.make(
+            chatID: ChatID(rawValue: "01J" + String(repeating: "N", count: 22)),
+            chatResolution: .notFound,
+            showsInternals: false,
+            remoteSession: .fixture(),
+            persistedTranscriptItems: [],
+            queuedMessages: [],
+            hasDraftText: false,
+            isChatOperationConfigured: true
+        )
+
+        #expect(presentation.contentState == .deletedChat)
+    }
+
+    @Test func contentStateKeepsReadFailureDistinctFromDeletion() {
+        let presentation = ChatDetailPresentation.make(
+            chatID: ChatID(rawValue: "01J" + String(repeating: "F", count: 22)),
+            chatResolution: .failed("database is busy"),
+            showsInternals: false,
+            remoteSession: .fixture(),
+            persistedTranscriptItems: [],
+            queuedMessages: [],
+            hasDraftText: false,
+            isChatOperationConfigured: true
+        )
+
+        #expect(presentation.contentState == .failedToLoadChat("database is busy"))
     }
 
     @Test func transcriptProjectionSelectsTheTypedLiveTranscriptInsteadOfPersistedRows() {
@@ -62,7 +92,7 @@ struct ChatDetailPresentationTests {
         ])
         let live = ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
+            chatResolution: .available(ChatSummary.fixture(id: chatID)),
             showsInternals: false,
             remoteSession: .fixture(
                 sessionChatID: chatID,
@@ -76,7 +106,7 @@ struct ChatDetailPresentationTests {
         )
         let persisted = ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
+            chatResolution: .available(ChatSummary.fixture(id: chatID)),
             showsInternals: false,
             remoteSession: .fixture(transcript: liveTranscript),
             persistedTranscriptItems: persistedItems,
@@ -141,7 +171,7 @@ struct ChatDetailPresentationTests {
         #expect(persistedAssistant.cachedResponseSummary == "Distinctive model summary.")
         let presentation = ChatDetailPresentation.make(
             chatID: chat.id,
-            chatSummary: chat,
+            chatResolution: .available(chat),
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: page.items,
@@ -174,7 +204,7 @@ struct ChatDetailPresentationTests {
 
         let live = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(sessionChatID: liveChatID, runState: .warm, pendingPermissions: [request]),
             persistedTranscriptItems: [],
@@ -184,7 +214,7 @@ struct ChatDetailPresentationTests {
         )
         let persisted = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(pendingPermissions: [request]),
             persistedTranscriptItems: [],
@@ -201,7 +231,7 @@ struct ChatDetailPresentationTests {
         let liveChatID = ChatID(rawValue: "01J" + String(repeating: "E", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(
                 sessionChatID: liveChatID,
@@ -224,7 +254,7 @@ struct ChatDetailPresentationTests {
         let liveChatID = ChatID(rawValue: "01J" + String(repeating: "F", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(
                 sessionChatID: liveChatID,
@@ -245,7 +275,7 @@ struct ChatDetailPresentationTests {
     @Test func composerProjectionDisablesInputAndSendWhenChatOperationIsNotConfigured() {
         let presentation = ChatDetailPresentation.make(
             chatID: nil,
-            chatSummary: nil,
+            chatResolution: nil,
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: [],
@@ -263,7 +293,7 @@ struct ChatDetailPresentationTests {
         let chatID = ChatID(rawValue: "01J" + String(repeating: "G", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
+            chatResolution: .available(ChatSummary.fixture(id: chatID)),
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: [],

--- a/Tests/WikiFSAppTests/ChatViewD2Tests.swift
+++ b/Tests/WikiFSAppTests/ChatViewD2Tests.swift
@@ -72,6 +72,21 @@ struct ChatViewD2Tests {
 
     // MARK: - (a) Source-of-truth rule + flip timing
 
+    @Test func persistedChatResolvesByIDWhenSummaryCacheIsStale() throws {
+        let (model, store) = try tempModel()
+        let chat = try store.createChat(kind: .edit, title: "Created outside the model")
+
+        #expect(model.chats.contains { $0.id == chat.id } == false)
+        #expect(model.resolveChat(id: chat.id) == .available(chat))
+    }
+
+    @Test func absentPersistedChatResolvesAsNotFound() throws {
+        let (model, _) = try tempModel()
+        let missingID = ChatID(rawValue: "01J" + String(repeating: "Z", count: 22))
+
+        #expect(model.resolveChat(id: missingID) == .notFound)
+    }
+
     @Test func activeChatID_isNil_byDefault() {
         let launcher = makeLauncher()
         #expect(launcher.activeChatID == nil)


### PR DESCRIPTION
## Summary

- Resolve persisted chat tabs by exact chat ID from SQLite.
- Keep loading, deleted, and read-failure states separate.
- Add a Retry action for database read failures.
- Add tests for stale chat-summary caches and authoritative not-found results.

## Problem

A persisted chat could exist in SQLite but remain absent from the app chat-summary cache. The chat tab then showed “Chat Missing” because it treated cache absence as deletion.

## Verification

- `make build`
- `make test` — 3,653 tests passed in 374 suites
- Pre-commit Swift lint — 0 violations in 587 files
- No new bare `try?`
