### PR TITLE
Show XML source as text

### DIFF
--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -118,6 +118,15 @@ struct SourceRendererPresentationPlanner: Sendable {
         return MermaidSourceDetector.renderableMarkdown(from: markdown)
     }
 
+    /// Makes raw XML inert in the Markdown reader while preserving it as text.
+    nonisolated static func sourceMarkdown(for source: SourceSummary, content: String) -> String {
+        guard MimeType.isXML(source.mimeType) else { return content }
+        return content
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { "    \($0)" }
+            .joined(separator: "\n")
+    }
+
     nonisolated static func hasPresentableSource(for source: SourceSummary, currentMarkdown: String?) -> Bool {
         usesMarkdownSourcePresentation(for: source, currentMarkdown: currentMarkdown)
     }
@@ -130,7 +139,7 @@ struct SourceRendererPresentationPlanner: Sendable {
         currentMarkdown: String?
     ) -> Bool {
         currentMarkdown != nil ||
-            (!isHTMLSource(source) && source.mimeType.map(MimeType.isText) == true) ||
+            (!isHTMLSource(source) && MimeType.isSourceTextPresentable(source.mimeType)) ||
             standaloneDiagramSource(source)
     }
 
@@ -315,7 +324,7 @@ enum SourceDetailPresentationCharacterization {
             contentArea = .tabbed
         } else if isPDF {
             contentArea = .pdfOnly
-        } else if source.mimeType.map(MimeType.isText) == true {
+        } else if MimeType.isSourceTextPresentable(source.mimeType) {
             contentArea = .markdown
         } else {
             contentArea = .binaryFallback

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -134,8 +134,7 @@ struct SourceDetailView: View {
     // MARK: - Computed
 
     private var isMarkdownNative: Bool {
-        if let mime = file.mimeType { return MimeType.isText(mime) }
-        return false
+        MimeType.isSourceTextPresentable(file.mimeType)
     }
 
     /// A PDF quote anchor is consumed only before a markdown extraction exists.
@@ -1426,7 +1425,7 @@ struct SourceDetailView: View {
             // sources never reach here (they hit `binaryFallback`).
             let sourceMarkdown = SourceRendererPresentationPlanner.standaloneDiagramSource(file)
                 ? MermaidSourceDetector.codeBlockMarkdown(from: content) ?? content
-                : content
+                : SourceRendererPresentationPlanner.sourceMarkdown(for: file, content: content)
             WikiReaderView(markdown: sourceMarkdown,
                             currentSelection: store.selection,
                             store: store,

--- a/Sources/WikiFSTypes/MimeType.swift
+++ b/Sources/WikiFSTypes/MimeType.swift
@@ -48,6 +48,12 @@ public enum MimeType {
     /// `application/xhtml+xml`.
     public static let xhtml = "application/xhtml+xml"
 
+    /// `application/xml`.
+    public static let xml = "application/xml"
+
+    /// `image/svg+xml`.
+    public static let svg = "image/svg+xml"
+
     /// `image/jpeg`.
     public static let imageJPEG = "image/jpeg"
 
@@ -77,6 +83,20 @@ public enum MimeType {
     public static func isText(_ mime: String?) -> Bool {
         guard let mime else { return false }
         return mime.lowercased().hasPrefix(textPrefix)
+    }
+
+    /// Whether source bytes can be presented as text without changing ingestion policy.
+    /// XML is textual even when its MIME type is outside `text/*`; SVG remains visually
+    /// renderable while also exposing its XML source.
+    public static func isSourceTextPresentable(_ mime: String?) -> Bool {
+        isText(mime) || isXML(mime)
+    }
+
+    /// Whether `mime` contains XML source that must display as code rather than markup.
+    public static func isXML(_ mime: String?) -> Bool {
+        guard let mime else { return false }
+        let normalized = mime.lowercased()
+        return normalized == "text/xml" || normalized == xml || normalized == svg
     }
 
     /// Whether `mime` is one of the recognized Markdown variants

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -117,7 +117,11 @@ import WikiFSTypes
 
     @Test("Planner maps SVG MIME and bytes to the SVG built-in")
     func plannerMatchesSVG() throws {
-        let bytes = Data("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\"></svg>".utf8)
+        let bytes = Data("""
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+          <circle cx="5" cy="5" r="4"/>
+        </svg>
+        """.utf8)
         let source = fixtureSource(
             filename: "diagram.svg",
             ext: "svg",
@@ -131,6 +135,38 @@ import WikiFSTypes
             origin: nil)
 
         #expect(id == .svg)
+        #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
+            for: source,
+            currentMarkdown: nil))
+
+        let xml = String(decoding: bytes, as: UTF8.self)
+        let sourceMarkdown = SourceRendererPresentationPlanner.sourceMarkdown(
+            for: source,
+            content: xml)
+        #expect(sourceMarkdown.hasPrefix("    <svg"))
+        #expect(sourceMarkdown.contains("\n      <circle"))
+        #expect(sourceMarkdown.hasSuffix("\n    </svg>"))
+    }
+
+    @Test("Generic XML uses source text presentation without a renderer")
+    func genericXMLUsesSourceTextPresentation() throws {
+        for mimeType in ["application/xml", "text/xml"] {
+            let bytes = Data("<document>Hello</document>".utf8)
+            let source = fixtureSource(
+                filename: "document.xml",
+                ext: "xml",
+                mimeType: mimeType,
+                byteSize: bytes.count)
+
+            #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
+                for: source,
+                currentMarkdown: nil))
+            #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
+                for: source,
+                boundedBytes: bytes,
+                currentMarkdown: nil,
+                origin: nil) == nil)
+        }
     }
 
     @Test("SVG factory requires source bytes")

--- a/Tests/WikiFSTests/MimeTypeTests.swift
+++ b/Tests/WikiFSTests/MimeTypeTests.swift
@@ -34,6 +34,28 @@ struct MimeTypeTests {
         #expect(MimeType.isText("application/octet-stream") == false)
     }
 
+    // MARK: - isSourceTextPresentable
+
+    @Test func sourceTextPresentationIncludesXML() {
+        #expect(MimeType.isSourceTextPresentable("text/xml"))
+        #expect(MimeType.isSourceTextPresentable("application/xml"))
+        #expect(MimeType.isSourceTextPresentable("image/svg+xml"))
+        #expect(MimeType.isSourceTextPresentable("Application/XML"))
+        #expect(MimeType.isSourceTextPresentable("IMAGE/SVG+XML"))
+    }
+
+    @Test func sourceTextPresentationIncludesOrdinaryText() {
+        #expect(MimeType.isSourceTextPresentable("text/plain"))
+        #expect(MimeType.isSourceTextPresentable("text/markdown"))
+    }
+
+    @Test func sourceTextPresentationRejectsNonTextContent() {
+        #expect(MimeType.isSourceTextPresentable(nil) == false)
+        #expect(MimeType.isSourceTextPresentable("application/pdf") == false)
+        #expect(MimeType.isSourceTextPresentable("application/json") == false)
+        #expect(MimeType.isSourceTextPresentable("image/jpeg") == false)
+    }
+
     // MARK: - isPDF (nil guard — already covered, included for symmetry)
 
     @Test func isPDFReturnsFalseForNil() {


### PR DESCRIPTION
## Summary

- Show `text/xml`, `application/xml`, and `image/svg+xml` source bytes as text.
- Format XML as inert code so the Source view does not render XML elements.
- Keep the SVG image available in the Rendered and Split views.
- Keep XML excluded from automatic Markdown ingestion and extraction.

## Test plan

- `make test`
- 3,665 tests passed.
- SwiftLint reported zero violations during the commit hook.
