### PR TITLE
fix(source-detail): display text source bytes

### DIFF
--- a/Sources/WikiFS/Renderer/RendererPresentationLifecycle.swift
+++ b/Sources/WikiFS/Renderer/RendererPresentationLifecycle.swift
@@ -73,6 +73,7 @@ struct RendererPresentationLifecycle: Sendable, Equatable {
             matchingRenderer: matchingRenderer,
             hasPresentableSource: SourceRendererPresentationPlanner.hasPresentableSource(
                 for: source,
+                boundedBytes: boundedBytes,
                 currentMarkdown: currentMarkdown),
             persistedSelection: persistedSelection)
         loadedFacts = LoadedFacts(

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -118,17 +118,38 @@ struct SourceRendererPresentationPlanner: Sendable {
         return MermaidSourceDetector.renderableMarkdown(from: markdown)
     }
 
-    /// Makes raw XML inert in the Markdown reader while preserving it as text.
-    nonisolated static func sourceMarkdown(for source: SourceSummary, content: String) -> String {
-        guard MimeType.isXML(source.mimeType) else { return content }
-        return content
-            .split(separator: "\n", omittingEmptySubsequences: false)
-            .map { "    \($0)" }
-            .joined(separator: "\n")
+    /// Returns strict UTF-8 source text only when the canonical bounded detector
+    /// agrees that the complete byte body is textual. Binary signatures and NUL
+    /// bytes therefore fail closed even when metadata claims a text type.
+    nonisolated static func sourceText(for source: SourceSummary, bytes: Data?) -> String? {
+        guard let bytes, !bytes.isEmpty, !bytes.contains(0),
+              let text = String(data: bytes, encoding: .utf8) else { return nil }
+        let detection = ContentTypeDetector.detect(.init(
+            data: bytes,
+            hints: .init(
+                declaredMIME: source.mimeType.map { .init($0, origin: .trustedGenerated) },
+                filenameExtension: source.ext.isEmpty ? nil : source.ext)))
+        guard !detection.evidence.contains(where: { $0.origin == .binarySignature }),
+              detection.evidence.contains(where: {
+                  $0.origin == .utf8Text || $0.origin == .structuredBytes
+              }) else { return nil }
+        return text
     }
 
-    nonisolated static func hasPresentableSource(for source: SourceSummary, currentMarkdown: String?) -> Bool {
-        usesMarkdownSourcePresentation(for: source, currentMarkdown: currentMarkdown)
+    /// Makes raw source bytes inert in the Markdown reader while preserving
+    /// whitespace and punctuation. Native Markdown remains a rendered document.
+    nonisolated static func sourceMarkdown(for source: SourceSummary, content: String) -> String {
+        guard !MimeType.isMarkdown(source.mimeType) else { return content }
+        return MermaidSourceDetector.codeBlockMarkdown(from: content) ?? content
+    }
+
+    nonisolated static func hasPresentableSource(
+        for source: SourceSummary,
+        boundedBytes: Data? = nil,
+        currentMarkdown: String?
+    ) -> Bool {
+        usesMarkdownSourcePresentation(
+            for: source, boundedBytes: boundedBytes, currentMarkdown: currentMarkdown)
     }
 
     /// Whether Source should use the Markdown/reader path instead of the raw
@@ -136,11 +157,10 @@ struct SourceRendererPresentationPlanner: Sendable {
     /// their MIME type is not text-presentable or is NULL.
     nonisolated static func usesMarkdownSourcePresentation(
         for source: SourceSummary,
+        boundedBytes: Data? = nil,
         currentMarkdown: String?
     ) -> Bool {
-        currentMarkdown != nil ||
-            (!isHTMLSource(source) && MimeType.isSourceTextPresentable(source.mimeType)) ||
-            standaloneDiagramSource(source)
+        currentMarkdown != nil || sourceText(for: source, bytes: boundedBytes) != nil
     }
 
     nonisolated static func mediaTarget(for source: SourceSummary, origin: SourceOrigin?) -> EmbedTarget? {

--- a/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
+++ b/Sources/WikiFS/Renderer/SourceRendererPresentationPlanner.swift
@@ -132,8 +132,8 @@ struct SourceRendererPresentationPlanner: Sendable {
     }
 
     /// Whether Source should use the Markdown/reader path instead of the raw
-    /// binary fallback. Standalone Mermaid sources retain this path even for
-    /// legacy rows whose MIME type is NULL (#620).
+    /// binary fallback. Standalone diagram sources retain this path even when
+    /// their MIME type is not text-presentable or is NULL.
     nonisolated static func usesMarkdownSourcePresentation(
         for source: SourceSummary,
         currentMarkdown: String?
@@ -175,6 +175,7 @@ struct SourceRendererPresentationPlanner: Sendable {
             || source.ext.lowercased() == MermaidSourceDetector.mermaidExtension
             || source.ext.lowercased() == "mermaid"
             || source.ext.lowercased() == "canvas"
+            || source.ext.lowercased() == "excalidraw"
     }
 
     private enum MediaMIMECandidate: Sendable, Equatable {

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -424,34 +424,13 @@ struct SourceDetailView: View {
     private var currentMarkdownContent: String? {
         if isEditing { return editBuffer }
         if let head = headVersion { return pinnedExtraction?.content ?? head.content }
-        // Issue #599: HTML sources preserve the original HTML bytes as the
-        // source blob — the markdown lives in a processed-markdown version
-        // (headVersion, above). Don't fall through to `sourceBytes` for HTML
-        // sources — the raw bytes are HTML, not markdown, and rendering them
-        // as markdown would show raw `<html>` tags. The Reader tab falls back
-        // to its "No Processed Markdown" placeholder until headVersion loads.
-        if SourceRendererPresentationPlanner.isHTMLSource(file) {
-            return nil
-        }
-        if isMarkdownNative, let data = sourceBytesSnapshot {
-            return String(data: data, encoding: .utf8)
-        }
-        if SourceRendererPresentationPlanner.standaloneDiagramSource(file),
-           let data = sourceBytesSnapshot {
-            return String(data: data, encoding: .utf8)
-        }
-        // #620: defense-in-depth — when a Mermaid-detected source arrives
-        // without a text MIME (e.g. a pre-existing NULL-mime `.mmd` row from
-        // before the `addSource` extension fallback, or any future ingest path
-        // that bypasses it), still surface the raw diagram bytes so the Reader
-        // and Rendered tabs render instead of empty states. Calls the static
-        // detector with `content: nil` (mime+filename arms only) — NOT the
-        // renderer matcher, which reads this same property and would recurse.
-        // The content-scan arm is irrelevant here: this
-        // branch is only reached when `isMarkdownNative` is false, and a
-        // fenced-block-only source (no `.mmd`, no `text/mermaid` mime) already
-        // had nowhere to read its bytes from before #620.
-        return nil
+        // Raw source presentation is byte-authoritative rather than an
+        // extension allowlist. The planner reuses ContentTypeDetector, so JSON,
+        // XML, PEM, AsciiDoc, source code, and extensionless UTF-8 are readable,
+        // while binary signatures, malformed UTF-8, and NUL-containing bodies
+        // continue to fail closed to Raw Source.
+        return SourceRendererPresentationPlanner.sourceText(
+            for: file, bytes: sourceBytesSnapshot)
     }
 
     private var findText: String? {
@@ -1220,6 +1199,7 @@ struct SourceDetailView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
             for: file,
+            boundedBytes: sourceBytesSnapshot,
             currentMarkdown: currentMarkdownContent
         ) {
             markdownContent

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -247,6 +247,22 @@ import WikiFSTypes
             currentMarkdown: "{\"nodes\":[],\"edges\":[]}"))
     }
 
+    @Test("Excalidraw sources use the readable source presentation")
+    func plannerUsesReadablePresentationForExcalidrawSources() {
+        let content = #"{"type":"excalidraw","version":2,"elements":[]}"#
+        let source = fixtureSource(
+            filename: "diagram.excalidraw",
+            ext: "excalidraw",
+            mimeType: MimeType.json,
+            byteSize: content.utf8.count)
+
+        #expect(SourceRendererPresentationPlanner.standaloneDiagramSource(source))
+        #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
+            for: source,
+            currentMarkdown: nil))
+        #expect(MermaidSourceDetector.codeBlockMarkdown(from: content) == "````\n\(content)\n````")
+    }
+
     @Test("JSON Canvas factory returns nil for unavailable and malformed input so the host keeps Source")
     @MainActor
     func jsonCanvasFactoryFailsClosedToHostFallback() throws {

--- a/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
+++ b/Tests/WikiFSAppTests/BuiltInRendererRegistryTests.swift
@@ -137,6 +137,7 @@ import WikiFSTypes
         #expect(id == .svg)
         #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
             for: source,
+            boundedBytes: bytes,
             currentMarkdown: nil))
 
         let xml = String(decoding: bytes, as: UTF8.self)
@@ -160,6 +161,7 @@ import WikiFSTypes
 
             #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
                 for: source,
+                boundedBytes: bytes,
                 currentMarkdown: nil))
             #expect(try SourceRendererPresentationPlanner.plannedBuiltInRenderer(
                 for: source,
@@ -259,8 +261,65 @@ import WikiFSTypes
         #expect(SourceRendererPresentationPlanner.standaloneDiagramSource(source))
         #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
             for: source,
+            boundedBytes: Data(content.utf8),
             currentMarkdown: nil))
-        #expect(MermaidSourceDetector.codeBlockMarkdown(from: content) == "````\n\(content)\n````")
+        #expect(SourceRendererPresentationPlanner.sourceMarkdown(for: source, content: content)
+            == "````\n\(content)\n````")
+    }
+
+    @Test("UTF-8 source formats use readable inert text")
+    func utf8SourceFormatsUseReadableInertText() {
+        let cases: [(filename: String, mimeType: String?, content: String)] = [
+            ("settings.json", MimeType.json, #"{"enabled":true}"#),
+            ("document.xml", MimeType.xml, "<?xml version=\"1.0\"?><document/>"),
+            ("certificate.pem", "application/x-pem-file", "-----BEGIN CERTIFICATE-----\nYWJj\n-----END CERTIFICATE-----"),
+            ("guide.adoc", "text/asciidoc", "= Guide\n\nReadable source"),
+            ("settings.yaml", "application/yaml", "enabled: true"),
+            ("main.swift", "application/octet-stream", "struct Example { let value = 1 }"),
+            ("README", nil, "extensionless UTF-8 text"),
+        ]
+
+        for value in cases {
+            let bytes = Data(value.content.utf8)
+            let ext = (value.filename as NSString).pathExtension
+            let source = fixtureSource(
+                filename: value.filename,
+                ext: ext,
+                mimeType: value.mimeType,
+                byteSize: bytes.count)
+
+            #expect(SourceRendererPresentationPlanner.sourceText(for: source, bytes: bytes) == value.content)
+            #expect(SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
+                for: source,
+                boundedBytes: bytes,
+                currentMarkdown: nil))
+            #expect(SourceRendererPresentationPlanner.sourceMarkdown(for: source, content: value.content)
+                == "````\n\(value.content)\n````")
+        }
+    }
+
+    @Test("Binary and invalid text bytes keep the Raw Source fallback")
+    func invalidTextBytesKeepRawSourceFallback() {
+        let source = fixtureSource(
+            filename: "claimed.txt",
+            ext: "txt",
+            mimeType: "text/plain",
+            byteSize: 8)
+        let rejected: [Data?] = [
+            nil,
+            Data(),
+            Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+            Data([0x61, 0x00, 0x62]),
+            Data([0xFF, 0xFE, 0xFD]),
+        ]
+
+        for bytes in rejected {
+            #expect(SourceRendererPresentationPlanner.sourceText(for: source, bytes: bytes) == nil)
+            #expect(!SourceRendererPresentationPlanner.usesMarkdownSourcePresentation(
+                for: source,
+                boundedBytes: bytes,
+                currentMarkdown: nil))
+        }
     }
 
     @Test("JSON Canvas factory returns nil for unavailable and malformed input so the host keeps Source")


### PR DESCRIPTION
Shows strict UTF-8 source bytes as readable text in Source Detail. Covers JSON, XML, PEM, AsciiDoc, YAML, source code, extensionless text, and Excalidraw JSON. Rejects NUL bytes, malformed UTF-8, and known binary signatures. Keeps ingestion policy unchanged. Validation: make build; make test passed 3,669 tests in 376 suites; language-server diagnostics passed; pre-commit lint passed.