### PR TITLE
feat(extractors): add MIME route selections

### DIFF
--- a/Sources/WikiFSCore/Extractor/ExtractorRouteSelection.swift
+++ b/Sources/WikiFSCore/Extractor/ExtractorRouteSelection.swift
@@ -1,0 +1,66 @@
+import Foundation
+import WikiFSTypes
+
+/// One persisted route selection: a typed extraction route and the version-free
+/// extractor reference chosen for it.
+///
+/// Records live in `ExtractionConfig.routeExtractors` as a deterministically
+/// sorted array — not a string-keyed dictionary — so the persisted order is
+/// canonical and duplicate route keys (possible in hand-edited files) remain
+/// representable and resolvable instead of silently colliding in JSON.
+public struct ExtractorRouteSelectionRecord: Codable, Hashable, Sendable, Comparable {
+    public let route: ExtractorRouteID
+    public let extractor: ExtractionBackendReference
+
+    public init(route: ExtractorRouteID, extractor: ExtractionBackendReference) {
+        self.route = route
+        self.extractor = extractor
+    }
+
+    /// Total order: route first, then the canonical JSON encoding of the
+    /// extractor reference as the tie-break, so two records for the same route
+    /// have a stable winner independent of their original array positions.
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.route != rhs.route { return lhs.route < rhs.route }
+        return Self.canonicalJSON(lhs) < Self.canonicalJSON(rhs)
+    }
+
+    /// Canonical JSON of one record — the deterministic tie-break for records
+    /// sharing a route. Encoding of this pure value type cannot fail; the empty
+    /// fallback is unreachable and exists only for totality.
+    fileprivate static func canonicalJSON(_ record: Self) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = DebugLog.trying("ExtractorRouteSelectionRecord canonicalJSON", operation: { try encoder.encode(record) }) else {
+            return ""
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+public extension Array where Element == ExtractorRouteSelectionRecord {
+    /// Deterministic normalization for persisted route records: sort into the
+    /// canonical route order, then keep exactly one record per route — the
+    /// canonically-greatest record wins, so the order records appear in inside a
+    /// hand-edited file cannot change which selection survives.
+    ///
+    /// Returns the normalized array plus the number of dropped duplicates so the
+    /// decode seam can emit one bounded diagnostic instead of one per record.
+    func normalizedForPersistence() -> (records: Self, droppedDuplicates: Int) {
+        let sortedRecords = sorted()
+        var result: Self = []
+        result.reserveCapacity(sortedRecords.count)
+        var dropped = 0
+        for record in sortedRecords {
+            if let last = result.last, last.route == record.route {
+                // Canonical sort order puts the greater record later, so the
+                // incoming record always replaces the earlier duplicate.
+                result[result.count - 1] = record
+                dropped += 1
+            } else {
+                result.append(record)
+            }
+        }
+        return (result, dropped)
+    }
+}

--- a/Sources/WikiFSCore/Extractor/ExtractorSelectionResolver.swift
+++ b/Sources/WikiFSCore/Extractor/ExtractorSelectionResolver.swift
@@ -43,11 +43,27 @@ public struct ExtractionSelectionDecision: Hashable, Sendable {
 
 /// Applies the version-free selection precedence without changing the persisted configuration.
 public enum ExtractorSelectionResolver {
+    /// Route-aware selection entry. Resolves one route through the same
+    /// precedence as the per-kind entry points; returns `nil` for routes without
+    /// a host execution path (a future registration's MIME type has no resolver
+    /// until an execution adapter exists).
+    public static func resolve(
+        _ route: ExtractorRouteID,
+        configuration: ExtractionConfig,
+        activeRegistrations: [ActiveExtractorRegistration]
+    ) -> ExtractionSelectionDecision? {
+        if route == .canonicalPDF { return resolvePDF(configuration: configuration, activeRegistrations: activeRegistrations) }
+        if route == .canonicalHTML { return resolveHTML(configuration: configuration, activeRegistrations: activeRegistrations) }
+        return nil
+    }
+
     public static func resolvePDF(
         configuration: ExtractionConfig,
         activeRegistrations: [ActiveExtractorRegistration]
     ) -> ExtractionSelectionDecision {
-        guard let logicalSelection = configuration.pdfExtractor else {
+        // Route-aware: an exact route record participates first; with no
+        // records this is exactly the pre-route `pdfExtractor ?? backend` rule.
+        guard let logicalSelection = configuration.extractorSelection(for: .canonicalPDF) else {
             return ExtractionSelectionDecision(selection: .pdfBuiltIn(configuration.backend))
         }
         switch logicalSelection {
@@ -73,7 +89,10 @@ public enum ExtractorSelectionResolver {
         configuration: ExtractionConfig,
         activeRegistrations: [ActiveExtractorRegistration]
     ) -> ExtractionSelectionDecision {
-        guard let logicalSelection = configuration.htmlExtractor else {
+        // Route-aware: an exact route record participates first; with no
+        // records this is exactly the pre-route `htmlExtractor ?? htmlBackend`
+        // (or prompt) rule.
+        guard let logicalSelection = configuration.extractorSelection(for: .canonicalHTML) else {
             guard let legacy = configuration.htmlBackend else {
                 return ExtractionSelectionDecision(selection: .noHTMLSelection)
             }

--- a/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
+++ b/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
@@ -69,12 +69,13 @@ public struct ExtractionConfig: JSONSidecarConfig {
     /// (`ExtractorRouteID` = kind + normalized MIME). A record for a canonical
     /// route takes precedence over the matching legacy `pdfExtractor` /
     /// `htmlExtractor` field; legacy fields remain the fallback when the record
-    /// is absent, so pre-route config files resolve exactly as before. Writes
-    /// through `setExtractorSelection(_:for:)` dual-write the matching legacy
-    /// field, keeping old readers truthful. Persisted as a deterministically
-    /// sorted array (never a string-keyed dictionary); a missing key decodes to
-    /// an empty list.
-    public var routeExtractors: [ExtractorRouteSelectionRecord]
+    /// is absent, so pre-route config files resolve exactly as before.
+    /// Mutation flows only through `setExtractorSelection(_:for:)` (and the
+    /// normalizing initializer/decoder), keeping the array sorted and
+    /// duplicate-free at all times. Persisted as a deterministically sorted
+    /// array (never a string-keyed dictionary); a missing key decodes to an
+    /// empty list.
+    public private(set) var routeExtractors: [ExtractorRouteSelectionRecord]
 
     /// The config's JSON filename inside the App Group container.
     public static let fileName = "extraction-config.json"
@@ -237,9 +238,10 @@ public struct ExtractionConfig: JSONSidecarConfig {
     /// Resilient route-record decode, matching the config's degrade-don't-throw
     /// philosophy: a missing key decodes to an empty list, a wholly malformed
     /// array degrades to empty through the logged decode seam, a malformed
-    /// single record is dropped with one logged diagnostic, and duplicate route
-    /// records are resolved deterministically (canonically-greatest record wins,
-    /// independent of file order) with one bounded diagnostic.
+    /// single record is skipped so later valid records still decode, and
+    /// duplicate route records are resolved deterministically
+    /// (canonically-greatest record wins, independent of file order) with one
+    /// bounded diagnostic.
     private static func decodedRouteRecords(
         from container: KeyedDecodingContainer<CodingKeys>
     ) -> [ExtractorRouteSelectionRecord] {
@@ -248,15 +250,19 @@ public struct ExtractionConfig: JSONSidecarConfig {
             return []
         }
         var records: [ExtractorRouteSelectionRecord] = []
-        // A conforming coder advances an unkeyed container even when a decode
-        // throws, so each failed record is dropped and iteration continues.
-        // Bound consecutive failures anyway: a nonconforming coder that leaves
-        // the index in place must degrade to a truncated decode, never hang.
+        // A decoder is not required to advance an unkeyed container when a
+        // decode throws — Foundation's JSONDecoder leaves the index in place —
+        // so each failed record is explicitly consumed before continuing.
+        // Bound consecutive failures anyway: a coder that cannot even consume
+        // an arbitrary JSON value must degrade to a truncated decode, never hang.
         var consecutiveFailures = 0
         while array.isAtEnd == false {
             let countBefore = records.count
             if let record = DebugLog.trying("init(from:) decode routeExtractors record", operation: { try array.decode(ExtractorRouteSelectionRecord.self) }) {
                 records.append(record)
+            } else if DebugLog.trying("init(from:) consume malformed routeExtractors record", operation: { try array.decode(AnyJSONValue.self) }) != nil {
+                consecutiveFailures = 0
+                continue
             }
             if records.count == countBefore {
                 consecutiveFailures += 1
@@ -283,5 +289,32 @@ public struct ExtractionConfig: JSONSidecarConfig {
     /// decode to `JSONSidecarConfig.load(from:)` and supplies the default config.
     public static func load(from directory: URL) -> ExtractionConfig {
         load(from: directory) ?? ExtractionConfig()
+    }
+}
+
+/// A `Decodable` that accepts any JSON value. Used only to consume a malformed
+/// array element so decoding can continue past it — a failed decode does not
+/// advance an unkeyed container's index. Each `try?` here is one attempt of
+/// the type ladder, not error swallowing: the final fallback rethrows.
+private struct AnyJSONValue: Decodable {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { return }
+        // The type ladder below intentionally ignores each failed attempt: an
+        // unmatched type is expected while probing for the value's shape, and
+        // the final fallback rethrows. Ignoring here is genuinely correct.
+        // swiftlint:disable:next silent_try_optional
+        if (try? container.decode([AnyJSONValue].self)) != nil { return }
+        // swiftlint:disable:next silent_try_optional
+        if (try? container.decode([String: AnyJSONValue].self)) != nil { return }
+        // swiftlint:disable:next silent_try_optional
+        if (try? container.decode(String.self)) != nil { return }
+        // swiftlint:disable:next silent_try_optional
+        if (try? container.decode(Double.self)) != nil { return }
+        // swiftlint:disable:next silent_try_optional
+        if (try? container.decode(Bool.self)) != nil { return }
+        throw DecodingError.dataCorrupted(.init(
+            codingPath: container.codingPath,
+            debugDescription: "unsupported JSON value"))
     }
 }

--- a/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
+++ b/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
@@ -65,6 +65,17 @@ public struct ExtractionConfig: JSONSidecarConfig {
     /// `htmlBackend` keeps its existing meaning and precedence.
     public var htmlExtractor: ExtractionBackendReference?
 
+    /// Route-indexed selections, one record per typed extraction route
+    /// (`ExtractorRouteID` = kind + normalized MIME). A record for a canonical
+    /// route takes precedence over the matching legacy `pdfExtractor` /
+    /// `htmlExtractor` field; legacy fields remain the fallback when the record
+    /// is absent, so pre-route config files resolve exactly as before. Writes
+    /// through `setExtractorSelection(_:for:)` dual-write the matching legacy
+    /// field, keeping old readers truthful. Persisted as a deterministically
+    /// sorted array (never a string-keyed dictionary); a missing key decodes to
+    /// an empty list.
+    public var routeExtractors: [ExtractorRouteSelectionRecord]
+
     /// The config's JSON filename inside the App Group container.
     public static let fileName = "extraction-config.json"
 
@@ -79,7 +90,8 @@ public struct ExtractionConfig: JSONSidecarConfig {
         htmlBackend: HtmlExtractionBackend? = nil,
         podcastBackend: PodcastTranscriptionBackend? = nil,
         pdfExtractor: ExtractionBackendReference? = nil,
-        htmlExtractor: ExtractionBackendReference? = nil
+        htmlExtractor: ExtractionBackendReference? = nil,
+        routeExtractors: [ExtractorRouteSelectionRecord] = []
     ) {
         self.backend = backend
         self.acpProviderId = acpProviderId
@@ -92,11 +104,17 @@ public struct ExtractionConfig: JSONSidecarConfig {
         self.podcastBackend = podcastBackend
         self.pdfExtractor = pdfExtractor
         self.htmlExtractor = htmlExtractor
+        self.routeExtractors = routeExtractors.normalizedForPersistence().records
     }
 
     /// The default model id used everywhere a model isn't explicitly set, so the
     /// literal lives in one place.
     public static let defaultAnthropicModel = "claude-sonnet-4-6"
+
+    /// Decode-resilience bound: how many consecutive malformed route records a
+    /// decode tolerates before assuming the coder is not advancing the array
+    /// index and truncating (see `decodedRouteRecords`).
+    static let maximumConsecutiveRouteDecodeFailures = 8
 
     public static let defaultGeminiModel = "gemini-3.5-flash"
 
@@ -129,6 +147,7 @@ public struct ExtractionConfig: JSONSidecarConfig {
         case doclingServeEndpoint
         case htmlBackend, podcastBackend
         case pdfExtractor, htmlExtractor
+        case routeExtractors
     }
 
     public init(from decoder: Decoder) throws {
@@ -155,6 +174,105 @@ public struct ExtractionConfig: JSONSidecarConfig {
         self.podcastBackend = DebugLog.trying("init(from:) decode podcastBackend") { try c.decode(PodcastTranscriptionBackend.self, forKey: .podcastBackend) }
         self.pdfExtractor = DebugLog.trying("init(from:) decode pdfExtractor") { try c.decode(ExtractionBackendReference.self, forKey: .pdfExtractor) }
         self.htmlExtractor = DebugLog.trying("init(from:) decode htmlExtractor") { try c.decode(ExtractionBackendReference.self, forKey: .htmlExtractor) }
+        self.routeExtractors = Self.decodedRouteRecords(from: c)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        // Explicit encode so the persisted byte shape stays identical to the
+        // synthesized form (encodeIfPresent for optionals) while route records
+        // are always written in deterministic route order.
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(backend, forKey: .backend)
+        try c.encodeIfPresent(acpProviderId, forKey: .acpProviderId)
+        try c.encode(anthropicModel, forKey: .anthropicModel)
+        try c.encodeIfPresent(anthropicBaseURLOverride, forKey: .anthropicBaseURLOverride)
+        try c.encode(geminiModel, forKey: .geminiModel)
+        try c.encodeIfPresent(geminiBaseURLOverride, forKey: .geminiBaseURLOverride)
+        try c.encodeIfPresent(doclingServeEndpoint, forKey: .doclingServeEndpoint)
+        try c.encodeIfPresent(htmlBackend, forKey: .htmlBackend)
+        try c.encodeIfPresent(podcastBackend, forKey: .podcastBackend)
+        try c.encodeIfPresent(pdfExtractor, forKey: .pdfExtractor)
+        try c.encodeIfPresent(htmlExtractor, forKey: .htmlExtractor)
+        try c.encode(routeExtractors.sorted(), forKey: .routeExtractors)
+    }
+
+    // MARK: - Route selections
+
+    /// The effective version-free selection for one route, applying the
+    /// persistence precedence: an exact `routeExtractors` record first, then the
+    /// matching legacy reference field for a canonical route (`pdfExtractor` /
+    /// `htmlExtractor`), then no selection. The older `backend` / `htmlBackend`
+    /// fields are the layer below this one — the resolver falls through to them
+    /// exactly as it did before route records existed.
+    public func extractorSelection(for route: ExtractorRouteID) -> ExtractionBackendReference? {
+        if let record = routeExtractors.first(where: { $0.route == route }) { return record.extractor }
+        if route == .canonicalPDF { return pdfExtractor }
+        if route == .canonicalHTML { return htmlExtractor }
+        return nil
+    }
+
+    /// Insert, replace, or remove (`nil`) the selection for one route.
+    ///
+    /// Dual-write compatibility: a canonical-route write also updates the
+    /// matching legacy reference field (`pdfExtractor` / `htmlExtractor`) so old
+    /// builds reading those fields resolve the same selection. The older
+    /// `backend` / `htmlBackend` fields stay owned by the Settings mapping
+    /// (`writePDF` / `writeHTML`), which keeps them truthful when a selection is
+    /// expressed through them. Unrelated route records are preserved; removal
+    /// drops only this route's record and clears the legacy reference, letting
+    /// the legacy fallback layer apply again.
+    public mutating func setExtractorSelection(_ extractor: ExtractionBackendReference?, for route: ExtractorRouteID) {
+        routeExtractors.removeAll { $0.route == route }
+        if let extractor {
+            routeExtractors.append(ExtractorRouteSelectionRecord(route: route, extractor: extractor))
+            routeExtractors.sort()
+        }
+        if route == .canonicalPDF {
+            pdfExtractor = extractor
+        } else if route == .canonicalHTML {
+            htmlExtractor = extractor
+        }
+    }
+
+    /// Resilient route-record decode, matching the config's degrade-don't-throw
+    /// philosophy: a missing key decodes to an empty list, a wholly malformed
+    /// array degrades to empty through the logged decode seam, a malformed
+    /// single record is dropped with one logged diagnostic, and duplicate route
+    /// records are resolved deterministically (canonically-greatest record wins,
+    /// independent of file order) with one bounded diagnostic.
+    private static func decodedRouteRecords(
+        from container: KeyedDecodingContainer<CodingKeys>
+    ) -> [ExtractorRouteSelectionRecord] {
+        guard container.contains(.routeExtractors) else { return [] }
+        guard var array = DebugLog.trying("init(from:) decode routeExtractors", operation: { try container.nestedUnkeyedContainer(forKey: .routeExtractors) }) else {
+            return []
+        }
+        var records: [ExtractorRouteSelectionRecord] = []
+        // A conforming coder advances an unkeyed container even when a decode
+        // throws, so each failed record is dropped and iteration continues.
+        // Bound consecutive failures anyway: a nonconforming coder that leaves
+        // the index in place must degrade to a truncated decode, never hang.
+        var consecutiveFailures = 0
+        while array.isAtEnd == false {
+            let countBefore = records.count
+            if let record = DebugLog.trying("init(from:) decode routeExtractors record", operation: { try array.decode(ExtractorRouteSelectionRecord.self) }) {
+                records.append(record)
+            }
+            if records.count == countBefore {
+                consecutiveFailures += 1
+                if consecutiveFailures > Self.maximumConsecutiveRouteDecodeFailures {
+                    DebugLog.config("ExtractionConfig: routeExtractors decode stalled after \(consecutiveFailures) malformed records; truncating the remainder")
+                    break
+                }
+            } else {
+                consecutiveFailures = 0
+            }
+        }
+        let normalized = records.normalizedForPersistence()
+        if normalized.droppedDuplicates > 0 {
+            DebugLog.config("ExtractionConfig: resolved \(normalized.droppedDuplicates) duplicate route selection record(s); kept the canonically-greatest record per route")
+        }
+        return normalized.records
     }
 
     // MARK: - Persistence (via `JSONSidecarConfig`)

--- a/Sources/WikiFSTypes/Extractor/ExtractorRoute.swift
+++ b/Sources/WikiFSTypes/Extractor/ExtractorRoute.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+// pattern: Functional Core
+
+/// One byte-extraction route: the `ExtractorKind` operation family plus the
+/// normalized `ExtractorMIMEType` of the input that route converts.
+///
+/// Route identity is deliberately its own type, distinct from every namespace it
+/// is assembled from:
+///
+/// - `ExtractorKind` is the manifest/protocol operation family (`.pdf`, `.html`)
+///   and stays exactly that — a route adds the MIME dimension.
+/// - `ExtractionBackendKind` / `ExtractionBackend` (WikiFSMarkdown) is the
+///   engine-adapter namespace — which backend runs, not which input it accepts.
+/// - `ContentCapabilities.ExtractionPath` is source-classification policy — how
+///   a source is routed to an extraction path, not a persisted selection key.
+///
+/// MIME is the authoritative input identity: filename extensions stay
+/// registration matching hints and are not part of the persisted route. Order is
+/// deterministic (kind raw value, then MIME raw value) so persisted route
+/// collections encode identically on every machine.
+public struct ExtractorRouteID: Codable, Hashable, Sendable, Comparable, CustomStringConvertible {
+    public let kind: ExtractorKind
+    public let mimeType: ExtractorMIMEType
+
+    private enum CodingKeys: String, CodingKey { case kind, mimeType }
+
+    public init(kind: ExtractorKind, mimeType: ExtractorMIMEType) {
+        self.kind = kind
+        self.mimeType = mimeType
+    }
+
+    /// Builds a route from a caller-supplied MIME string, normalizing surrounding
+    /// whitespace and case before validation. Returns `nil` when the normalized
+    /// string is still not a valid MIME type.
+    public init?(normalizing kind: ExtractorKind, mimeTypeString: String) {
+        let normalized = mimeTypeString.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let mimeType = ExtractorMIMEType(rawValue: normalized) else { return nil }
+        self.init(kind: kind, mimeType: mimeType)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.kind = try container.decode(ExtractorKind.self, forKey: .kind)
+        self.mimeType = try container.decode(ExtractorMIMEType.self, forKey: .mimeType)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(mimeType, forKey: .mimeType)
+    }
+
+    /// Kind raw value first, then MIME raw value — the total order every
+    /// persisted route collection is sorted by.
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.kind.rawValue != rhs.kind.rawValue { return lhs.kind.rawValue < rhs.kind.rawValue }
+        return lhs.mimeType < rhs.mimeType
+    }
+
+    public var description: String { "\(kind.rawValue) \(mimeType.rawValue)" }
+}
+
+public extension ExtractorRouteID {
+    /// The PDF document route — the only PDF route current registrations and
+    /// execution support.
+    static let canonicalPDF = ExtractorRouteID.validatedCanonical(kind: .pdf, mimeTypeString: "application/pdf")
+
+    /// The HTML document route — the only HTML route current registrations and
+    /// execution support.
+    static let canonicalHTML = ExtractorRouteID.validatedCanonical(kind: .html, mimeTypeString: "text/html")
+
+    /// True for the two routes host execution supports today. Future package
+    /// registrations may declare other MIME types; displaying and resolving them
+    /// is the route table's job, while execution adapters for new kinds remain
+    /// separate work.
+    var isCanonical: Bool { self == .canonicalPDF || self == .canonicalHTML }
+
+    private static func validatedCanonical(kind: ExtractorKind, mimeTypeString: String) -> ExtractorRouteID {
+        guard let route = ExtractorRouteID(normalizing: kind, mimeTypeString: mimeTypeString) else {
+            preconditionFailure("canonical route literal must be a valid MIME type: \(kind.rawValue) \(mimeTypeString)")
+        }
+        return route
+    }
+}

--- a/Tests/WikiFSTests/ExtractionConfigTests.swift
+++ b/Tests/WikiFSTests/ExtractionConfigTests.swift
@@ -289,6 +289,237 @@ struct ExtractionConfigTests {
         #expect(htmlConfig.htmlExtractor == .installed(logical))
     }
 
+    // MARK: - Route selections (typed MIME routes)
+
+    /// AC.2: a config file without `routeExtractors` decodes to an empty record
+    /// list, the route accessors fall through to the legacy reference fields,
+    /// and PDF/HTML resolution is byte-for-byte the same decision the pre-route
+    /// entry points produced.
+    @Test func legacyPDFAndHTMLFieldsResolveWithoutRouteRecords() throws {
+        let json = Data(#"""
+        {"backend":"gemini","htmlBackend":"defuddle","pdfExtractor":{"kind":"builtIn","builtIn":{"kind":"pdf","backend":"acp"}},"htmlExtractor":{"kind":"builtIn","builtIn":{"kind":"html","backend":"tagBased"}}}
+        """#.utf8)
+        let decoded = try JSONDecoder().decode(ExtractionConfig.self, from: json)
+        let inCode = ExtractionConfig(
+            backend: .gemini,
+            htmlBackend: .defuddle,
+            pdfExtractor: .builtIn(.pdf(.acp)),
+            htmlExtractor: .builtIn(.html(.tagBased)))
+        #expect(decoded == inCode)
+        #expect(decoded.routeExtractors.isEmpty)
+        #expect(decoded.extractorSelection(for: .canonicalPDF) == decoded.pdfExtractor)
+        #expect(decoded.extractorSelection(for: .canonicalHTML) == decoded.htmlExtractor)
+        #expect(ExtractorSelectionResolver.resolvePDF(configuration: decoded, activeRegistrations: []) ==
+            ExtractorSelectionResolver.resolvePDF(configuration: inCode, activeRegistrations: []))
+        #expect(ExtractorSelectionResolver.resolveHTML(configuration: decoded, activeRegistrations: []) ==
+            ExtractorSelectionResolver.resolveHTML(configuration: inCode, activeRegistrations: []))
+    }
+
+    /// AC.3: records encode in deterministic route order regardless of the order
+    /// they were inserted. Determinism is asserted through the real persistence
+    /// path (`JSONSidecarConfig.save`), whose encoder sorts keys; bare
+    /// `JSONEncoder()` output is hash-ordered and not a determinism contract.
+    @Test func routeSelectionsEncodeInDeterministicOrder() throws {
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.pdf"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        let future = ExtractorRouteSelectionRecord(
+            route: try ExtractorRouteID(kind: .pdf, mimeType: ExtractorMIMEType(validating: "application/epub+zip")),
+            extractor: .installed(logical))
+        var first = ExtractionConfig(backend: .gemini)
+        first.setExtractorSelection(.installed(logical), for: .canonicalHTML)
+        first.setExtractorSelection(.builtIn(.pdf(.doclingServe)), for: .canonicalPDF)
+        first.setExtractorSelection(.installed(logical), for: future.route)
+        var second = ExtractionConfig(backend: .gemini)
+        second.setExtractorSelection(.installed(logical), for: future.route)
+        second.setExtractorSelection(.builtIn(.pdf(.doclingServe)), for: .canonicalPDF)
+        second.setExtractorSelection(.installed(logical), for: .canonicalHTML)
+        #expect(first == second)
+
+        // Identical configs persist byte-for-byte identical files, and records
+        // appear in canonical route order (kind raw value, then MIME raw value:
+        // "html text/html" < "pdf application/epub+zip" < "pdf application/pdf").
+        let firstDir = tempDirectory()
+        let secondDir = tempDirectory()
+        try first.save(to: firstDir)
+        try second.save(to: secondDir)
+        let firstBytes = try Data(contentsOf: firstDir.appendingPathComponent(ExtractionConfig.fileName))
+        let secondBytes = try Data(contentsOf: secondDir.appendingPathComponent(ExtractionConfig.fileName))
+        #expect(firstBytes == secondBytes)
+        #expect(try routeMIMEOrder(in: firstBytes) == ["text/html", "application/epub+zip", "application/pdf"])
+    }
+
+    /// AC.3: replacing one route's selection leaves every other route record
+    /// untouched, including future non-canonical routes.
+    @Test func routeSelectionReplacementPreservesOtherRoutes() throws {
+        let htmlLogical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.html"),
+            registrationID: try ExtractorRegistrationID(validating: "article"))
+        let htmlRecord = ExtractorRouteSelectionRecord(route: .canonicalHTML, extractor: .installed(htmlLogical))
+        var config = ExtractionConfig(backend: .gemini, routeExtractors: [htmlRecord])
+
+        config.setExtractorSelection(.builtIn(.pdf(.acp)), for: .canonicalPDF)
+        #expect(config.routeExtractors.count == 2)
+        #expect(config.routeExtractors.contains { $0.route == .canonicalPDF })
+
+        config.setExtractorSelection(.builtIn(.pdf(.doclingServe)), for: .canonicalPDF)
+        #expect(config.routeExtractors.count == 2)
+        #expect(config.extractorSelection(for: .canonicalHTML) == .installed(htmlLogical))
+        #expect(config.extractorSelection(for: .canonicalPDF) == .builtIn(.pdf(.doclingServe)))
+
+        config.setExtractorSelection(nil, for: .canonicalPDF)
+        #expect(config.routeExtractors.count == 1)
+        #expect(config.extractorSelection(for: .canonicalHTML) == .installed(htmlLogical))
+        #expect(config.extractorSelection(for: .canonicalPDF) == nil)
+    }
+
+    /// AC.3 + AC.11 persistence half: a canonical route write dual-writes the
+    /// matching legacy reference field so old builds reading `pdfExtractor` /
+    /// `htmlExtractor` resolve the same selection; removal clears both. The
+    /// older `backend` / `htmlBackend` fields stay owned by the Settings
+    /// mapping and are not rewritten here.
+    @Test func canonicalRouteWritesKeepLegacyFieldsTruthful() throws {
+        var config = ExtractionConfig(backend: .anthropic, htmlBackend: .defuddle)
+
+        config.setExtractorSelection(.builtIn(.pdf(.acp)), for: .canonicalPDF)
+        #expect(config.pdfExtractor == .builtIn(.pdf(.acp)))
+        #expect(config.backend == .anthropic)
+
+        config.setExtractorSelection(.builtIn(.html(.tagBased)), for: .canonicalHTML)
+        #expect(config.htmlExtractor == .builtIn(.html(.tagBased)))
+        #expect(config.htmlBackend == .defuddle)
+
+        config.setExtractorSelection(nil, for: .canonicalPDF)
+        #expect(config.pdfExtractor == nil)
+        config.setExtractorSelection(nil, for: .canonicalHTML)
+        #expect(config.htmlExtractor == nil)
+
+        // A non-canonical route record never touches legacy fields.
+        let future = try ExtractorRouteID(kind: .pdf, mimeType: ExtractorMIMEType(validating: "application/epub+zip"))
+        config.setExtractorSelection(.builtIn(.pdf(.acp)), for: future)
+        #expect(config.pdfExtractor == nil)
+        #expect(config.routeExtractors.count == 1)
+
+        // Round-trips through disk.
+        let dir = tempDirectory()
+        try config.save(to: dir)
+        #expect(ExtractionConfig.load(from: dir) == config)
+    }
+
+    /// AC.2/AC.3: duplicate records for one route in a hand-edited file resolve
+    /// to the same single record regardless of their order in the file, with
+    /// malformed records dropped through the logged decode seam.
+    @Test func duplicateRouteRecordsResolveDeterministicallyAndLogBoundedDiagnostic() throws {
+        let builtInRecord = #"""
+        {"route":{"kind":"pdf","mimeType":"application/pdf"},"extractor":{"kind":"builtIn","builtIn":{"kind":"pdf","backend":"acp"}}}
+        """#
+        let installedRecord = #"""
+        {"route":{"kind":"pdf","mimeType":"application/pdf"},"extractor":{"kind":"installed","installed":{"packageID":"org.example.pdf","registrationID":"main"}}}
+        """#
+        let htmlRecord = #"""
+        {"route":{"kind":"html","mimeType":"text/html"},"extractor":{"kind":"builtIn","builtIn":{"kind":"html","backend":"tagBased"}}}
+        """#
+        let firstOrder = try JSONDecoder().decode(
+            ExtractionConfig.self,
+            from: Data(#"{"backend":"gemini","routeExtractors":[\#(builtInRecord),\#(installedRecord),\#(htmlRecord)]}"#.utf8))
+        let secondOrder = try JSONDecoder().decode(
+            ExtractionConfig.self,
+            from: Data(#"{"backend":"gemini","routeExtractors":[\#(installedRecord),\#(htmlRecord),\#(builtInRecord)]}"#.utf8))
+        #expect(firstOrder == secondOrder)
+        #expect(firstOrder.routeExtractors.count == 2)
+
+        // The winner is the canonically-greatest record for the route (here the
+        // installed reference, which sorts after the built-in one).
+        #expect(firstOrder.extractorSelection(for: .canonicalPDF) ==
+            .installed(LogicalExtractorReference(
+                packageID: try ExtractorPackageID(validating: "org.example.pdf"),
+                registrationID: try ExtractorRegistrationID(validating: "main"))))
+        #expect(firstOrder.extractorSelection(for: .canonicalHTML) == .builtIn(.html(.tagBased)))
+
+        // A wholly malformed array and a malformed record both degrade without
+        // throwing, keeping whatever records remain valid.
+        let malformedArray = try JSONDecoder().decode(
+            ExtractionConfig.self, from: Data(#"{"backend":"gemini","routeExtractors":"nope"}"#.utf8))
+        #expect(malformedArray.routeExtractors.isEmpty)
+        let malformedRecord = try JSONDecoder().decode(
+            ExtractionConfig.self,
+            from: Data(#"{"backend":"gemini","routeExtractors":[\#(builtInRecord),{"route":{"kind":"pdf","mimeType":"bogus"}}]}"#.utf8))
+        #expect(malformedRecord.routeExtractors.count == 1)
+        #expect(malformedRecord.extractorSelection(for: .canonicalPDF) == .builtIn(.pdf(.acp)))
+    }
+
+    /// AC.4: PDF/HTML resolution produces the same decision whether a selection
+    /// is expressed as a legacy reference field or an equivalent route record,
+    /// and a route record overrides a conflicting legacy field. Unavailable
+    /// installed selections keep the exact fixed fallback and diagnostic.
+    @Test func routeResolutionMatchesLegacyEntryPoints() throws {
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.pdf"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        let pdfOnly = try activeRegistration(logical: logical, version: "1.0.0", digestByte: 3, kinds: [.pdf])
+        var config = ExtractionConfig(backend: .acp, htmlBackend: .tagBased, pdfExtractor: .builtIn(.pdf(.localPdf2md)))
+
+        // Legacy reference and equivalent route record resolve identically.
+        let legacyPDF = ExtractorSelectionResolver.resolvePDF(configuration: config, activeRegistrations: [pdfOnly])
+        #expect(legacyPDF.selection == .pdfBuiltIn(.localPdf2md))
+        config.setExtractorSelection(.builtIn(.pdf(.localPdf2md)), for: .canonicalPDF)
+        #expect(ExtractorSelectionResolver.resolvePDF(configuration: config, activeRegistrations: [pdfOnly]) == legacyPDF)
+
+        // A route record overrides a conflicting legacy field.
+        config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
+        let recordPDF = ExtractorSelectionResolver.resolvePDF(configuration: config, activeRegistrations: [pdfOnly])
+        #expect(recordPDF.selection == .installed(kind: .pdf, reference: pdfOnly.reference))
+        #expect(recordPDF.diagnostic == nil)
+
+        // Unavailable installed via a route record: fixed fallback + diagnostic,
+        // identical to the legacy expression of the same selection.
+        config.pdfExtractor = nil
+        let unavailableRecord = config
+        let unavailablePDF = ExtractorSelectionResolver.resolvePDF(configuration: unavailableRecord, activeRegistrations: [])
+        #expect(unavailablePDF.selection == .pdfBuiltIn(.localPdf2md))
+        #expect(unavailablePDF.diagnostic == .unavailableInstalled(logical))
+        let legacyUnavailable = ExtractionConfig(
+            backend: .acp,
+            htmlBackend: .tagBased,
+            pdfExtractor: .installed(logical))
+        #expect(ExtractorSelectionResolver.resolvePDF(configuration: legacyUnavailable, activeRegistrations: []) == unavailablePDF)
+
+        // HTML: route record overrides htmlBackend; removal restores the
+        // legacy path exactly.
+        var htmlConfig = ExtractionConfig(backend: .gemini, htmlBackend: .defuddle)
+        htmlConfig.setExtractorSelection(.builtIn(.html(.tagBased)), for: .canonicalHTML)
+        let recordHTML = ExtractorSelectionResolver.resolveHTML(configuration: htmlConfig, activeRegistrations: [])
+        #expect(recordHTML.selection == .htmlBuiltIn(.tagBased))
+        #expect(recordHTML == ExtractorSelectionResolver.resolveHTML(
+            configuration: ExtractionConfig(backend: .gemini, htmlExtractor: .builtIn(.html(.tagBased))),
+            activeRegistrations: []))
+        htmlConfig.setExtractorSelection(nil, for: .canonicalHTML)
+        #expect(ExtractorSelectionResolver.resolveHTML(configuration: htmlConfig, activeRegistrations: []).selection == .htmlBuiltIn(.defuddle))
+    }
+
+    /// The route-aware entry point agrees with the per-kind entry points on the
+    /// canonical routes and declines routes without a host execution path.
+    @Test func routeAwareEntryMatchesPerKindEntryPoints() throws {
+        let config = ExtractionConfig(backend: .anthropic, htmlBackend: .defuddle)
+        #expect(ExtractorSelectionResolver.resolve(.canonicalPDF, configuration: config, activeRegistrations: []) ==
+            ExtractorSelectionResolver.resolvePDF(configuration: config, activeRegistrations: []))
+        #expect(ExtractorSelectionResolver.resolve(.canonicalHTML, configuration: config, activeRegistrations: []) ==
+            ExtractorSelectionResolver.resolveHTML(configuration: config, activeRegistrations: []))
+        let future = try ExtractorRouteID(kind: .html, mimeType: ExtractorMIMEType(validating: "application/xhtml+xml"))
+        #expect(ExtractorSelectionResolver.resolve(future, configuration: config, activeRegistrations: []) == nil)
+    }
+
+    /// Decodes the raw `routeExtractors` array from encoded JSON and returns the
+    /// MIME types in persisted order — a byte-order probe for determinism.
+    private func routeMIMEOrder(in data: Data) throws -> [String] {
+        struct Probe: Decodable {
+            let route: ProbeRoute
+            struct ProbeRoute: Decodable { let mimeType: String }
+        }
+        struct Envelope: Decodable { let routeExtractors: [Probe] }
+        return try JSONDecoder().decode(Envelope.self, from: data).routeExtractors.map(\.route.mimeType)
+    }
+
     private func activeRegistration(
         logical: LogicalExtractorReference,
         version: String,

--- a/Tests/WikiFSTests/ExtractionConfigTests.swift
+++ b/Tests/WikiFSTests/ExtractionConfigTests.swift
@@ -448,6 +448,39 @@ struct ExtractionConfigTests {
         #expect(malformedRecord.extractorSelection(for: .canonicalPDF) == .builtIn(.pdf(.acp)))
     }
 
+    /// A malformed record must not swallow later valid records: Foundation's
+    /// JSONDecoder leaves an unkeyed container's index in place after a failed
+    /// decode, so the decode seam consumes the bad element and continues.
+    @Test func malformedRecordDoesNotTruncateLaterValidRecords() throws {
+        let builtInRecord = #"""
+        {"route":{"kind":"pdf","mimeType":"application/pdf"},"extractor":{"kind":"builtIn","builtIn":{"kind":"pdf","backend":"acp"}}}
+        """#
+        let htmlRecord = #"""
+        {"route":{"kind":"html","mimeType":"text/html"},"extractor":{"kind":"builtIn","builtIn":{"kind":"html","backend":"tagBased"}}}
+        """#
+        let malformed = #"{"route":{"kind":"pdf","mimeType":"bogus"}}"#
+
+        // Malformed record first.
+        let badFirst = try JSONDecoder().decode(
+            ExtractionConfig.self,
+            from: Data(#"{"backend":"gemini","routeExtractors":[\#(malformed),\#(builtInRecord),\#(htmlRecord)]}"#.utf8))
+        #expect(badFirst.routeExtractors.count == 2)
+        #expect(badFirst.extractorSelection(for: .canonicalPDF) == .builtIn(.pdf(.acp)))
+        #expect(badFirst.extractorSelection(for: .canonicalHTML) == .builtIn(.html(.tagBased)))
+
+        // Malformed record in the middle.
+        let badMiddle = try JSONDecoder().decode(
+            ExtractionConfig.self,
+            from: Data(#"{"backend":"gemini","routeExtractors":[\#(builtInRecord),\#(malformed),\#(htmlRecord)]}"#.utf8))
+        #expect(badMiddle == badFirst)
+
+        // Multiple malformed records still terminate.
+        let allBad = try JSONDecoder().decode(
+            ExtractionConfig.self,
+            from: Data(#"{"backend":"gemini","routeExtractors":[\#(malformed),\#(malformed)]}"#.utf8))
+        #expect(allBad.routeExtractors.isEmpty)
+    }
+
     /// AC.4: PDF/HTML resolution produces the same decision whether a selection
     /// is expressed as a legacy reference field or an equivalent route record,
     /// and a route record overrides a conflicting legacy field. Unavailable

--- a/Tests/WikiFSTests/ExtractorRouteTests.swift
+++ b/Tests/WikiFSTests/ExtractorRouteTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+import WikiFSTypes
+@testable import WikiFSCore
+
+/// `ExtractorRouteID` identity, ordering, normalization, and coding, plus
+/// `ExtractorRouteSelectionRecord` deterministic normalization.
+struct ExtractorRouteTests {
+
+    // MARK: - AC.1: route identity is its own typed namespace
+
+    /// The route type cannot be interchanged with the namespaces it is built
+    /// from. The cross-type half of this contract is compile-time (a route is
+    /// not an `ExtractorKind`, a `ExtractorMIMEType`, or a raw string — those
+    /// arguments simply do not type-check); this test pins the runtime half:
+    /// identity is the *pair*, so kind and MIME each contribute distinction.
+    @Test func routeNamespacesRemainDistinct() throws {
+        let pdf = ExtractorRouteID.canonicalPDF
+        let html = ExtractorRouteID.canonicalHTML
+
+        // Same kind, different MIME → different routes.
+        let xhtml = try ExtractorRouteID(
+            kind: .html,
+            mimeType: ExtractorMIMEType(validating: "application/xhtml+xml"))
+        #expect(xhtml != html)
+        #expect(xhtml.kind == html.kind)
+
+        // Same MIME, different kind → different routes.
+        let pdfMIME = try ExtractorMIMEType(validating: "application/pdf")
+        let otherKind = ExtractorRouteID(kind: .html, mimeType: pdfMIME)
+        #expect(otherKind != pdf)
+        #expect(otherKind.mimeType == pdf.mimeType)
+
+        // The two canonical routes are the only canonical ones.
+        #expect(pdf.isCanonical)
+        #expect(html.isCanonical)
+        #expect(xhtml.isCanonical == false)
+
+        // A route identity helper accepts routes only — the adjacent lines show
+        // the distinct namespaces that must NOT satisfy it (compile-time).
+        func identity(_ route: ExtractorRouteID) -> ExtractorRouteID { route }
+        #expect(identity(pdf) == pdf)
+        // identity(.pdf)                      // ExtractorKind: does not compile
+        // identity(pdfMIME)                   // ExtractorMIMEType: does not compile
+        // identity("application/pdf")         // raw string: does not compile
+    }
+
+    @Test func canonicalRoutesUseNormalizedMIME() {
+        #expect(ExtractorRouteID.canonicalPDF.kind == .pdf)
+        #expect(ExtractorRouteID.canonicalPDF.mimeType.rawValue == "application/pdf")
+        #expect(ExtractorRouteID.canonicalHTML.kind == .html)
+        #expect(ExtractorRouteID.canonicalHTML.mimeType.rawValue == "text/html")
+    }
+
+    // MARK: - Normalization and ordering
+
+    @Test func normalizingInitCanonicalizesCaseAndWhitespace() throws {
+        let route = try #require(ExtractorRouteID(normalizing: .pdf, mimeTypeString: "  Application/PDF \n"))
+        #expect(route == .canonicalPDF)
+        #expect(ExtractorRouteID(normalizing: .pdf, mimeTypeString: "not a mime") == nil)
+        #expect(ExtractorRouteID(normalizing: .pdf, mimeTypeString: "") == nil)
+    }
+
+    @Test func routeOrderingIsKindThenMIME() throws {
+        let htmlTagBased = try ExtractorRouteID(kind: .html, mimeType: ExtractorMIMEType(validating: "application/xhtml+xml"))
+        let htmlCanonical = ExtractorRouteID.canonicalHTML
+        let pdfCanonical = ExtractorRouteID.canonicalPDF
+
+        // Kind raw value orders first ("html" < "pdf"), then MIME raw value.
+        #expect(htmlCanonical < pdfCanonical)
+        #expect(htmlTagBased < pdfCanonical)
+        #expect(htmlTagBased < htmlCanonical || htmlCanonical < htmlTagBased) // total order within a kind
+    }
+
+    // MARK: - Coding
+
+    @Test func routeCodingRoundTripsKeyedShape() throws {
+        let data = try JSONEncoder().encode(ExtractorRouteID.canonicalPDF)
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: String])
+        #expect(object["kind"] == "pdf")
+        #expect(object["mimeType"] == "application/pdf")
+        let decoded = try JSONDecoder().decode(ExtractorRouteID.self, from: data)
+        #expect(decoded == .canonicalPDF)
+    }
+
+    @Test func routeCodingRejectsInvalidMIME() {
+        #expect(throws: Error.self) {
+            try JSONDecoder().decode(ExtractorRouteID.self, from: Data(#"{"kind":"pdf","mimeType":"not a mime"}"#.utf8))
+        }
+    }
+
+    // MARK: - Record normalization
+
+    @Test func recordNormalizationKeepsCanonicallyGreatestPerRoute() throws {
+        let builtIn = ExtractorRouteSelectionRecord(
+            route: .canonicalPDF,
+            extractor: .builtIn(.pdf(.localPdf2md)))
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.pdf"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        let installed = ExtractorRouteSelectionRecord(
+            route: .canonicalPDF,
+            extractor: .installed(logical))
+        let htmlRecord = ExtractorRouteSelectionRecord(
+            route: .canonicalHTML,
+            extractor: .builtIn(.html(.tagBased)))
+
+        // The installed reference sorts after the built-in one canonically.
+        let expectedWinner = [builtIn, installed].sorted().last
+
+        // Both original orders produce the identical normalized result.
+        let first = [builtIn, installed, htmlRecord].normalizedForPersistence()
+        let second = [installed, builtIn, htmlRecord].normalizedForPersistence()
+        #expect(first.records == second.records)
+        #expect(first.droppedDuplicates == 1)
+        #expect(second.droppedDuplicates == 1)
+        #expect(first.records.count == 2)
+        #expect(first.records.contains(htmlRecord))
+        #expect(first.records.contains { $0 == expectedWinner })
+
+        // Duplicate-free input is preserved in sorted route order.
+        let clean = [htmlRecord, builtIn].normalizedForPersistence()
+        #expect(clean.records == [htmlRecord, builtIn])
+        #expect(clean.droppedDuplicates == 0)
+    }
+}

--- a/Tests/WikiFSTests/Fixtures/IdentifierBoundaryTypecheck/negative-extractor-route-batch.swift
+++ b/Tests/WikiFSTests/Fixtures/IdentifierBoundaryTypecheck/negative-extractor-route-batch.swift
@@ -1,0 +1,38 @@
+import Foundation
+import WikiFSCore
+import WikiFSTypes
+
+do {
+    // extractorKindIsRejectedByRouteAPI
+    func acceptsRoute(_ route: ExtractorRouteID) {}
+
+    acceptsRoute(ExtractorKind.pdf)
+}
+
+do {
+    // mimeTypeIsRejectedByRouteAPI
+    func acceptsRoute(_ route: ExtractorRouteID) {}
+
+    acceptsRoute(try ExtractorMIMEType(validating: "application/pdf"))
+}
+
+do {
+    // stringIsRejectedByRouteAPI
+    func acceptsRoute(_ route: ExtractorRouteID) {}
+
+    acceptsRoute("application/pdf")
+}
+
+do {
+    // routeIsRejectedByKindAPI
+    func acceptsKind(_ kind: ExtractorKind) {}
+
+    acceptsKind(ExtractorRouteID.canonicalPDF)
+}
+
+do {
+    // extractorKindIsRejectedByMIMEAPI
+    func acceptsMIME(_ mimeType: ExtractorMIMEType) {}
+
+    acceptsMIME(ExtractorKind.pdf)
+}

--- a/Tests/WikiFSTests/Fixtures/IdentifierBoundaryTypecheck/positive.swift
+++ b/Tests/WikiFSTests/Fixtures/IdentifierBoundaryTypecheck/positive.swift
@@ -25,3 +25,19 @@ func acceptsCorrectIdentifierNamespaces(
     try store.setActiveMarkdown(sourceID: sourceID, to: sourceMarkdownVersionID)
     try concreteStore.rollbackSourceContent(sourceID: sourceID, to: sourceVersionID)
 }
+
+func acceptsCorrectExtractorRouteUsage(
+    configuration: ExtractionConfig,
+    registrations: [ActiveExtractorRegistration]
+) {
+    let pdf = ExtractorRouteID.canonicalPDF
+    let html = ExtractorRouteID.canonicalHTML
+    let future = try? ExtractorRouteID(normalizing: .html, mimeTypeString: "Application/XHTML+XML")
+    let ordered: [ExtractorRouteID] = [pdf, html] + (future.map { [$0] } ?? [])
+    let sortedRoutes = ordered.sorted()
+    _ = configuration.extractorSelection(for: pdf)
+    var mutableConfiguration = configuration
+    mutableConfiguration.setExtractorSelection(nil, for: html)
+    _ = ExtractorSelectionResolver.resolve(pdf, configuration: mutableConfiguration, activeRegistrations: registrations)
+    _ = sortedRoutes
+}

--- a/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
+++ b/Tests/WikiFSTests/IdentifierBoundaryTypecheckTests.swift
@@ -71,6 +71,16 @@ struct IdentifierBoundaryTypecheckTests {
             ]
         ),
         BatchFixture(
+            name: "negative-extractor-route-batch.swift",
+            cases: [
+                .init(label: "extractorKindIsRejectedByRouteAPI", batchFixture: "negative-extractor-route-batch.swift", expectedDiagnostic: "cannot convert value of type 'ExtractorKind' to expected argument type 'ExtractorRouteID'"),
+                .init(label: "mimeTypeIsRejectedByRouteAPI", batchFixture: "negative-extractor-route-batch.swift", expectedDiagnostic: "cannot convert value of type 'ExtractorMIMEType' to expected argument type 'ExtractorRouteID'"),
+                .init(label: "stringIsRejectedByRouteAPI", batchFixture: "negative-extractor-route-batch.swift", expectedDiagnostic: "cannot convert value of type 'String' to expected argument type 'ExtractorRouteID'"),
+                .init(label: "routeIsRejectedByKindAPI", batchFixture: "negative-extractor-route-batch.swift", expectedDiagnostic: "cannot convert value of type 'ExtractorRouteID' to expected argument type 'ExtractorKind'"),
+                .init(label: "extractorKindIsRejectedByMIMEAPI", batchFixture: "negative-extractor-route-batch.swift", expectedDiagnostic: "cannot convert value of type 'ExtractorKind' to expected argument type 'ExtractorMIMEType'"),
+            ]
+        ),
+        BatchFixture(
             name: "negative-read-access-batch.swift",
             cases: [
                 .init(label: "readAccessCannotEscape", batchFixture: "negative-read-access-batch.swift", expectedDiagnostic: "requires that 'WikiReadAccess' conform to 'Copyable'"),
@@ -101,7 +111,10 @@ struct IdentifierBoundaryTypecheckTests {
         "chatIDIsRejectedByPageAPI",
         "chatIDIsRejectedByProcessedMarkdownVersionAPI",
         "chatIDIsRejectedBySourceAPI",
+        "extractorKindIsRejectedByMIMEAPI",
+        "extractorKindIsRejectedByRouteAPI",
         "markdownVersionIDIsRejectedBySourceVersionAPI",
+        "mimeTypeIsRejectedByRouteAPI",
         "pageIDIsRejectedByChatAPI",
         "pageIDIsRejectedByChatTurnAPI",
         "pageIDIsRejectedByLauncherChatAPI",
@@ -118,6 +131,7 @@ struct IdentifierBoundaryTypecheckTests {
         "readAccessCannotEscape",
         "readAccessCannotExposeStore",
         "readAccessCannotWrite",
+        "routeIsRejectedByKindAPI",
         "sourceIDIsRejectedByChatAPI",
         "sourceIDIsRejectedByPageAPI",
         "sourceIDIsRejectedByProcessedMarkdownVersionAPI",
@@ -129,6 +143,7 @@ struct IdentifierBoundaryTypecheckTests {
         "sourceVersionIDIsRejectedBySourceAPI",
         "stringIsRejectedByChatCommandAPI",
         "stringIsRejectedByLauncherChatAPI",
+        "stringIsRejectedByRouteAPI",
     ]
 
     private enum ProcessExitWaitError: Error {

--- a/plans/dynamic-extractor-packages.md
+++ b/plans/dynamic-extractor-packages.md
@@ -187,6 +187,26 @@ Primary touch points include:
 31. Keep reviewed local pdf2md as the PDF fallback and built-in tag-based extraction as the HTML fallback.
 32. Keep an unavailable logical selection saved. Report one redacted diagnostic and use the documented fallback. Never select another third-party package silently.
 
+## Route selections: typed MIME routes
+
+The Settings routing table needs a stable identity for one default-extraction route. Route identity is a typed pair, `ExtractorRouteID`: an `ExtractorKind` plus a normalized `ExtractorMIMEType`. The type keeps three namespaces distinct — a route is not an extractor kind, not a backend kind, and not a raw MIME string. MIME is authoritative. Filename extensions stay registration matching hints and never enter the persisted route.
+
+The current canonical routes are PDF (`application/pdf`) and HTML (`text/html`). Route identity admits other kind-plus-MIME pairs, and the UI can display them, but execution adapters for new kinds stay separate work. This stack changes no execution path.
+
+`ExtractionConfig.routeExtractors` stores one `ExtractorRouteSelectionRecord` per route as a deterministically sorted array. A string-keyed JSON dictionary was rejected: an array keeps the persisted order canonical and makes duplicate route keys in hand-edited files representable and resolvable.
+
+Precedence for a route:
+
+1. An exact `routeExtractors` record.
+2. For a canonical route, the matching legacy field (`pdfExtractor` or `htmlExtractor`).
+3. No selection.
+
+Below both layers, `backend` and `htmlBackend` keep their existing meaning. A config file without `routeExtractors` resolves exactly as before.
+
+Dual-write compatibility. A write through `setExtractorSelection(_:for:)` to a canonical route also updates the matching legacy reference field, so old builds reading `pdfExtractor` or `htmlExtractor` see the same selection. Removal clears the record and the legacy reference, so the legacy fallback applies again. The Settings mapping (`writePDF` / `writeHTML`) keeps owning `backend` and `htmlBackend`.
+
+Decode resilience. A missing key decodes to an empty list. A malformed record is dropped through the logged decode seam. Duplicate records for one route resolve deterministically: the canonically-greatest record wins, independent of file order, with one bounded diagnostic.
+
 ## Phase 2: Add the trusted dynamic Cordis plugin host
 
 1. Keep `PluginCatalog` immutable and link-time. Do not add dynamic module loading to it.

--- a/progress/2026-08-28T060000Z-extractor-route-selections.md
+++ b/progress/2026-08-28T060000Z-extractor-route-selections.md
@@ -1,0 +1,62 @@
+---
+timestamp: 2026-08-28T060000Z
+title: Typed MIME route selections
+branch: feature/extractor-route-selections
+status: complete
+---
+
+# Typed MIME route selections
+
+## Progress
+
+Extraction selection gained a typed route identity as the foundation for the
+registration-driven Settings routing table.
+
+- `ExtractorRouteID` (WikiFSTypes) identifies one byte-extraction route by
+  `ExtractorKind` plus a normalized `ExtractorMIMEType`. It is its own type —
+  not a kind, not a backend kind, not a raw MIME string. Canonical constants
+  cover the two routes execution supports: PDF (`application/pdf`) and HTML
+  (`text/html`).
+- `ExtractorRouteSelectionRecord` (WikiFSCore) pairs one route with one
+  version-free `ExtractionBackendReference`.
+- `ExtractionConfig.routeExtractors` stores records as a deterministically
+  sorted array, not a string-keyed dictionary. A missing key decodes to an
+  empty list; a malformed record is dropped through the logged decode seam;
+  duplicate records for one route resolve deterministically (canonically-
+  greatest record wins, independent of file order) with one bounded
+  diagnostic and a non-advancing-coder stall guard.
+- `extractorSelection(for:)` applies the precedence: exact route record, then
+  the matching legacy reference field for a canonical route, then none.
+  `setExtractorSelection(_:for:)` dual-writes the matching legacy field so old
+  builds stay truthful; `backend` / `htmlBackend` remain owned by the Settings
+  mapping.
+- `ExtractorSelectionResolver` gained a route-aware entry point. `resolvePDF`
+  and `resolveHTML` delegate through the route accessor, preserving result
+  types, ranking, diagnostics, and fixed fallbacks exactly. Execution
+  dispatch, the registry adapter enum, source dispatch, queue routing, and
+  process execution are unchanged.
+
+Design notes: `plans/dynamic-extractor-packages.md` § "Route selections: typed
+MIME routes".
+
+## Verification
+
+The following gates passed on 2026-08-28:
+
+```text
+swift test --filter 'ExtractorRouteTests|ExtractionConfigTests|ReviewedLegacySelectionMappingTests'
+42 tests passed
+
+make build
+make test
+swift build
+swift test
+```
+
+New regression coverage: route namespace distinctness, canonical-route MIME
+normalization, kind-then-MIME ordering, keyed coding round-trip, record
+normalization winner determinism, legacy configs without `routeExtractors`
+resolving exactly as before, deterministic persisted record order through the
+real `JSONSidecarConfig.save` path, replacement/removal preserving unrelated
+routes, canonical dual-write truthfulness, duplicate/malformed record decode
+resilience, and route-aware resolution parity with the legacy entry points.


### PR DESCRIPTION
Stack: PR 1 of 3 on top of #1158 (extractor routing table).

Parent: #1158 (`feature/dynamic-extractor-packages`) at exact head
`f99c68166dc3dfa34ff1cb92f06784274b9a0e4a`.

## What this PR does

Adds the typed route identity and route-indexed configuration that the
registration-driven extractor routing table (PRs 2–3) will be built on.

- `ExtractorRouteID` (`Sources/WikiFSTypes/Extractor/ExtractorRoute.swift`):
  a validated, Codable, Hashable, Comparable, Sendable pair of
  `ExtractorKind` + normalized `ExtractorMIMEType`. It is deliberately its own
  namespace — distinct from `ExtractorKind` (manifest/protocol operation
  family), `ExtractionBackendKind` (engine adapter namespace), and
  `ContentCapabilities.ExtractionPath` (source-classification policy). MIME is
  authoritative; filename extensions stay registration matching hints.
  Canonical constants: PDF (`application/pdf`), HTML (`text/html`).
- `ExtractorRouteSelectionRecord` pairs a route with a version-free
  `ExtractionBackendReference`.
- `ExtractionConfig.routeExtractors` persists records as a deterministically
  sorted array (not a string-keyed dictionary). Decode resilience matches the
  existing config philosophy: missing key → empty list, malformed record →
  dropped through the logged decode seam, duplicate route records →
  deterministically resolved (canonically-greatest wins, order-independent)
  with one bounded diagnostic, plus a stall guard against a non-advancing
  coder.
- `extractorSelection(for:)` precedence: exact record → matching legacy
  reference field (canonical routes only) → none.
- `setExtractorSelection(_:for:)` insert/replace/remove dual-writes the
  matching legacy `pdfExtractor` / `htmlExtractor` field so existing builds
  resolve the same selection. `backend` / `htmlBackend` stay owned by the
  existing Settings mapping (`writePDF` / `writeHTML`).
- `ExtractorSelectionResolver.resolve(_:configuration:activeRegistrations:)`
  is the route-aware entry point; `resolvePDF` / `resolveHTML` now source the
  selection through the route accessor. Result types, semantic-version and
  exact-revision ranking, redacted diagnostics, and fixed fallbacks (reviewed
  pdf2md for PDF, tag-based for HTML, prompt for absent HTML) are unchanged.

## What this PR deliberately does not do

No execution change: `ExtractionServices`, the registry adapter enum, source
dispatch, queue routing, and process execution are untouched. `ExtractorKind`
remains exactly `.pdf` and `.html`. No manifest schema, reviewed package
bytes, MIME registration, or protocol revision changes. Route identity admits
future kind-plus-MIME pairs, but resolving a non-canonical route returns nil
until an execution adapter exists — a separate project.

## Verification

```text
swift test --filter 'ExtractorRouteTests|ExtractionConfigTests|ReviewedLegacySelectionMappingTests'  # 42 passed
make build
make test
swift build
swift test
```

Design notes: `plans/dynamic-extractor-packages.md` § "Route selections: typed
MIME routes". Progress: `progress/2026-08-28T060000Z-extractor-route-selections.md`.
