### PR TITLE
Fix chat detail resolution and improve wikictl input

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -100,7 +100,8 @@ public enum ArgumentParser {
                                               print a page body; --json adds head_version_id;
                                               --workspace W reads the staged version
       page add --title X [--id Y] --body-file <path|-> [--expect-head <ver>] [--workspace W] [--author <who>] [--source <source-id[:role]> ...]
-                                              create-or-update a page;
+                                              create-or-update a page; use --body-file -
+                                              with a pipe or heredoc;
                                               --expect-head enables CAS (exit 3 on conflict);
                                               --workspace W writes into workspace W;
                                               --author <who> stamps created_by/last_edited_by (defaults to WIKI_AUTHOR env)
@@ -121,8 +122,10 @@ public enum ArgumentParser {
                                               rewrite the curated index.md body;
                                               --workspace W stages into workspace W
       source list [--json]                    list sources (TSV, or JSON lines)
-      source add --url URL [--allow-duplicate]
-                                              fetch and add a URL source
+      source add (--url URL [--allow-duplicate] | --body-file <path|-> [--name NAME])
+                                              fetch a URL or add raw file/stdin bytes;
+                                              use --body-file - with a pipe or heredoc;
+                                              --name is required for stdin
       source cat  (--id X | --name N) [--markdown]
                                               write raw source bytes (or extracted markdown
                                               with --markdown) to stdout
@@ -474,10 +477,25 @@ public enum ArgumentParser {
 
         switch sub {
         case "add":
-            guard let url = options.value("--url") else {
-                throw Failure.usage("source add: --url is required")
+            let url = options.value("--url")
+            let bodyFile = options.value("--body-file")
+            guard (url == nil) != (bodyFile == nil) else {
+                throw Failure.usage("source add: pass exactly one of --url URL or --body-file <path|->")
             }
-            return .source(.addURL(url, allowDuplicateURL: options.flag("--allow-duplicate")))
+            if let url {
+                return .source(.addURL(url, allowDuplicateURL: options.flag("--allow-duplicate")))
+            }
+            guard !options.flag("--allow-duplicate") else {
+                throw Failure.usage("source add: --allow-duplicate applies only to --url")
+            }
+            guard let bodyFile else {
+                throw Failure.usage("source add: --body-file is required")
+            }
+            let name = options.value("--name")
+            if bodyFile == "-", name == nil {
+                throw Failure.usage("source add: --name is required when --body-file is -")
+            }
+            return .source(.addFile(path: bodyFile, name: name))
         case "list":
             return .source(.list(json: options.flag("--json")))
 

--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -55,6 +55,8 @@ public enum ArgumentParser {
         case bookmark(BookmarkCommand.Action)
         /// Workspace commands (W1, PR #312): create, status, abandon, merge.
         case workspace(WorkspaceCommand.Action)
+        /// Print command usage. Does not require a wiki selection.
+        case help
         /// Print build version info. Does not require a wiki selection.
         case version(json: Bool)
         /// Print the resolved Cordis profile. Does not require a wiki selection.
@@ -192,10 +194,12 @@ public enum ArgumentParser {
     ) throws -> Invocation {
         var args = arguments
 
-        // `version` / `--version` / `-v` — print build version info and exit.
-        // Intercepted BEFORE the wiki selector requirement so it works without
-        // --wiki or WIKI_DB.
+        // Help and version commands are intercepted BEFORE the wiki selector
+        // requirement so they work without --wiki or WIKI_DB.
         if let first = args.first {
+            if first == "--help" {
+                return Invocation(wikiSelector: "", command: .help)
+            }
             if first == "version" {
                 let options = try Options(Array(args.dropFirst()), booleanFlags: ["--json"])
                 return Invocation(wikiSelector: "", command: .version(json: options.flag("--json")))

--- a/Sources/WikiCtlCore/SourceCommand.swift
+++ b/Sources/WikiCtlCore/SourceCommand.swift
@@ -39,6 +39,8 @@ public enum SourceCommand {
 
     public enum Action: Equatable {
         case addURL(String, allowDuplicateURL: Bool)
+        /// Add raw source bytes from a body-file path or `-` for stdin.
+        case addFile(path: String, name: String?)
         case list(json: Bool)
         case cat(Selector, markdown: Bool)
         case export(Selector, out: String?, markdown: Bool)
@@ -82,7 +84,9 @@ public enum SourceCommand {
     ) throws -> Result {
         switch action {
         case .addURL:
-            throw Failure.message("source add requires async execution")
+            throw Failure.message("source add --url requires async execution")
+        case .addFile(let path, let name):
+            return try addFile(path: path, name: name, in: store)
         case .list(let json):
             return try list(in: store, json: json)
         case .cat(let selector, let markdown):
@@ -161,6 +165,49 @@ public enum SourceCommand {
             ingestMetadata: material.ingestMetadata,
             provenance: material.provenance,
             role: .primary, originalPath: nil, activityID: nil,
+            resolvedDisplayName: nil)
+        return Result(
+            payload: .text("Added \(summary.effectiveName) (\(summary.id.rawValue))."),
+            didCommit: true)
+    }
+
+    private static func readSourceData(_ path: String) throws -> Data {
+        if path == "-" {
+            return FileHandle.standardInput.readDataToEndOfFile()
+        }
+        return try Data(contentsOf: URL(fileURLWithPath: path))
+    }
+
+    private static func addFile(path: String, name: String?, in store: WikiStore) throws -> Result {
+        let data = try readSourceData(path)
+        return try addFile(path: path, name: name, data: data, in: store)
+    }
+
+    static func addFile(
+        path: String,
+        name: String?,
+        data: Data,
+        in store: WikiStore
+    ) throws -> Result {
+        let filename: String
+        if let name {
+            filename = name
+        } else {
+            filename = URL(fileURLWithPath: path).lastPathComponent
+        }
+        guard !filename.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw Failure.message("source add: --name must not be empty")
+        }
+
+        let summary = try store.addSource(
+            filename: filename,
+            data: data,
+            detectionHints: ContentTypeDetectionHints(filename: filename),
+            ingestMetadata: nil,
+            provenance: SourceProvenance(agentName: "wikictl", activityKind: "import", plan: path == "-" ? "stdin" : path),
+            role: .primary,
+            originalPath: path == "-" ? nil : path,
+            activityID: nil,
             resolvedDisplayName: nil)
         return Result(
             payload: .text("Added \(summary.effectiveName) (\(summary.id.rawValue))."),

--- a/Sources/WikiFS/Chats/ChatDetailPresentation.swift
+++ b/Sources/WikiFS/Chats/ChatDetailPresentation.swift
@@ -7,7 +7,9 @@ import WikiFSCore
 struct ChatDetailPresentation {
     enum ContentState: Equatable {
         case internals
-        case missingChat
+        case loadingChat
+        case deletedChat
+        case failedToLoadChat(String)
         case chatSurface
     }
 
@@ -54,7 +56,7 @@ struct ChatDetailPresentation {
 
     static func make(
         chatID: ChatID?,
-        chatSummary: ChatSummary?,
+        chatResolution: ChatResolution?,
         showsInternals: Bool,
         remoteSession: RemoteState,
         persistedTranscriptItems: [PersistedChatTranscriptItem],
@@ -102,8 +104,17 @@ struct ChatDetailPresentation {
         let contentState: ContentState
         if showsInternals && controls.showsDebugControls {
             contentState = .internals
-        } else if chatID != nil && !isLiveChat && chatSummary == nil {
-            contentState = .missingChat
+        } else if chatID != nil && !isLiveChat {
+            switch chatResolution {
+            case .available:
+                contentState = .chatSurface
+            case .notFound:
+                contentState = .deletedChat
+            case .failed(let message):
+                contentState = .failedToLoadChat(message)
+            case nil:
+                contentState = .loadingChat
+            }
         } else {
             contentState = .chatSurface
         }

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -33,6 +33,8 @@ struct ChatDetailView: View {
     @State private var queuedMessages: [PendingQueuedMessage] = []
     @State private var diagnosticExportError: String?
     @State private var metadataState: MetadataHydrationState = .idle
+    @State private var chatResolution: ChatResolution?
+    @State private var chatResolutionRetryVersion = 0
     /// Durable data is refreshed by the keyed read task. Daemon snapshots only
     /// re-project this cache; they never cause a SQLite read from the inspector.
     @State private var durableChatMetadata: ChatMetadataInput?
@@ -44,7 +46,10 @@ struct ChatDetailView: View {
     }
 
     private var chatSummary: ChatSummary? {
-        store.chats.first { $0.id == chatID }
+        if case .available(let summary) = chatResolution {
+            return summary
+        }
+        return nil
     }
 
     private var remotePresentationState: ChatDetailPresentation.RemoteState {
@@ -63,7 +68,7 @@ struct ChatDetailView: View {
     private var presentation: ChatDetailPresentation {
         ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: chatSummary,
+            chatResolution: chatResolution,
             showsInternals: showsInternals,
             remoteSession: remotePresentationState,
             persistedTranscriptItems: persistedTranscriptItems,
@@ -131,6 +136,17 @@ struct ChatDetailView: View {
             }
             guard !runState.isAnswering, runState.isLive, !queuedMessages.isEmpty else { return }
             firePendingQueuedMessage()
+        }
+        .task(id: ChatResolutionTaskKey(
+            chatID: chatID,
+            messageVersion: store.messageVersion,
+            retryVersion: chatResolutionRetryVersion
+        )) {
+            guard let chatID, !isLiveChat else {
+                chatResolution = nil
+                return
+            }
+            chatResolution = store.resolveChat(id: chatID)
         }
         .task(id: ChatHydrationTaskKey(chatID: chatID, sessionID: remoteSession.instanceID)) {
             if let chatID {
@@ -259,8 +275,14 @@ struct ChatDetailView: View {
         case .internals:
             internalsContent
 
-        case .missingChat:
-            missingChatContent
+        case .loadingChat:
+            loadingChatContent
+
+        case .deletedChat:
+            deletedChatContent
+
+        case .failedToLoadChat(let message):
+            failedToLoadChatContent(message: message)
 
         case .chatSurface:
             chatSurfaceContent
@@ -277,11 +299,34 @@ struct ChatDetailView: View {
         .padding(ChatMetrics.contentInset)
     }
 
-    private var missingChatContent: some View {
+    private var loadingChatContent: some View {
         ContentUnavailableView {
-            Label("Chat Missing", systemImage: ResourceKind.chat.systemImageName)
+            Label("Loading Chat", systemImage: ResourceKind.chat.systemImageName)
         } description: {
-            Text("This chat is no longer available.")
+            ProgressView()
+                .controlSize(.small)
+                .accessibilityLabel("Loading chat")
+        }
+    }
+
+    private var deletedChatContent: some View {
+        ContentUnavailableView {
+            Label("Chat Deleted", systemImage: ResourceKind.chat.systemImageName)
+        } description: {
+            Text("This chat no longer exists in this wiki.")
+        }
+    }
+
+    private func failedToLoadChatContent(message: String) -> some View {
+        ContentUnavailableView {
+            Label("Couldn’t Load Chat", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text(message)
+        } actions: {
+            Button("Retry") {
+                chatResolution = nil
+                chatResolutionRetryVersion &+= 1
+            }
         }
     }
 
@@ -830,6 +875,12 @@ private struct ChatAnchorTaskKey: Hashable {
     let chatID: ChatID?
     let anchorVersion: Int
     let messageCount: Int
+}
+
+private struct ChatResolutionTaskKey: Hashable {
+    let chatID: ChatID?
+    let messageVersion: Int
+    let retryVersion: Int
 }
 
 private struct ChatHydrationTaskKey: Hashable {

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -23,6 +23,12 @@ public struct SearchUpgradeState: Identifiable {
     }
 }
 
+public enum ChatResolution: Equatable, Sendable {
+    case available(ChatSummary)
+    case notFound
+    case failed(String)
+}
+
 /// The app's single source of truth for wiki state and the in-flight editing
 /// session. `@MainActor @Observable` (uses `Observation`, NOT SwiftUI — this
 /// type is UI-framework-agnostic so it can be unit-tested directly).
@@ -4594,10 +4600,24 @@ public final class WikiStoreModel {
         }
     }
 
-    /// `@MainActor` wrapper for `getChat(id:)` (#830). Returns `nil` if the
-    /// chat doesn't exist or the read fails.
+    /// Resolves one chat authoritatively instead of inferring existence from
+    /// the cached `chats` projection. Only `.chatNotFound` means the chat was
+    /// deleted; database failures remain retryable errors.
+    public func resolveChat(id: ChatID) -> ChatResolution {
+        do {
+            return .available(try store.getChat(id: id))
+        } catch WikiStoreError.chatNotFound {
+            return .notFound
+        } catch {
+            DebugLog.store("WikiStoreModel.resolveChat failed for \(id.rawValue): \(error)")
+            return .failed(error.localizedDescription)
+        }
+    }
+
+    /// Compatibility wrapper for callers that only need an optional summary.
     public func getChat(id: ChatID) -> ChatSummary? {
-        DebugLog.trying("getChat", operation: { try store.getChat(id: id) })
+        guard case .available(let summary) = resolveChat(id: id) else { return nil }
+        return summary
     }
 
     /// `@MainActor` wrapper for the per-chat model override write/clear (the

--- a/Sources/wikictl/main.swift
+++ b/Sources/wikictl/main.swift
@@ -30,7 +30,12 @@ func run() async -> Int32 {
         return 2
     }
 
-    // `version` doesn't need a wiki — print and exit before wiki resolution.
+    // Help and version don't need a wiki — print and exit before wiki resolution.
+    if case .help = invocation.command {
+        print(ArgumentParser.usageText)
+        return 0
+    }
+
     if case .version(let json) = invocation.command {
         // The App Group id and WHERE it came from are reported here on purpose.
         // A wrong container is otherwise invisible: the CLI just says "no wiki
@@ -196,7 +201,7 @@ func execute(
     case .workspace(let action):
         let r = try WorkspaceCommand.run(action, in: store)
         return SourceCommand.Result(payload: .text(r.output), didCommit: r.didCommit)
-    case .version, .dumpConfig:
+    case .help, .version, .dumpConfig:
         // Handled before wiki resolution in `run()` — unreachable here.
         return SourceCommand.Result(payload: .text(""), didCommit: false)
     case .wikiList, .wikiCreate, .wikiDelete, .wikiRename:

--- a/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
@@ -12,7 +12,7 @@ struct ChatDetailPresentationTests {
     @Test func contentStateShowsInternalsOnlyForRunningQueryDebugSurface() {
         let presentation = ChatDetailPresentation.make(
             chatID: ChatID(rawValue: "01J" + String(repeating: "A", count: 22)),
-            chatSummary: nil,
+            chatResolution: nil,
             showsInternals: true,
             remoteSession: .fixture(runState: .answering, runningKind: .query),
             persistedTranscriptItems: [],
@@ -25,10 +25,10 @@ struct ChatDetailPresentationTests {
         #expect(presentation.controls.showsDebugControls)
     }
 
-    @Test func contentStateShowsMissingForDeletedPersistedChat() {
+    @Test func unresolvedPersistedChatShowsLoadingUntilAuthoritativeLookupCompletes() {
         let presentation = ChatDetailPresentation.make(
             chatID: ChatID(rawValue: "01J" + String(repeating: "B", count: 22)),
-            chatSummary: nil,
+            chatResolution: nil,
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: [],
@@ -37,7 +37,37 @@ struct ChatDetailPresentationTests {
             isChatOperationConfigured: true
         )
 
-        #expect(presentation.contentState == .missingChat)
+        #expect(presentation.contentState == .loadingChat)
+    }
+
+    @Test func contentStateShowsDeletedOnlyAfterAuthoritativeNotFound() {
+        let presentation = ChatDetailPresentation.make(
+            chatID: ChatID(rawValue: "01J" + String(repeating: "N", count: 22)),
+            chatResolution: .notFound,
+            showsInternals: false,
+            remoteSession: .fixture(),
+            persistedTranscriptItems: [],
+            queuedMessages: [],
+            hasDraftText: false,
+            isChatOperationConfigured: true
+        )
+
+        #expect(presentation.contentState == .deletedChat)
+    }
+
+    @Test func contentStateKeepsReadFailureDistinctFromDeletion() {
+        let presentation = ChatDetailPresentation.make(
+            chatID: ChatID(rawValue: "01J" + String(repeating: "F", count: 22)),
+            chatResolution: .failed("database is busy"),
+            showsInternals: false,
+            remoteSession: .fixture(),
+            persistedTranscriptItems: [],
+            queuedMessages: [],
+            hasDraftText: false,
+            isChatOperationConfigured: true
+        )
+
+        #expect(presentation.contentState == .failedToLoadChat("database is busy"))
     }
 
     @Test func transcriptProjectionSelectsTheTypedLiveTranscriptInsteadOfPersistedRows() {
@@ -62,7 +92,7 @@ struct ChatDetailPresentationTests {
         ])
         let live = ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
+            chatResolution: .available(ChatSummary.fixture(id: chatID)),
             showsInternals: false,
             remoteSession: .fixture(
                 sessionChatID: chatID,
@@ -76,7 +106,7 @@ struct ChatDetailPresentationTests {
         )
         let persisted = ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
+            chatResolution: .available(ChatSummary.fixture(id: chatID)),
             showsInternals: false,
             remoteSession: .fixture(transcript: liveTranscript),
             persistedTranscriptItems: persistedItems,
@@ -141,7 +171,7 @@ struct ChatDetailPresentationTests {
         #expect(persistedAssistant.cachedResponseSummary == "Distinctive model summary.")
         let presentation = ChatDetailPresentation.make(
             chatID: chat.id,
-            chatSummary: chat,
+            chatResolution: .available(chat),
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: page.items,
@@ -174,7 +204,7 @@ struct ChatDetailPresentationTests {
 
         let live = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(sessionChatID: liveChatID, runState: .warm, pendingPermissions: [request]),
             persistedTranscriptItems: [],
@@ -184,7 +214,7 @@ struct ChatDetailPresentationTests {
         )
         let persisted = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(pendingPermissions: [request]),
             persistedTranscriptItems: [],
@@ -201,7 +231,7 @@ struct ChatDetailPresentationTests {
         let liveChatID = ChatID(rawValue: "01J" + String(repeating: "E", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(
                 sessionChatID: liveChatID,
@@ -224,7 +254,7 @@ struct ChatDetailPresentationTests {
         let liveChatID = ChatID(rawValue: "01J" + String(repeating: "F", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: liveChatID,
-            chatSummary: ChatSummary.fixture(id: liveChatID),
+            chatResolution: .available(ChatSummary.fixture(id: liveChatID)),
             showsInternals: false,
             remoteSession: .fixture(
                 sessionChatID: liveChatID,
@@ -245,7 +275,7 @@ struct ChatDetailPresentationTests {
     @Test func composerProjectionDisablesInputAndSendWhenChatOperationIsNotConfigured() {
         let presentation = ChatDetailPresentation.make(
             chatID: nil,
-            chatSummary: nil,
+            chatResolution: nil,
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: [],
@@ -263,7 +293,7 @@ struct ChatDetailPresentationTests {
         let chatID = ChatID(rawValue: "01J" + String(repeating: "G", count: 22))
         let presentation = ChatDetailPresentation.make(
             chatID: chatID,
-            chatSummary: ChatSummary.fixture(id: chatID),
+            chatResolution: .available(ChatSummary.fixture(id: chatID)),
             showsInternals: false,
             remoteSession: .fixture(),
             persistedTranscriptItems: [],

--- a/Tests/WikiFSAppTests/ChatViewD2Tests.swift
+++ b/Tests/WikiFSAppTests/ChatViewD2Tests.swift
@@ -72,6 +72,21 @@ struct ChatViewD2Tests {
 
     // MARK: - (a) Source-of-truth rule + flip timing
 
+    @Test func persistedChatResolvesByIDWhenSummaryCacheIsStale() throws {
+        let (model, store) = try tempModel()
+        let chat = try store.createChat(kind: .edit, title: "Created outside the model")
+
+        #expect(model.chats.contains { $0.id == chat.id } == false)
+        #expect(model.resolveChat(id: chat.id) == .available(chat))
+    }
+
+    @Test func absentPersistedChatResolvesAsNotFound() throws {
+        let (model, _) = try tempModel()
+        let missingID = ChatID(rawValue: "01J" + String(repeating: "Z", count: 22))
+
+        #expect(model.resolveChat(id: missingID) == .notFound)
+    }
+
     @Test func activeChatID_isNil_byDefault() {
         let launcher = makeLauncher()
         #expect(launcher.activeChatID == nil)

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -18,6 +18,12 @@ struct WikiCtlCommandTests {
 
     // MARK: - Argument parsing
 
+    @Test func parsesTopLevelHelpWithoutWikiSelector() throws {
+        let invocation = try ArgumentParser.parse(["--help"], env: noEnv)
+        #expect(invocation.wikiSelector.isEmpty)
+        #expect(invocation.command == .help)
+    }
+
     @Test func parsesWikiFromFlag() throws {
         let invocation = try ArgumentParser.parse(["--wiki", "WIKI1", "page", "list"], env: noEnv)
         #expect(invocation.wikiSelector == "WIKI1")

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -24,6 +24,12 @@ struct WikiCtlCommandTests {
         #expect(invocation.command == .help)
     }
 
+    @Test func usageDocumentsPipeAndHeredocBodyFiles() {
+        #expect(ArgumentParser.usageText.contains("page add --title X"))
+        #expect(ArgumentParser.usageText.contains("source add (--url URL"))
+        #expect(ArgumentParser.usageText.contains("with a pipe or heredoc"))
+    }
+
     @Test func parsesWikiFromFlag() throws {
         let invocation = try ArgumentParser.parse(["--wiki", "WIKI1", "page", "list"], env: noEnv)
         #expect(invocation.wikiSelector == "WIKI1")
@@ -405,6 +411,37 @@ struct WikiCtlCommandTests {
 
     // MARK: - File command parsing
 
+    @Test func parsesSourceAddFromURL() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "add", "--url", "https://example.com"], env: noEnv)
+        #expect(invocation.command == .source(.addURL("https://example.com", allowDuplicateURL: false)))
+    }
+
+    @Test func parsesSourceAddFromBodyFileAndStdin() throws {
+        let file = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "add", "--body-file", "notes.md"], env: noEnv)
+        #expect(file.command == .source(.addFile(path: "notes.md", name: nil)))
+
+        let stdin = try ArgumentParser.parse(
+            ["--wiki", "W", "source", "add", "--name", "notes.md", "--body-file", "-"], env: noEnv)
+        #expect(stdin.command == .source(.addFile(path: "-", name: "notes.md")))
+    }
+
+    @Test func sourceAddRequiresOneInputModeAndNamesStdin() {
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(["--wiki", "W", "source", "add"], env: noEnv)
+        }
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(
+                ["--wiki", "W", "source", "add", "--url", "https://example.com", "--body-file", "notes.md"],
+                env: noEnv)
+        }
+        #expect(throws: ArgumentParser.Failure.self) {
+            try ArgumentParser.parse(
+                ["--wiki", "W", "source", "add", "--body-file", "-"], env: noEnv)
+        }
+    }
+
     @Test func parsesFileList() throws {
         let invocation = try ArgumentParser.parse(
             ["--wiki", "W", "source", "list"], env: noEnv)
@@ -467,6 +504,40 @@ struct WikiCtlCommandTests {
     }
 
     // MARK: - File command dispatch (against a temp DB)
+
+    @Test func sourceAddBodyFilePreservesBytesAndDerivesName() throws {
+        let store = try tempStore()
+        let input = FileManager.default.temporaryDirectory
+            .appendingPathComponent("wikictl-source-\(UUID().uuidString).bin")
+        let bytes = Data([0x00, 0xFF, 0x42, 0x0A])
+        try bytes.write(to: input)
+        defer {
+            do {
+                try FileManager.default.removeItem(at: input)
+            } catch {
+                Issue.record("failed to remove test input: \(error)")
+            }
+        }
+
+        let result = try SourceCommand.run(
+            .addFile(path: input.path, name: nil), in: store, cwd: "/tmp")
+        #expect(result.didCommit)
+        let source = try #require(try store.listSources().first)
+        #expect(source.filename == input.lastPathComponent)
+        #expect(try store.sourceContent(id: source.id) == bytes)
+    }
+
+    @Test func sourceAddStdinUsesSuppliedNameAndPreservesBytes() throws {
+        let store = try tempStore()
+        let bytes = Data("# From stdin\n\nPipe and heredoc body.\n".utf8)
+
+        let result = try SourceCommand.addFile(
+            path: "-", name: "piped-notes.md", data: bytes, in: store)
+        #expect(result.didCommit)
+        let source = try #require(try store.listSources().first)
+        #expect(source.filename == "piped-notes.md")
+        #expect(try store.sourceContent(id: source.id) == bytes)
+    }
 
     @Test func fileListTSV() throws {
         let store = try tempStore()


### PR DESCRIPTION
## Summary

- resolve persisted chat tabs against authoritative store state before presentation
- add a successful top-level `wikictl --help` command that does not require a wiki selection
- let `wikictl source add` ingest raw files, pipes, and heredocs through the same `--body-file <path|->` convention as `page add`

## CLI examples

```sh
wikictl --help

wikictl page add --title "Example" --body-file - <<'EOF'
# Example

Page content.
EOF

wikictl source add --name "notes.md" --body-file - <<'EOF'
# Notes

Source content.
EOF
```

Existing URL ingestion remains available as `wikictl source add --url URL`.

## Validation

- `swift test --filter WikiCtlCommandTests`: 124 tests passed
- `make test`: 3,660 tests passed across 374 suites
- pre-commit lint: 0 violations across 587 Swift files
- direct `wikictl --help` verification: exit 0, help on stdout, empty stderr
