### PR TITLE
Restore rendering tabs in source detail

### DIFF
--- a/Sources/WikiFS/Renderer/RendererHostView.swift
+++ b/Sources/WikiFS/Renderer/RendererHostView.swift
@@ -4,21 +4,13 @@ import WikiFSTypes
 
 // pattern: Imperative Shell
 
-/// The visual and accessibility state for one presentation control.
-///
-/// Keeping this projection pure makes Source, Rendered, and Split semantics
-/// consistent for both the native control treatment and VoiceOver.
-struct RendererPresentationControlState: Sendable, Equatable {
-    let presentation: RendererSourcePresentationMode
-    let selectedPresentation: RendererSourcePresentationMode
-
-    var isSelected: Bool { presentation == selectedPresentation }
-    var accessibilityValue: String { isSelected ? "Selected" : "Not selected" }
-}
-
-/// Generic native renderer host. It owns presentation controls and keeps Source
+/// Generic native renderer host. It owns presentation tabs and keeps Source
 /// visible whenever matching or rendering cannot provide a rendered pane.
 struct RendererHostView<Source: View, Rendered: View>: View {
+    private enum Tab: Hashable {
+        case source
+        case renderer(RendererReference)
+    }
     @Binding var state: RendererPresentationState
     let descriptors: [RendererDescriptor]
     let showsControls: Bool
@@ -56,111 +48,47 @@ struct RendererHostView<Source: View, Rendered: View>: View {
                         fallbackWithSource(reason: RendererPresentationState.unavailableFallbackMessage)
                     }
                 case .split:
-                    if RendererPresentationLayout.supportsSplit(detailWidth: PageEditorMetrics.detailMinWidth) {
-                        HSplitView {
-                            source().frame(minWidth: RendererPresentationLayout.minimumSourcePaneWidth)
-                            if let selectedDescriptor {
-                                if let renderedContent = rendered(selectedDescriptor) {
-                                    renderedContent.frame(minWidth: RendererPresentationLayout.minimumRenderedPaneWidth)
-                                } else {
-                                    fallbackPane(reason: "The selected renderer could not be loaded.")
-                                }
-                            } else {
-                                fallbackPane(reason: RendererPresentationState.unavailableFallbackMessage)
-                            }
-                        }
-                    } else {
-                        fallbackWithSource(reason: "The detail pane is too narrow for Split view.")
-                    }
+                    // Split is retained only for persisted-data compatibility.
+                    // RendererPresentationState normalizes it to Rendered.
+                    fallbackWithSource(reason: RendererPresentationState.unavailableFallbackMessage)
                 }
             }
         }
     }
 
     private var controls: some View {
-        HStack(spacing: 8) {
-            presentationControl(.source) {
-                Button("Source") {
-                    state.selectSource()
-                    onPresentationSelected(.source)
-                }
-                .keyboardShortcut("1", modifiers: [.command, .option])
-                .accessibilityLabel("Show source")
+        Picker("Rendering", selection: selectedTab) {
+            Text("Source").tag(Tab.source)
+            ForEach(descriptors, id: \.reference) { descriptor in
+                Text(descriptor.displayName).tag(Tab.renderer(descriptor.reference))
             }
-            presentationControl(.rendered) {
-                Menu("Rendered", content: {
-                    ForEach(descriptors, id: \.reference) { descriptor in
-                        Button(descriptor.displayName) {
-                            state.selectRendered(descriptor.reference)
-                            onRendererSelected(descriptor.reference)
-                            onPresentationSelected(.rendered)
-                        }
-                    }
-                }, primaryAction: {
-                    guard let reference = Self.splitRendererReference(
-                        pinnedRenderer: state.pinnedRenderer,
-                        availableRendererReferences: descriptors.map(\.reference)
-                    ) else { return }
-                    state.selectRendered(reference)
-                    onRendererSelected(reference)
-                    onPresentationSelected(.rendered)
-                }
-                )
-                .keyboardShortcut("2", modifiers: [.command, .option])
-                .accessibilityLabel("Show rendered content")
-            }
-            presentationControl(.split) {
-                Button("Split") {
-                    if let reference = Self.splitRendererReference(
-                        pinnedRenderer: state.pinnedRenderer,
-                        availableRendererReferences: descriptors.map(\.reference)
-                    ) {
-                        state.selectSplit(reference)
-                        onRendererSelected(reference)
-                        onPresentationSelected(.split)
-                    }
-                }
-                .keyboardShortcut("3", modifiers: [.command, .option])
-                .accessibilityLabel("Show source and rendered content")
-                .disabled(descriptors.isEmpty)
-            }
-            Spacer()
         }
-        .font(.callout)
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .accessibilityLabel("Source rendering")
         .padding(.horizontal, PageEditorMetrics.contentInset)
         .padding(.vertical, 6)
     }
 
-    @ViewBuilder
-    private func presentationControl<Content: View>(
-        _ presentation: RendererSourcePresentationMode,
-        @ViewBuilder content: () -> Content
-    ) -> some View {
-        let controlState = RendererPresentationControlState(
-            presentation: presentation,
-            selectedPresentation: state.selection)
-        if controlState.isSelected {
-            content()
-                .buttonStyle(.borderedProminent)
-                .accessibilityValue(controlState.accessibilityValue)
-                .accessibilityAddTraits(.isSelected)
-        } else {
-            content()
-                .buttonStyle(.bordered)
-                .accessibilityValue(controlState.accessibilityValue)
-        }
-    }
-
-    /// A pin only belongs to the descriptor snapshot that supplied it. If the
-    /// snapshot changed, Split must use a descriptor that is available now.
-    static func splitRendererReference(
-        pinnedRenderer: RendererReference?,
-        availableRendererReferences: [RendererReference]
-    ) -> RendererReference? {
-        guard let pinnedRenderer, availableRendererReferences.contains(pinnedRenderer) else {
-            return availableRendererReferences.first
-        }
-        return pinnedRenderer
+    private var selectedTab: Binding<Tab> {
+        Binding(
+            get: {
+                guard state.selection == .rendered, let reference = state.pinnedRenderer else {
+                    return .source
+                }
+                return .renderer(reference)
+            },
+            set: { tab in
+                switch tab {
+                case .source:
+                    state.selectSource()
+                    onPresentationSelected(.source)
+                case let .renderer(reference):
+                    state.selectRendered(reference)
+                    onRendererSelected(reference)
+                    onPresentationSelected(.rendered)
+                }
+            })
     }
 
     /// A fallback is only valid for the source that scheduled it. This pure
@@ -193,7 +121,7 @@ struct RendererHostView<Source: View, Rendered: View>: View {
         } description: {
             Text(reason)
         }
-        .frame(minWidth: RendererPresentationLayout.minimumRenderedPaneWidth, maxWidth: .infinity, maxHeight: .infinity)
+        .frame(minWidth: RendererHostMetrics.minimumFallbackPaneWidth, maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
             selectSourceAfterFallback(reason)
         }

--- a/Sources/WikiFS/Renderer/RendererPresentationLifecycle.swift
+++ b/Sources/WikiFS/Renderer/RendererPresentationLifecycle.swift
@@ -50,11 +50,6 @@ struct RendererPresentationLifecycle: Sendable, Equatable {
         temporarilyUnavailableRenderer = nil
     }
 
-    mutating func selectSplit(_ reference: RendererReference) {
-        state.selectSplit(reference)
-        temporarilyUnavailableRenderer = nil
-    }
-
     mutating func selectRendered(_ reference: RendererReference) {
         state.selectRendered(reference)
         temporarilyUnavailableRenderer = nil
@@ -116,10 +111,8 @@ struct RendererPresentationLifecycle: Sendable, Equatable {
                availableRenderers.contains(unavailable.reference),
                persistedSelection != .source {
                 switch persistedSelection ?? unavailable.selection {
-                case .rendered:
+                case .rendered, .split:
                     state.selectRendered(unavailable.reference)
-                case .split:
-                    state.selectSplit(unavailable.reference)
                 case .source:
                     break
                 }

--- a/Sources/WikiFS/Renderer/RendererPresentationState.swift
+++ b/Sources/WikiFS/Renderer/RendererPresentationState.swift
@@ -32,6 +32,9 @@ struct RendererPresentationState: Sendable, Equatable {
         persistedSelection: Selection?
     ) -> Self {
         guard let matchingRenderer else { return Self(sourceID: sourceID) }
+        let persistedSelection = persistedSelection.map { selection in
+            selection == .split ? .rendered : selection
+        }
         let selection = persistedSelection ?? (hasPresentableSource ? .source : .rendered)
         guard selection != .source else { return Self(sourceID: sourceID) }
         return Self(sourceID: sourceID, selection: selection, pinnedRenderer: matchingRenderer)
@@ -45,12 +48,6 @@ struct RendererPresentationState: Sendable, Equatable {
 
     mutating func selectRendered(_ reference: RendererReference) {
         selection = .rendered
-        pinnedRenderer = reference
-        fallbackReason = nil
-    }
-
-    mutating func selectSplit(_ reference: RendererReference) {
-        selection = .split
         pinnedRenderer = reference
         fallbackReason = nil
     }
@@ -72,14 +69,7 @@ struct RendererPresentationState: Sendable, Equatable {
     }
 }
 
-enum RendererPresentationLayout {
-    /// Both panes must fit within `PageEditorMetrics.detailMinWidth` (420pt).
-    static let minimumSourcePaneWidth: CGFloat = 200
-    static let minimumRenderedPaneWidth: CGFloat = 200
-    static let splitDividerAllowance: CGFloat = 20
-
-    static func supportsSplit(detailWidth: CGFloat) -> Bool {
-        detailWidth >= minimumSourcePaneWidth + minimumRenderedPaneWidth + splitDividerAllowance
-    }
+enum RendererHostMetrics {
+    static let minimumFallbackPaneWidth: CGFloat = 200
 }
 #endif

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -275,7 +275,6 @@ enum SourceDetailPresentationCharacterization {
         case html = "HTML"
         case rendered = "Rendered"
         case media = "Media"
-        case split = "Split"
     }
 
     struct Result: Sendable, Equatable {
@@ -308,13 +307,13 @@ enum SourceDetailPresentationCharacterization {
 
         let tabs: [Presentation]
         if hasMediaPlayer {
-            tabs = hasProcessedMarkdown ? [.reader, .media, .split] : [.reader, .media]
+            tabs = [.reader, .media]
         } else if isPDF && hasProcessedMarkdown {
-            tabs = [.reader, .pdf, .split]
+            tabs = [.reader, .pdf]
         } else if isHTMLSource && (hasProcessedMarkdown || htmlString != nil) {
-            tabs = hasProcessedMarkdown ? [.reader, .html, .split] : [.html]
+            tabs = hasProcessedMarkdown ? [.reader, .html] : [.html]
         } else if mermaidSource {
-            tabs = [.reader, .rendered, .split]
+            tabs = [.reader, .rendered]
         } else {
             tabs = []
         }

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -889,11 +889,9 @@ struct SourceDetailView: View {
                             editBuffer = currentMarkdownContent ?? ""
                             isEditing = true
                             // #211: focus the editor even if the user had
-                            // switched to the PDF, HTML, Media, or Rendered
-                            // tab, where the markdown editor isn't rendered.
-                            // Leave Split alone — the editor is already
-                            // visible there. Rendered-only mode needs Source
-                            // so editing keeps its editor input visible.
+                            // switched to a rendering tab, where the markdown
+                            // editor is not visible. Editing needs Source so
+                            // its editor input remains visible.
                             if rendererPresentationLifecycle.state.selection == .rendered {
                                 var lifecycle = rendererPresentationLifecycle
                                 lifecycle.selectSource()
@@ -1371,8 +1369,8 @@ struct SourceDetailView: View {
     private func handleRendererFallback(_ reason: String) {
         DebugLog.tabs("SourceDetailView: renderer fallback (source=\(file.id.rawValue), reason=\(reason))")
         // The host owns the live Source fallback. Do not persist it: an
-        // explicit Rendered or Split selection and its renderer preference
-        // remain available for a later refresh or reopen retry.
+        // explicit renderer selection and its preference remain available for
+        // a later refresh or reopen retry.
     }
 
     // MARK: Markdown reader / editor

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -372,7 +372,7 @@ import WikiFSTypes
         #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(for: missing, boundedBytes: nil, currentMarkdown: nil, origin: nil) == nil)
     }
 
-    @Test("Characterization: PDF with markdown keeps Reader/PDF/Split tabs")
+    @Test("PDF with markdown exposes Reader and PDF rendering tabs")
     func characterizesPDFWithMarkdown() {
         let result = SourceDetailPresentationCharacterization.characterize(
             source: fixtureSource(filename: "paper.pdf", ext: "pdf", mimeType: MimeType.pdf, byteSize: 4),
@@ -381,7 +381,7 @@ import WikiFSTypes
             hasProcessedMarkdown: true,
             origin: nil)
         #expect(result.contentArea == .tabbed)
-        #expect(result.tabs == [.reader, .pdf, .split])
+        #expect(result.tabs == [.reader, .pdf])
     }
 
     @Test("Characterization: PDF without markdown renders PDF only")
@@ -396,7 +396,7 @@ import WikiFSTypes
         #expect(result.tabs == [])
     }
 
-    @Test("Characterization: HTML with markdown keeps Reader/HTML/Split tabs")
+    @Test("HTML with markdown exposes Reader and HTML rendering tabs")
     func characterizesHTMLWithMarkdown() {
         let result = SourceDetailPresentationCharacterization.characterize(
             source: fixtureSource(filename: "page.html", ext: "html", mimeType: MimeType.html, byteSize: 14),
@@ -405,7 +405,7 @@ import WikiFSTypes
             hasProcessedMarkdown: true,
             origin: nil)
         #expect(result.contentArea == .tabbed)
-        #expect(result.tabs == [.reader, .html, .split])
+        #expect(result.tabs == [.reader, .html])
     }
 
     @Test("Characterization: HTML without markdown renders HTML only")
@@ -420,7 +420,7 @@ import WikiFSTypes
         #expect(result.tabs == [.html])
     }
 
-    @Test("Characterization: Mermaid keeps Reader/Rendered/Split tabs")
+    @Test("Mermaid exposes Reader and Rendered tabs")
     func characterizesMermaid() {
         let result = SourceDetailPresentationCharacterization.characterize(
             source: fixtureSource(filename: "diagram.mmd", ext: "mmd", mimeType: nil, byteSize: 12),
@@ -429,10 +429,10 @@ import WikiFSTypes
             hasProcessedMarkdown: false,
             origin: nil)
         #expect(result.contentArea == .tabbed)
-        #expect(result.tabs == [.reader, .rendered, .split])
+        #expect(result.tabs == [.reader, .rendered])
     }
 
-    @Test("Characterization: media with transcript keeps Reader/Media/Split tabs")
+    @Test("Media with transcript exposes Reader and Media tabs")
     func characterizesMediaWithTranscript() {
         let result = SourceDetailPresentationCharacterization.characterize(
             source: fixtureSource(filename: "video", ext: "", mimeType: "video/youtube", byteSize: 0),
@@ -441,7 +441,7 @@ import WikiFSTypes
             hasProcessedMarkdown: true,
             origin: fixtureOrigin(provider: .youtube, plan: "https://www.youtube.com/watch?v=dQw4w9WgXcQ", externalIdentity: "dQw4w9WgXcQ"))
         #expect(result.contentArea == .tabbed)
-        #expect(result.tabs == [.reader, .media, .split])
+        #expect(result.tabs == [.reader, .media])
     }
 
     @Test("Characterization: malformed media metadata keeps fallback with no Media tab")

--- a/Tests/WikiFSAppTests/RendererPresentationStateTests.swift
+++ b/Tests/WikiFSAppTests/RendererPresentationStateTests.swift
@@ -83,7 +83,7 @@ import WikiFSTypes
         #expect(state.fallbackReason == nil)
     }
 
-    @Test("Production lifecycle: an unchanged source refresh preserves its pinned renderer and selected mode")
+    @Test("Production lifecycle: an unchanged source refresh preserves its renderer tab")
     func unchangedRefreshPreservesPinnedRendererAndMode() {
         let source = pdfSource()
         let pdf = BuiltInRendererReference.reference(for: .pdf)
@@ -93,7 +93,6 @@ import WikiFSTypes
             matchingRenderer: pdf,
             currentMarkdown: nil,
             persistedSelection: .rendered)
-        lifecycle.selectSplit(pdf)
 
         lifecycle.refreshLoadedSource(
             source: source,
@@ -102,7 +101,7 @@ import WikiFSTypes
             currentMarkdown: nil,
             persistedSelection: .rendered)
 
-        #expect(lifecycle.state.selection == .split)
+        #expect(lifecycle.state.selection == .rendered)
         #expect(lifecycle.state.pinnedRenderer == pdf)
     }
 
@@ -164,22 +163,17 @@ import WikiFSTypes
         #expect(lifecycle.state.pinnedRenderer == pdf)
     }
 
-    @Test("The detail minimum width admits the production Split layout")
-    func detailMinimumWidthSupportsSplit() {
-        #expect(RendererPresentationLayout.supportsSplit(detailWidth: PageEditorMetrics.detailMinWidth))
-    }
-
-    @Test("A removed pin lets Split choose an available renderer")
-    func unavailablePinDoesNotBlockSplitSelection() {
+    @Test("A legacy Split preference opens the matching renderer tab")
+    func legacySplitPreferenceNormalizesToRendered() {
         let pdf = BuiltInRendererReference.reference(for: .pdf)
-        let html = BuiltInRendererReference.reference(for: .html)
-        var state = RendererPresentationState(sourceID: SourceID(rawValue: "01J00000000000000000000000"))
-        state.selectRendered(pdf)
-        state.keepPinnedRenderer(available: [html])
-        state.selectSplit(html)
+        let state = RendererPresentationState.defaultState(
+            sourceID: SourceID(rawValue: "01J00000000000000000000000"),
+            matchingRenderer: pdf,
+            hasPresentableSource: true,
+            persistedSelection: .split)
 
-        #expect(state.selection == .split)
-        #expect(state.pinnedRenderer == html)
+        #expect(state.selection == .rendered)
+        #expect(state.pinnedRenderer == pdf)
     }
 
     @Test("Fallback reason survives the transition to Source")
@@ -193,26 +187,6 @@ import WikiFSTypes
         #expect(state.fallbackReason == "The selected renderer is unavailable.")
         state.selectSource()
         #expect(state.fallbackReason == nil)
-    }
-
-    @Test("Presentation controls describe the active visual and VoiceOver state")
-    func presentationControlsDescribeActiveVisualAndVoiceOverState() {
-        let source = RendererPresentationControlState(
-            presentation: .source,
-            selectedPresentation: .rendered)
-        let rendered = RendererPresentationControlState(
-            presentation: .rendered,
-            selectedPresentation: .rendered)
-        let split = RendererPresentationControlState(
-            presentation: .split,
-            selectedPresentation: .rendered)
-
-        #expect(source.isSelected == false)
-        #expect(source.accessibilityValue == "Not selected")
-        #expect(rendered.isSelected)
-        #expect(rendered.accessibilityValue == "Selected")
-        #expect(split.isSelected == false)
-        #expect(split.accessibilityValue == "Not selected")
     }
 
     @Test("Fallback waits for explicit renderer selection before recovering")
@@ -231,20 +205,6 @@ import WikiFSTypes
         #expect(state.selection == .rendered)
         #expect(state.pinnedRenderer == pdf)
         #expect(state.fallbackReason == nil)
-    }
-
-    @Test("Split metrics fit the source detail minimum width")
-    func splitMetricsFitDetailMinimumWidth() {
-        #expect(RendererPresentationLayout.supportsSplit(detailWidth: PageEditorMetrics.detailMinWidth))
-    }
-
-    @Test func refreshKeepsThePinnedSplitPresentationWhenRendererRemainsAvailable() {
-        let pdf = BuiltInRendererReference.reference(for: .pdf)
-        var state = RendererPresentationState(sourceID: SourceID(rawValue: "01J00000000000000000000000"))
-        state.selectSplit(pdf)
-        state.keepPinnedRenderer(available: [pdf])
-        #expect(state.selection == .split)
-        #expect(state.pinnedRenderer == pdf)
     }
 
     @Test("Lifecycle: an unextracted PDF resolves Rendered only after its source facts load")
@@ -444,8 +404,8 @@ import WikiFSTypes
         #expect(lifecycle.state.fallbackReason == nil)
     }
 
-    @Test("Lifecycle: transient omission restores Split only with the same exact renderer")
-    func lifecycleSplitRecoveryRejectsRendererSubstitution() {
+    @Test("Lifecycle: transient omission restores a legacy Split preference as Rendered only with the same exact renderer")
+    func lifecycleLegacySplitRecoveryRejectsRendererSubstitution() {
         let source = lifecycleSource(
             filename: "architecture.svg",
             ext: "svg",
@@ -487,7 +447,7 @@ import WikiFSTypes
             boundedBytes: bytes,
             currentMarkdown: nil,
             persistedSelection: .split)
-        #expect(lifecycle.state.selection == .split)
+        #expect(lifecycle.state.selection == .rendered)
         #expect(lifecycle.state.pinnedRenderer == svg)
         #expect(lifecycle.state.fallbackReason == nil)
     }
@@ -509,17 +469,6 @@ import WikiFSTypes
         #expect(lifecycle.state.sourceID == secondSource)
         #expect(lifecycle.state.selection == .source)
         #expect(lifecycle.state.pinnedRenderer == nil)
-    }
-
-    @Test("Split uses the first current descriptor when its pin is stale")
-    @MainActor
-    func splitUsesCurrentDescriptorWhenPinIsStale() {
-        let pdf = BuiltInRendererReference.reference(for: .pdf)
-        let html = BuiltInRendererReference.reference(for: .html)
-
-        #expect(RendererHostView<EmptyView, EmptyView>.splitRendererReference(
-            pinnedRenderer: pdf,
-            availableRendererReferences: [html]) == html)
     }
 
     @Test("Deferred fallback applies only to the source that scheduled it")

--- a/Tests/WikiFSAppTests/SourceDetailRendererArchitectureAuditTests.swift
+++ b/Tests/WikiFSAppTests/SourceDetailRendererArchitectureAuditTests.swift
@@ -97,24 +97,18 @@ import Testing
         #expect(host.contains("shouldApplyDeferredFallback(failedSourceID: failedSourceID, currentState: state)"))
     }
 
-    @Test func rendererShortcutsDoNotOverlapGlobalCommandNumberTabs() throws {
+    @Test func rendererHostUsesOneTabPerAvailableRenderingAndNoSplitControl() throws {
         let root = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let content = try String(contentsOf: root.appendingPathComponent("Sources/WikiFS/Window/ContentView.swift"), encoding: .utf8)
         let host = try String(contentsOf: root.appendingPathComponent("Sources/WikiFS/Renderer/RendererHostView.swift"), encoding: .utf8)
-        #expect(content.contains("KeyEquivalent(Character(\"\\(i + 1)\")), modifiers: .command"))
-        for shortcut in ["1", "2", "3"] {
-            #expect(host.contains(".keyboardShortcut(\"\(shortcut)\", modifiers: [.command, .option])"))
-            #expect(host.contains(".keyboardShortcut(\"\(shortcut)\", modifiers: .command)") == false)
-        }
-        #expect(host.contains("primaryAction:"))
-    }
 
-    @Test("Renderer host guards Split with the detail-width contract") func rendererHostGuardsSplitWidth() throws {
-        let root = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
-        let host = try String(contentsOf: root.appendingPathComponent("Sources/WikiFS/Renderer/RendererHostView.swift"), encoding: .utf8)
-        #expect(host.contains("RendererPresentationLayout.supportsSplit(detailWidth: PageEditorMetrics.detailMinWidth)"))
+        #expect(host.contains("Picker(\"Rendering\", selection: selectedTab)"))
+        #expect(host.contains(".pickerStyle(.segmented)"))
+        #expect(host.contains("ForEach(descriptors, id: \\.reference)"))
+        #expect(host.contains("Text(descriptor.displayName).tag(Tab.renderer(descriptor.reference))"))
+        #expect(host.contains(".accessibilityLabel(\"Source rendering\")"))
+        #expect(host.contains("Button(\"Split\")") == false)
+        #expect(host.contains("HSplitView") == false)
     }
 }
 #endif


### PR DESCRIPTION
Replaces the rendering buttons with a segmented tab picker. Adds one tab for Source and one tab for each available renderer. Removes the Split control and split-pane presentation. Converts stored Split selections to the matching renderer tab. Verification: make build passed; make test passed 3,669 tests in 376 suites; pre-commit lint found no violations.