### PR TITLE
refactor(extractors): derive route presentation from registrations

### DIFF
--- a/Sources/WikiFSEngine/ExtractionServiceKeys.swift
+++ b/Sources/WikiFSEngine/ExtractionServiceKeys.swift
@@ -89,10 +89,55 @@ public struct InstalledExtractionMatch: Sendable {
 public struct ExtractionBatchEntry: Sendable {
     public let key: ExtractionAdapterKey
     public let backend: RegisteredExtractionBackend
+    /// Manifest-derived presentation metadata for the registration this entry
+    /// belongs to (display name, declared kinds, MIME types, filename
+    /// extensions). Sourced from the validated manifest by the trusted
+    /// definition factory — never inferred from package or registration IDs.
+    /// Built-in registrations carry `nil`.
+    public let presentation: ExtractorRegistrationPresentation?
 
     public init(key: ExtractionAdapterKey, backend: RegisteredExtractionBackend) {
+        self.init(key: key, backend: backend, presentation: nil)
+    }
+
+    public init(
+        key: ExtractionAdapterKey,
+        backend: RegisteredExtractionBackend,
+        presentation: ExtractorRegistrationPresentation?
+    ) {
         self.key = key
         self.backend = backend
+        self.presentation = presentation
+    }
+}
+
+/// Manifest-derived presentation metadata for one installed registration:
+/// what the Settings route table needs to offer a package as a route choice
+/// without inspecting package payloads or paths.
+public struct ExtractorRegistrationPresentation: Hashable, Sendable {
+    /// User-facing registration name from the validated manifest.
+    public let displayName: String
+    /// The package's user-facing name from the validated manifest.
+    public let packageName: String
+    /// Declared operation kinds (already validated to the supported subset).
+    public let kinds: Set<ExtractorKind>
+    /// Declared input MIME types — the route dimension.
+    public let mimeTypes: Set<ExtractorMIMEType>
+    /// Declared filename extensions — matching hints only, never route identity.
+    public let filenameExtensions: Set<ExtractorFileExtension>
+
+    public init(
+        displayName: String,
+        packageName: String,
+        kinds: Set<ExtractorKind>,
+        mimeTypes: Set<ExtractorMIMEType>,
+        filenameExtensions: Set<ExtractorFileExtension>
+    ) {
+        self.displayName = displayName
+        self.packageName = packageName
+        self.kinds = kinds
+        self.mimeTypes = mimeTypes
+        self.filenameExtensions = filenameExtensions
     }
 }
 
@@ -144,6 +189,7 @@ public actor ExtractionBackendRegistry {
     private struct Registration: Sendable {
         let token: UUID
         let backend: RegisteredExtractionBackend
+        let presentation: ExtractorRegistrationPresentation?
     }
 
     private var registrations: [ExtractionAdapterKey: Registration] = [:]
@@ -165,7 +211,7 @@ public actor ExtractionBackendRegistry {
             throw ExtractionBackendRegistryError.duplicateAdapter(key)
         }
         let token = UUID()
-        registrations[key] = Registration(token: token, backend: backend)
+        registrations[key] = Registration(token: token, backend: backend, presentation: nil)
         return ExtractionBackendRegistration { [weak self] in
             await self?.remove(key: key, token: token)
         }
@@ -176,12 +222,12 @@ public actor ExtractionBackendRegistry {
     public func registerBatch(
         _ entries: [ExtractionBatchEntry]
     ) throws -> ExtractionBackendBatchHandle {
-        var incoming: [ExtractionAdapterKey: RegisteredExtractionBackend] = [:]
+        var incoming: [ExtractionAdapterKey: ExtractionBatchEntry] = [:]
         for entry in entries {
             guard incoming[entry.key] == nil else {
                 throw ExtractionBackendRegistryError.batchCollision([entry.key])
             }
-            incoming[entry.key] = entry.backend
+            incoming[entry.key] = entry
         }
         let colliding = entries.map(\.key).filter { registrations[$0] != nil }.sorted {
             $0.sortKey < $1.sortKey
@@ -190,8 +236,11 @@ public actor ExtractionBackendRegistry {
             throw ExtractionBackendRegistryError.batchCollision(colliding)
         }
         let token = UUID()
-        for (key, backend) in incoming {
-            registrations[key] = Registration(token: token, backend: backend)
+        for (key, entry) in incoming {
+            registrations[key] = Registration(
+                token: token,
+                backend: entry.backend,
+                presentation: entry.presentation)
         }
         return ExtractionBackendBatchHandle(
             registry: self,
@@ -345,6 +394,32 @@ public extension ExtractionBackendRegistry {
             }
         }
         return rows.sorted { $0.id < $1.id }
+    }
+
+    /// Route presentation snapshot: one entry per active exact registration
+    /// carrying its manifest-derived presentation metadata. Multiple exact
+    /// versions of one logical registration each appear; the route table
+    /// builder deduplicates them into logical choices. Registrations without
+    /// presentation metadata (built-ins) never appear here. Deterministic:
+    /// sorted by exact reference.
+    func installedRegistrationSnapshots() async -> [ExtractorRouteRegistrationSnapshot] {
+        var byReference: [ExtractorReference: ExtractorRegistrationPresentation] = [:]
+        for (key, registration) in registrations {
+            guard case .installed(_, let reference) = key,
+                  let presentation = registration.presentation else { continue }
+            byReference[reference] = presentation
+        }
+        return byReference
+            .sorted { $0.key < $1.key }
+            .map { reference, presentation in
+                ExtractorRouteRegistrationSnapshot(
+                    reference: reference,
+                    displayName: presentation.displayName,
+                    packageName: presentation.packageName,
+                    kinds: presentation.kinds,
+                    mimeTypes: presentation.mimeTypes,
+                    filenameExtensions: presentation.filenameExtensions)
+            }
     }
 }
 

--- a/Sources/WikiFSEngine/ExtractorPackagePluginDefinitionFactory.swift
+++ b/Sources/WikiFSEngine/ExtractorPackagePluginDefinitionFactory.swift
@@ -30,6 +30,18 @@ public enum ExtractorPackagePluginDefinitionFactory {
         PluginID("dynamic:extractor-package/" + Self.identityDigest(revision, protocolRevision: nil))
     }
 
+    /// The dynamic definition identity for one exact revision under one
+    /// protocol revision. Public so lifecycle observers can map a hosted
+    /// definition back to its revision (reconciler inspection → Settings).
+    public static func definitionID(
+        revision: ExtractorPackageRevisionID,
+        protocolRevision: ExtractorProtocolRevision
+    ) -> DynamicPluginDefinitionID {
+        DynamicPluginDefinitionID("extractor-package/" + Self.identityDigest(
+            revision,
+            protocolRevision: protocolRevision.rawValue))
+    }
+
     /// Immutable fingerprint over everything this definition's behavior
     /// depends on: exact revision, supported protocol, normalized
     /// registrations, and the fixed dependency contract version.
@@ -88,9 +100,7 @@ public enum ExtractorPackagePluginDefinitionFactory {
             ServiceDependency(ExtractionServiceKeys.packageSourceLocator),
         ]
         let fingerprint = try self.fingerprint(for: manifest, revision: revision)
-        let id = DynamicPluginDefinitionID("extractor-package/" + Self.identityDigest(
-            revision,
-            protocolRevision: manifest.protocolRevision.rawValue))
+        let id = Self.definitionID(revision: revision, protocolRevision: manifest.protocolRevision)
         let capturedRevision = revision
         let capturedManifest = manifest
         let plugin = PluginDefinition(
@@ -158,6 +168,15 @@ public enum ExtractorPackagePluginDefinitionFactory {
             var entries: [ExtractionBatchEntry] = []
             entries.reserveCapacity(manifest.registrations.count)
             for registration in manifest.registrations.sorted() {
+                // Manifest-derived presentation metadata rides with the
+                // registration so Settings can project routes without
+                // re-reading the package.
+                let presentation = ExtractorRegistrationPresentation(
+                    displayName: registration.displayName,
+                    packageName: manifest.displayName,
+                    kinds: registration.kinds,
+                    mimeTypes: registration.mimeTypes,
+                    filenameExtensions: registration.filenameExtensions)
                 let kinds = registration.kinds
                     .sorted { $0.rawValue < $1.rawValue }
                 for kind in kinds {
@@ -176,7 +195,8 @@ public enum ExtractorPackagePluginDefinitionFactory {
                                     revision: revision,
                                     manifest: manifest)
                                 return ExtractionBackendAdapter.pdf(preparation)
-                            }))
+                            },
+                            presentation: presentation))
                     case .html:
                         entries.append(ExtractionBatchEntry(
                             key: .installed(kind: backendKind, reference: reference),
@@ -185,7 +205,8 @@ public enum ExtractorPackagePluginDefinitionFactory {
                                     revision: revision,
                                     manifest: manifest)
                                 return ExtractionBackendAdapter.html(html)
-                            }))
+                            },
+                            presentation: presentation))
                     }
                 }
             }

--- a/Sources/WikiFSEngine/ExtractorPackagePluginReconciler.swift
+++ b/Sources/WikiFSEngine/ExtractorPackagePluginReconciler.swift
@@ -169,19 +169,27 @@ public actor ExtractorPackagePluginReconciler {
             records: catalog.records,
             sourceLocator: sourceLocator)
         retainEach(built.failures)
-        revisionIDsByDefinitionID = built.revisionIDsByDefinitionID
 
         do {
             let report = try await host.reconcile(desired: built.definitions)
+            // Commit the observation map only after the host accepted the
+            // generation: a rejected reconcile keeps the prior graph, so its
+            // definition → revision metadata must stay paired with it.
+            revisionIDsByDefinitionID = built.revisionIDsByDefinitionID
             lastAppliedGeneration = catalog.generation
             retainNotices(for: report.operationFailures)
+            // Host activation failures carry real revisions through the
+            // desired map and are retained so the Settings observation path
+            // can report the failed-to-activate lifecycle state.
+            let activationFailures = activateFailures(from: report)
+            retainEach(activationFailures)
             return ExtractorPackageReconciliationReport(
                 observedGeneration: catalog.generation,
                 appliedGeneration: catalog.generation,
                 skippedAsUnchanged: false,
                 registeredDefinitionIDs: Array(report.outcomes.keys).sorted { $0.rawValue < $1.rawValue },
                 removedCount: report.removedDefinitionIDs.count,
-                failedPackages: built.failures + activateFailures(from: report))
+                failedPackages: built.failures + activationFailures)
         } catch {
             retain("host reconcile rejected generation \(catalog.generation)")
             return ExtractorPackageReconciliationReport(
@@ -245,8 +253,11 @@ public actor ExtractorPackagePluginReconciler {
     ) -> [ExtractorPackageReconciliationFailure] {
         report.outcomes.compactMap { id, outcome in
             guard case .failed(_, _, let phase, let failure) = outcome else { return nil }
+            // Real revision when the desired map knows this definition; the
+            // placeholder keeps the redaction contract for unknown IDs.
+            let revision = revisionIDsByDefinitionID[id] ?? .placeholderForDiagnostic
             return ExtractorPackageReconciliationFailure(
-                revision: .placeholderForDiagnostic,
+                revision: revision,
                 message: "\(Self.shortDefinitionID(id)): phase=\(phase.rawValue) \(failure.message)")
         }
     }

--- a/Sources/WikiFSEngine/ExtractorPackagePluginReconciler.swift
+++ b/Sources/WikiFSEngine/ExtractorPackagePluginReconciler.swift
@@ -94,6 +94,10 @@ public actor ExtractorPackagePluginReconciler {
     private let sourceLocator: any ExtractorPackageSourceLocating
     private var lastAppliedGeneration: UInt64?
     private var retainedFailures: [ExtractorPackageReconciliationFailure] = []
+    /// Maps each desired dynamic definition to its exact revision so
+    /// inspection can report lifecycle state in package terms (Settings
+    /// route statuses). Rebuilt on every applied reconcile.
+    private var revisionIDsByDefinitionID: [DynamicPluginDefinitionID: ExtractorPackageRevisionID] = [:]
 
     init(
         host: DynamicPluginHost,
@@ -115,10 +119,12 @@ public actor ExtractorPackagePluginReconciler {
         sourceLocator: any ExtractorPackageSourceLocating
     ) -> (
         definitions: [TrustedDynamicPluginDefinition],
-        failures: [ExtractorPackageReconciliationFailure]
+        failures: [ExtractorPackageReconciliationFailure],
+        revisionIDsByDefinitionID: [DynamicPluginDefinitionID: ExtractorPackageRevisionID]
     ) {
         var definitions: [TrustedDynamicPluginDefinition] = []
         var failures: [ExtractorPackageReconciliationFailure] = []
+        var revisionIDsByDefinitionID: [DynamicPluginDefinitionID: ExtractorPackageRevisionID] = [:]
         definitions.reserveCapacity(records.count)
         for record in records.sorted() {
             do {
@@ -133,13 +139,14 @@ public actor ExtractorPackagePluginReconciler {
                     revision: record.revision,
                     manifest: validated.validated.manifest)
                 definitions.append(definition)
+                revisionIDsByDefinitionID[definition.id] = record.revision
             } catch {
                 failures.append(ExtractorPackageReconciliationFailure(
                     revision: record.revision,
                     message: Self.failureMessage(error)))
             }
         }
-        return (definitions, failures)
+        return (definitions, failures, revisionIDsByDefinitionID)
     }
 
     /// Applies the authoritative catalog generation. Unchanged generations are
@@ -162,6 +169,7 @@ public actor ExtractorPackagePluginReconciler {
             records: catalog.records,
             sourceLocator: sourceLocator)
         retainEach(built.failures)
+        revisionIDsByDefinitionID = built.revisionIDsByDefinitionID
 
         do {
             let report = try await host.reconcile(desired: built.definitions)
@@ -187,16 +195,24 @@ public actor ExtractorPackagePluginReconciler {
     }
 
     /// Inspection snapshot for settings UI and diagnostics: what the durable
-    /// catalog said versus what this process graph currently holds.
+    /// catalog said versus what this process graph currently holds, plus the
+    /// exact revisions whose hosted definitions are waiting for activation.
     public func observation() async -> (
         appliedGeneration: UInt64?,
         hostedPlugins: [DynamicPluginInspection],
-        retainedFailures: [ExtractorPackageReconciliationFailure]
+        retainedFailures: [ExtractorPackageReconciliationFailure],
+        waitingRevisionIDs: Set<ExtractorPackageRevisionID>
     ) {
-        (
+        let hostedPlugins = await host.inspectAll()
+        let waitingRevisionIDs = Set(
+            hostedPlugins
+                .filter { $0.lifecycle == .waiting }
+                .compactMap { revisionIDsByDefinitionID[$0.definitionID] })
+        return (
             lastAppliedGeneration,
-            await host.inspectAll(),
-            retainedFailures
+            hostedPlugins,
+            retainedFailures,
+            waitingRevisionIDs
         )
     }
 

--- a/Sources/WikiFSEngine/ExtractorRoutePresentation.swift
+++ b/Sources/WikiFSEngine/ExtractorRoutePresentation.swift
@@ -1,0 +1,224 @@
+import Foundation
+import WikiFSCore
+
+// pattern: Functional Core
+
+/// One active exact registration's route-presentation data: manifest-derived
+/// metadata plus the exact reference, projected by the extraction backend
+/// registry. Settings consumes this snapshot to build route choices without
+/// inspecting package payloads, paths, or manifests.
+public struct ExtractorRouteRegistrationSnapshot: Hashable, Sendable {
+    /// The exact active registration (revision + registration ID).
+    public let reference: ExtractorReference
+    /// User-facing registration name from the validated manifest.
+    public let displayName: String
+    /// User-facing package name from the validated manifest.
+    public let packageName: String
+    /// Declared operation kinds.
+    public let kinds: Set<ExtractorKind>
+    /// Declared input MIME types — each (kind, MIME) pair is a route.
+    public let mimeTypes: Set<ExtractorMIMEType>
+    /// Declared filename extensions — matching hints, never route identity.
+    public let filenameExtensions: Set<ExtractorFileExtension>
+
+    public init(
+        reference: ExtractorReference,
+        displayName: String,
+        packageName: String,
+        kinds: Set<ExtractorKind>,
+        mimeTypes: Set<ExtractorMIMEType>,
+        filenameExtensions: Set<ExtractorFileExtension>
+    ) {
+        self.reference = reference
+        self.displayName = displayName
+        self.packageName = packageName
+        self.kinds = kinds
+        self.mimeTypes = mimeTypes
+        self.filenameExtensions = filenameExtensions
+    }
+}
+
+/// Where a route choice comes from. A closed enum — display strings are
+/// presentation, never logic.
+public enum ExtractorRouteSourceCategory: String, Hashable, Sendable, CaseIterable {
+    case reviewedPackage = "reviewed-package"
+    case installedPackage = "installed-package"
+    case connectedService = "connected-service"
+    case builtIn = "built-in"
+    case prompt
+    case unavailable
+}
+
+/// One host-owned route presentation: what the format column shows and what
+/// the fixed fallback for that route is.
+public struct ExtractorRouteDescriptor: Hashable, Sendable {
+    public let route: ExtractorRouteID
+    public let displayName: String
+    public let systemImage: String?
+    public let fallbackDescription: String
+
+    public init(route: ExtractorRouteID, displayName: String, systemImage: String?, fallbackDescription: String) {
+        self.route = route
+        self.displayName = displayName
+        self.systemImage = systemImage
+        self.fallbackDescription = fallbackDescription
+    }
+}
+
+/// One selectable default-extractor choice inside a route row.
+public struct ExtractorRouteChoice: Hashable, Sendable, Identifiable {
+    public let route: ExtractorRouteID
+    /// The persisted value this choice writes. `nil` only for the prompt
+    /// choice (no selection).
+    public let reference: ExtractionBackendReference?
+    public let displayName: String
+    public let category: ExtractorRouteSourceCategory
+    /// For installed-namespace choices (reviewed and installed packages): the
+    /// exact revision summary of the highest active compatible registration,
+    /// e.g. "2.0.0 · a1b2c3d4e5f6". `nil` when inactive or not installed.
+    public let exactSummary: String?
+
+    public init(
+        route: ExtractorRouteID,
+        reference: ExtractionBackendReference?,
+        displayName: String,
+        category: ExtractorRouteSourceCategory,
+        exactSummary: String? = nil
+    ) {
+        self.route = route
+        self.reference = reference
+        self.displayName = displayName
+        self.category = category
+        self.exactSummary = exactSummary
+    }
+
+    public var id: String {
+        let referenceKey: String
+        switch reference {
+        case .none: referenceKey = "prompt"
+        case .builtIn(let builtIn): referenceKey = "builtIn/\(builtIn)"
+        case .installed(let logical): referenceKey = "installed/\(logical)"
+        }
+        return "\(route.description)/\(referenceKey)"
+    }
+}
+
+/// What the status column reports for a route row.
+public enum ExtractorRouteStatus: Hashable, Sendable {
+    /// The resolved selection is usable right now.
+    case available
+    /// A saved installed selection is unavailable and a fixed fallback is active.
+    case usingFallback(description: String)
+    /// A saved installed selection has no active registration and no recorded
+    /// activation failure or waiting run.
+    case notInstalled
+    /// The selected package is admitted but its host service has not activated it.
+    case waitingForHostService
+    /// The selected package's activation failed in this process.
+    case failedActivation
+}
+
+/// One route row in the Settings extractor route table: descriptor, the saved
+/// and resolved selections, the compatible choices, and the status.
+public struct ExtractorRouteSettingsRow: Hashable, Sendable, Identifiable {
+    public let descriptor: ExtractorRouteDescriptor
+    /// The persisted selection for this route (route record first, then the
+    /// matching legacy reference field). `nil` = no selection.
+    public let savedSelection: ExtractionBackendReference?
+    /// What execution would resolve to today, via the selection resolver.
+    public let resolvedSelection: ResolvedExtractionSelection?
+    public let choices: [ExtractorRouteChoice]
+    public let status: ExtractorRouteStatus
+
+    public init(
+        descriptor: ExtractorRouteDescriptor,
+        savedSelection: ExtractionBackendReference?,
+        resolvedSelection: ResolvedExtractionSelection?,
+        choices: [ExtractorRouteChoice],
+        status: ExtractorRouteStatus
+    ) {
+        self.descriptor = descriptor
+        self.savedSelection = savedSelection
+        self.resolvedSelection = resolvedSelection
+        self.choices = choices
+        self.status = status
+    }
+
+    public var route: ExtractorRouteID { descriptor.route }
+    public var id: String { descriptor.route.description }
+}
+
+/// Host-owned route descriptors and built-in/connected choices for the two
+/// canonical routes. Future registrations can add routes and package choices,
+/// but the host's own choices are fixed here — reviewed packages included.
+public enum ExtractorRouteHostCatalog {
+    /// Canonical routes in host display order (PDF first, then HTML).
+    public static let descriptors: [ExtractorRouteDescriptor] = [
+        ExtractorRouteDescriptor(
+            route: .canonicalPDF,
+            displayName: "PDF",
+            systemImage: "doc.richtext",
+            fallbackDescription: "Bundled pdf2md extraction"),
+        ExtractorRouteDescriptor(
+            route: .canonicalHTML,
+            displayName: "HTML",
+            systemImage: "safari",
+            fallbackDescription: "Tag-based text extraction"),
+    ]
+
+    /// The host's fixed choices for one route. Only the canonical routes have
+    /// host choices; a future registration-derived route offers package
+    /// choices only.
+    public static func choices(for route: ExtractorRouteID) -> [ExtractorRouteChoice] {
+        if route == .canonicalPDF {
+            return [
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .installed(ProcessExtractionServices.reviewedPDFLogical),
+                    displayName: "pdf2md",
+                    category: .reviewedPackage),
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .builtIn(.pdf(.acp)),
+                    displayName: "ACP Provider",
+                    category: .connectedService),
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .builtIn(.pdf(.doclingServe)),
+                    displayName: "Docling Serve",
+                    category: .connectedService),
+            ]
+        }
+        if route == .canonicalHTML {
+            return [
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: nil,
+                    displayName: "No default (ask each time)",
+                    category: .prompt),
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .installed(ProcessExtractionServices.reviewedHTMLLogical),
+                    displayName: "Defuddle",
+                    category: .reviewedPackage),
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .builtIn(.html(.tagBased)),
+                    displayName: "Tag-based",
+                    category: .builtIn),
+            ]
+        }
+        return []
+    }
+
+    /// Stable fallback label for a route without a host descriptor — derived
+    /// from the normalized MIME type alone. Future-facing: no current
+    /// registration produces a route outside the host catalog.
+    public static func fallbackDescriptor(for route: ExtractorRouteID) -> ExtractorRouteDescriptor {
+        ExtractorRouteDescriptor(
+            route: route,
+            displayName: route.mimeType.rawValue,
+            systemImage: nil,
+            fallbackDescription: "No built-in fallback for this format")
+    }
+}

--- a/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
+++ b/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
@@ -28,20 +28,21 @@ public enum ExtractorRouteTableBuilder {
     public struct Input: Sendable {
         public let configuration: ExtractionConfig
         public let registrations: [ExtractorRouteRegistrationSnapshot]
-        /// Retained reconciler failures — the "failed to activate" signal.
-        public let activationFailures: [ExtractorPackageReconciliationFailure]
+        /// Package IDs with a retained reconciler activation failure — the
+        /// "failed to activate" signal, matched at package granularity.
+        public let failedPackageIDs: Set<String>
         /// Exact revisions with a hosted definition waiting for activation.
         public let waitingRevisionIDs: Set<ExtractorPackageRevisionID>
 
         public init(
             configuration: ExtractionConfig,
             registrations: [ExtractorRouteRegistrationSnapshot],
-            activationFailures: [ExtractorPackageReconciliationFailure] = [],
+            failedPackageIDs: Set<String> = [],
             waitingRevisionIDs: Set<ExtractorPackageRevisionID> = []
         ) {
             self.configuration = configuration
             self.registrations = registrations
-            self.activationFailures = activationFailures
+            self.failedPackageIDs = failedPackageIDs
             self.waitingRevisionIDs = waitingRevisionIDs
         }
     }
@@ -87,8 +88,8 @@ public enum ExtractorRouteTableBuilder {
         activeRegistrations: [ActiveExtractorRegistration]
     ) -> ExtractorRouteSettingsRow {
         let descriptor = descriptor(for: route, input: input)
-        let choices = buildChoices(route: route, input: input)
         let savedSelection = input.configuration.extractorSelection(for: route)
+        let choices = buildChoices(route: route, input: input, savedSelection: savedSelection)
         let decision = ExtractorSelectionResolver.resolve(
             route,
             configuration: input.configuration,
@@ -111,7 +112,11 @@ public enum ExtractorRouteTableBuilder {
             ?? ExtractorRouteHostCatalog.fallbackDescriptor(for: route)
     }
 
-    private static func buildChoices(route: ExtractorRouteID, input: Input) -> [ExtractorRouteChoice] {
+    private static func buildChoices(
+        route: ExtractorRouteID,
+        input: Input,
+        savedSelection: ExtractionBackendReference?
+    ) -> [ExtractorRouteChoice] {
         let hostChoices = ExtractorRouteHostCatalog.choices(for: route)
         let packages = packageChoices(route: route, input: input)
         // Installed packages slot directly after the reviewed package (mirroring
@@ -120,6 +125,20 @@ public enum ExtractorRouteTableBuilder {
         var choices = hostChoices
         let insertIndex = choices.lastIndex { $0.category == .reviewedPackage }.map { $0 + 1 } ?? 0
         choices.insert(contentsOf: packages, at: insertIndex)
+        // A saved installed selection with no active registration stays
+        // selectable so the picker keeps showing it (the status column reports
+        // the fallback). Every other saved value is already represented.
+        if case .installed(let logical)? = savedSelection,
+           choices.contains(where: { $0.reference == .installed(logical) }) == false {
+            let staleIndex = choices.lastIndex { $0.category == .reviewedPackage }.map { $0 + 1 } ?? 0
+            choices.insert(
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .installed(logical),
+                    displayName: logical.packageID.rawValue,
+                    category: .unavailable),
+                at: staleIndex)
+        }
         return choices
     }
 
@@ -176,7 +195,7 @@ public enum ExtractorRouteTableBuilder {
         if input.waitingRevisionIDs.contains(where: { $0.packageID == logical.packageID }) {
             return .waitingForHostService
         }
-        if input.activationFailures.contains(where: { $0.packageID == logical.packageID.rawValue }) {
+        if input.failedPackageIDs.contains(logical.packageID.rawValue) {
             return .failedActivation
         }
         return .usingFallback(description: fallbackDescription(route: route, input: input))

--- a/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
+++ b/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
@@ -112,8 +112,14 @@ public enum ExtractorRouteTableBuilder {
     }
 
     private static func buildChoices(route: ExtractorRouteID, input: Input) -> [ExtractorRouteChoice] {
-        var choices = ExtractorRouteHostCatalog.choices(for: route)
-        choices.append(contentsOf: packageChoices(route: route, input: input))
+        let hostChoices = ExtractorRouteHostCatalog.choices(for: route)
+        let packages = packageChoices(route: route, input: input)
+        // Installed packages slot directly after the reviewed package (mirroring
+        // the long-standing picker order), before connected services and
+        // built-ins. HTML's prompt choice stays first.
+        var choices = hostChoices
+        let insertIndex = choices.lastIndex { $0.category == .reviewedPackage }.map { $0 + 1 } ?? 0
+        choices.insert(contentsOf: packages, at: insertIndex)
         return choices
     }
 

--- a/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
+++ b/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
@@ -1,0 +1,199 @@
+import Foundation
+import WikiFSCore
+
+// pattern: Functional Core
+
+/// Builds the Settings extractor route table: one deterministic row per route
+/// from the union of host-owned descriptors, active package registration
+/// snapshots, and saved selections (including unavailable ones). Pure — no
+/// registry, catalog, or UI access; every input is a value.
+///
+/// Row union rules:
+///
+/// - Host descriptors seed the canonical PDF and HTML routes, so those rows
+///   always exist even with no packages installed.
+/// - Every active exact registration contributes one row per declared
+///   (kind, MIME) pair, so a future registration can add a row without a
+///   Settings layout change. Execution adapters for new kinds stay separate
+///   work — such rows resolve to no selection.
+/// - Saved route records seed their route even when nothing active backs it,
+///   keeping a stale package selection visible with its fallback state.
+///
+/// Deterministic ordering: host descriptor order first (PDF, then HTML), then
+/// remaining routes by the typed route order (kind raw value, then MIME raw
+/// value). Choices order: host catalog choices first, then package choices by
+/// package ID and registration ID.
+public enum ExtractorRouteTableBuilder {
+    /// All builder inputs as plain values.
+    public struct Input: Sendable {
+        public let configuration: ExtractionConfig
+        public let registrations: [ExtractorRouteRegistrationSnapshot]
+        /// Retained reconciler failures — the "failed to activate" signal.
+        public let activationFailures: [ExtractorPackageReconciliationFailure]
+        /// Exact revisions with a hosted definition waiting for activation.
+        public let waitingRevisionIDs: Set<ExtractorPackageRevisionID>
+
+        public init(
+            configuration: ExtractionConfig,
+            registrations: [ExtractorRouteRegistrationSnapshot],
+            activationFailures: [ExtractorPackageReconciliationFailure] = [],
+            waitingRevisionIDs: Set<ExtractorPackageRevisionID> = []
+        ) {
+            self.configuration = configuration
+            self.registrations = registrations
+            self.activationFailures = activationFailures
+            self.waitingRevisionIDs = waitingRevisionIDs
+        }
+    }
+
+    public static func build(_ input: Input) -> [ExtractorRouteSettingsRow] {
+        let routes = descriptors(for: input).map(\.route)
+        let activeRegistrations = activeResolverRegistrations(input.registrations)
+        return routes.map { route in
+            buildRow(route: route, input: input, activeRegistrations: activeRegistrations)
+        }
+    }
+
+    // MARK: - Route collection
+
+    private static func descriptors(for input: Input) -> [ExtractorRouteDescriptor] {
+        var descriptors = ExtractorRouteHostCatalog.descriptors
+        let hostedRoutes = Set(descriptors.map(\.route))
+        var extra: [ExtractorRouteID] = []
+        for snapshot in input.registrations {
+            for kind in snapshot.kinds {
+                for mimeType in snapshot.mimeTypes {
+                    let route = ExtractorRouteID(kind: kind, mimeType: mimeType)
+                    if hostedRoutes.contains(route) == false, extra.contains(route) == false {
+                        extra.append(route)
+                    }
+                }
+            }
+        }
+        for record in input.configuration.routeExtractors
+        where hostedRoutes.contains(record.route) == false && extra.contains(record.route) == false {
+            extra.append(record.route)
+        }
+        // Deterministic: typed route order (kind raw value, then MIME raw value).
+        descriptors.append(contentsOf: extra.sorted().map(ExtractorRouteHostCatalog.fallbackDescriptor(for:)))
+        return descriptors
+    }
+
+    // MARK: - Row construction
+
+    private static func buildRow(
+        route: ExtractorRouteID,
+        input: Input,
+        activeRegistrations: [ActiveExtractorRegistration]
+    ) -> ExtractorRouteSettingsRow {
+        let descriptor = descriptor(for: route, input: input)
+        let choices = buildChoices(route: route, input: input)
+        let savedSelection = input.configuration.extractorSelection(for: route)
+        let decision = ExtractorSelectionResolver.resolve(
+            route,
+            configuration: input.configuration,
+            activeRegistrations: activeRegistrations)
+        let status = buildStatus(
+            route: route,
+            input: input,
+            savedSelection: savedSelection,
+            decision: decision)
+        return ExtractorRouteSettingsRow(
+            descriptor: descriptor,
+            savedSelection: savedSelection,
+            resolvedSelection: decision?.selection,
+            choices: choices,
+            status: status)
+    }
+
+    private static func descriptor(for route: ExtractorRouteID, input: Input) -> ExtractorRouteDescriptor {
+        ExtractorRouteHostCatalog.descriptors.first { $0.route == route }
+            ?? ExtractorRouteHostCatalog.fallbackDescriptor(for: route)
+    }
+
+    private static func buildChoices(route: ExtractorRouteID, input: Input) -> [ExtractorRouteChoice] {
+        var choices = ExtractorRouteHostCatalog.choices(for: route)
+        choices.append(contentsOf: packageChoices(route: route, input: input))
+        return choices
+    }
+
+    /// Package choices for one route: registrations whose declared kinds and
+    /// MIME types cover the route. Multiple exact versions of one logical
+    /// (package, registration) deduplicate into one choice showing the highest
+    /// active exact revision; the lifecycle rows below the table keep every
+    /// exact version for inspection and removal.
+    private static func packageChoices(route: ExtractorRouteID, input: Input) -> [ExtractorRouteChoice] {
+        let matching = input.registrations.filter { snapshot in
+            snapshot.kinds.contains(route.kind) && snapshot.mimeTypes.contains(route.mimeType)
+        }
+        var highestByLogical: [LogicalExtractorReference: ExtractorRouteRegistrationSnapshot] = [:]
+        for snapshot in matching {
+            let logical = LogicalExtractorReference(
+                packageID: snapshot.reference.revision.packageID,
+                registrationID: snapshot.reference.registrationID)
+            if let current = highestByLogical[logical],
+               snapshot.reference.revision <= current.reference.revision {
+                continue
+            }
+            highestByLogical[logical] = snapshot
+        }
+        return highestByLogical
+            .sorted { $0.key < $1.key }
+            .map { logical, snapshot in
+                ExtractorRouteChoice(
+                    route: route,
+                    reference: .installed(logical),
+                    displayName: snapshot.displayName,
+                    category: .installedPackage,
+                    exactSummary: Self.exactSummary(snapshot.reference.revision))
+            }
+    }
+
+    // MARK: - Status
+
+    private static func buildStatus(
+        route: ExtractorRouteID,
+        input: Input,
+        savedSelection: ExtractionBackendReference?,
+        decision: ExtractionSelectionDecision?
+    ) -> ExtractorRouteStatus {
+        guard case .installed(let logical)? = savedSelection else {
+            // Built-in, connected, prompt, and no selection: what resolves is
+            // what runs.
+            return .available
+        }
+        if case .installed? = decision?.selection {
+            return .available
+        }
+        // Unavailable installed selection: keep it selected and report the
+        // live fallback, or the package-level lifecycle state when one exists.
+        if input.waitingRevisionIDs.contains(where: { $0.packageID == logical.packageID }) {
+            return .waitingForHostService
+        }
+        if input.activationFailures.contains(where: { $0.packageID == logical.packageID.rawValue }) {
+            return .failedActivation
+        }
+        return .usingFallback(description: fallbackDescription(route: route, input: input))
+    }
+
+    private static func fallbackDescription(route: ExtractorRouteID, input: Input) -> String {
+        descriptor(for: route, input: input).fallbackDescription
+    }
+
+    // MARK: - Resolver inputs
+
+    private static func activeResolverRegistrations(
+        _ snapshots: [ExtractorRouteRegistrationSnapshot]
+    ) -> [ActiveExtractorRegistration] {
+        snapshots.map { snapshot in
+            ActiveExtractorRegistration(
+                reference: snapshot.reference,
+                kinds: snapshot.kinds,
+                protocolRevision: .v1)
+        }
+    }
+
+    private static func exactSummary(_ revision: ExtractorPackageRevisionID) -> String {
+        "\(revision.version.rawValue) · \(revision.digest.hex.prefix(12))"
+    }
+}

--- a/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
+++ b/Sources/WikiFSEngine/ExtractorRouteTableBuilder.swift
@@ -49,9 +49,8 @@ public enum ExtractorRouteTableBuilder {
 
     public static func build(_ input: Input) -> [ExtractorRouteSettingsRow] {
         let routes = descriptors(for: input).map(\.route)
-        let activeRegistrations = activeResolverRegistrations(input.registrations)
         return routes.map { route in
-            buildRow(route: route, input: input, activeRegistrations: activeRegistrations)
+            buildRow(route: route, input: input)
         }
     }
 
@@ -84,16 +83,19 @@ public enum ExtractorRouteTableBuilder {
 
     private static func buildRow(
         route: ExtractorRouteID,
-        input: Input,
-        activeRegistrations: [ActiveExtractorRegistration]
+        input: Input
     ) -> ExtractorRouteSettingsRow {
         let descriptor = descriptor(for: route, input: input)
         let savedSelection = input.configuration.extractorSelection(for: route)
         let choices = buildChoices(route: route, input: input, savedSelection: savedSelection)
+        // Resolver compatibility is route-scoped: only registrations declaring
+        // BOTH the route's kind and MIME participate, so a package that is
+        // active for the kind but not this MIME cannot resolve (or report
+        // Available) on this route.
         let decision = ExtractorSelectionResolver.resolve(
             route,
             configuration: input.configuration,
-            activeRegistrations: activeRegistrations)
+            activeRegistrations: activeResolverRegistrations(route: route, input: input))
         let status = buildStatus(
             route: route,
             input: input,
@@ -208,14 +210,17 @@ public enum ExtractorRouteTableBuilder {
     // MARK: - Resolver inputs
 
     private static func activeResolverRegistrations(
-        _ snapshots: [ExtractorRouteRegistrationSnapshot]
+        route: ExtractorRouteID,
+        input: Input
     ) -> [ActiveExtractorRegistration] {
-        snapshots.map { snapshot in
-            ActiveExtractorRegistration(
-                reference: snapshot.reference,
-                kinds: snapshot.kinds,
-                protocolRevision: .v1)
-        }
+        input.registrations
+            .filter { $0.kinds.contains(route.kind) && $0.mimeTypes.contains(route.mimeType) }
+            .map { snapshot in
+                ActiveExtractorRegistration(
+                    reference: snapshot.reference,
+                    kinds: snapshot.kinds,
+                    protocolRevision: .v1)
+            }
     }
 
     private static func exactSummary(_ revision: ExtractorPackageRevisionID) -> String {

--- a/Sources/WikiFSEngine/ProcessExtractionContext.swift
+++ b/Sources/WikiFSEngine/ProcessExtractionContext.swift
@@ -147,7 +147,8 @@ public struct ProcessExtractionContext: Sendable {
     public func observationSnapshot() async -> (
         appliedGeneration: UInt64?,
         hostedPlugins: [DynamicPluginInspection],
-        retainedFailures: [ExtractorPackageReconciliationFailure]
+        retainedFailures: [ExtractorPackageReconciliationFailure],
+        waitingRevisionIDs: Set<ExtractorPackageRevisionID>
     ) {
         await reconciler.observation()
     }

--- a/Tests/WikiFSTests/ExtractorGeneratedPluginTests.swift
+++ b/Tests/WikiFSTests/ExtractorGeneratedPluginTests.swift
@@ -124,6 +124,60 @@ struct ExtractionBackendRegistryBatchTests {
         #expect(await registry.resolveInstalled(logical, kind: .html) != nil)
     }
 
+    // MARK: - Route presentation snapshots
+
+    @Test func presentationSnapshotsCarryManifestMetadataAndDropWithDisposal() async throws {
+        let registry = ExtractionBackendRegistry()
+        let lowReference = try reference(
+            packageID: "org.example.route",
+            version: "1.0.0",
+            digestHex: String(repeating: "1", count: 64))
+        let highReference = try reference(
+            packageID: "org.example.route",
+            version: "2.0.0",
+            digestHex: String(repeating: "2", count: 64))
+        let pdfMIME = try ExtractorMIMEType(validating: "application/pdf")
+        let pdfExtension = try #require(ExtractorFileExtension(rawValue: "pdf"))
+        let presentation = ExtractorRegistrationPresentation(
+            displayName: "Main",
+            packageName: "Route Package",
+            kinds: [.pdf, .html],
+            mimeTypes: [pdfMIME],
+            filenameExtensions: [pdfExtension])
+        let batch = try await registry.registerBatch([
+            ExtractionBatchEntry(
+                key: .installed(kind: .pdf, reference: lowReference),
+                backend: makeStubBackend(),
+                presentation: presentation),
+            ExtractionBatchEntry(
+                key: .installed(kind: .pdf, reference: highReference),
+                backend: makeStubBackend(),
+                presentation: presentation),
+            ExtractionBatchEntry(
+                key: .installed(kind: .html, reference: highReference),
+                backend: makeStubBackend(),
+                presentation: presentation),
+            ExtractionBatchEntry(
+                key: .builtIn(ExtractionBackendKey(kind: .pdf, backendID: "legacy")),
+                backend: makeStubBackend()),
+        ])
+
+        var snapshots = await registry.installedRegistrationSnapshots()
+        // One snapshot per exact registration reference — the same registration
+        // registered in the PDF and HTML namespaces collapses onto its single
+        // reference. Built-ins never appear.
+        #expect(snapshots.count == 2)
+        #expect(snapshots.map(\.reference) == [lowReference, highReference])
+        #expect(snapshots.allSatisfy { $0.displayName == "Main" && $0.packageName == "Route Package" })
+        #expect(snapshots.allSatisfy { $0.kinds == [.pdf, .html] })
+        #expect(snapshots.allSatisfy { $0.mimeTypes == [pdfMIME] })
+        #expect(snapshots.allSatisfy { $0.filenameExtensions == [pdfExtension] })
+
+        await batch.dispose()
+        snapshots = await registry.installedRegistrationSnapshots()
+        #expect(snapshots.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeBuiltInBackend(id: String) -> RegisteredExtractionBackend {
@@ -190,7 +244,7 @@ struct ExtractionBackendRegistryBatchTests {
     }
 }
 
-private struct StubMarkdownExtractor: MarkdownExtractor {
+struct StubMarkdownExtractor: MarkdownExtractor {
     var displayName: String { "stub" }
     func readiness() async -> ExtractionReadiness { .ready }
     func convert(
@@ -200,7 +254,7 @@ private struct StubMarkdownExtractor: MarkdownExtractor {
     ) async throws -> String { "" }
 }
 
-private struct StubHTMLExtractor: HtmlMarkdownExtractor {
+struct StubHTMLExtractor: HtmlMarkdownExtractor {
     func extract(html: String) async -> HtmlExtractionResult? { nil }
 }
 

--- a/Tests/WikiFSTests/ExtractorPackageSettingsSnapshotTests.swift
+++ b/Tests/WikiFSTests/ExtractorPackageSettingsSnapshotTests.swift
@@ -1,0 +1,106 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import WikiFSEngine
+import WikiFSTypes
+
+/// AC.5: the registry's route presentation snapshot exposes each active
+/// registration's manifest metadata and identity without any package payload
+/// or path ever reaching the presentation layer.
+@Suite("Extractor package settings snapshot")
+struct ExtractorPackageSettingsSnapshotTests {
+
+    private func digest(_ byte: UInt8) -> String {
+        String(repeating: String(format: "%02x", byte), count: 32)
+    }
+
+    @Test func registrationRoutesPreserveManifestMetadata() async throws {
+        let registry = ExtractionBackendRegistry()
+        let reference = ExtractorReference(
+            revision: ExtractorPackageRevisionID(
+                packageID: try ExtractorPackageID(validating: "org.example.news"),
+                version: try ExtractorPackageVersion(validating: "1.2.3"),
+                digest: try ExtractorPackageDigest(hex: digest(9))),
+            registrationID: try ExtractorRegistrationID(validating: "articles"))
+        let presentation = ExtractorRegistrationPresentation(
+            displayName: "Article Extractor",
+            packageName: "News Package",
+            kinds: [.html],
+            mimeTypes: [
+                try ExtractorMIMEType(validating: "text/html"),
+                try ExtractorMIMEType(validating: "application/xhtml+xml"),
+            ],
+            filenameExtensions: Set([
+                ExtractorFileExtension(rawValue: "html"),
+                ExtractorFileExtension(rawValue: "xhtml"),
+            ].compactMap { $0 }))
+        _ = try await registry.registerBatch([
+            ExtractionBatchEntry(
+                key: .installed(kind: .html, reference: reference),
+                backend: RegisteredExtractionBackend(key: ExtractionBackendKey(kind: .html, backendID: "stub")) {
+                    .html(StubHTMLExtractor())
+                },
+                presentation: presentation),
+        ])
+
+        let snapshots = await registry.installedRegistrationSnapshots()
+        #expect(snapshots.count == 1)
+        let snapshot = try #require(snapshots.first)
+        // Declared manifest data survives the projection intact.
+        #expect(snapshot.displayName == "Article Extractor")
+        #expect(snapshot.packageName == "News Package")
+        #expect(snapshot.kinds == [.html])
+        #expect(snapshot.mimeTypes.count == 2)
+        #expect(snapshot.filenameExtensions.count == 2)
+        // Logical and exact identity are present for selection and lifecycle.
+        #expect(snapshot.reference == reference)
+        #expect(snapshot.reference.revision.packageID.rawValue == "org.example.news")
+        #expect(snapshot.reference.registrationID.rawValue == "articles")
+        #expect(snapshot.reference.revision.version.rawValue == "1.2.3")
+    }
+
+    @Test func snapshotContainsNoPackagePayloadOrPaths() async throws {
+        let registry = ExtractionBackendRegistry()
+        let reference = ExtractorReference(
+            revision: ExtractorPackageRevisionID(
+                packageID: try ExtractorPackageID(validating: "org.example.paths"),
+                version: try ExtractorPackageVersion(validating: "1.0.0"),
+                digest: try ExtractorPackageDigest(hex: digest(1))),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        let presentation = ExtractorRegistrationPresentation(
+            displayName: "Main",
+            packageName: "Paths Package",
+            kinds: [.pdf],
+            mimeTypes: [try ExtractorMIMEType(validating: "application/pdf")],
+            filenameExtensions: [])
+        _ = try await registry.registerBatch([
+            ExtractionBatchEntry(
+                key: .installed(kind: .pdf, reference: reference),
+                backend: RegisteredExtractionBackend(key: ExtractionBackendKey(kind: .pdf, backendID: "stub")) {
+                    .pdf(ExtractionPreparation(
+                        extractor: StubMarkdownExtractor(),
+                        backend: .localPdf2md,
+                        modelVersion: nil))
+                },
+                presentation: presentation),
+        ])
+
+        // Only value metadata is projected: no URLs, absolute paths, or
+        // package payload references of any kind.
+        let snapshots = await registry.installedRegistrationSnapshots()
+        let rendered = snapshots.map(String.init(describing:))
+        for description in rendered {
+            #expect(description.contains("file://") == false)
+            #expect(description.contains("/Users/") == false)
+            #expect(description.contains(".sqlite") == false)
+        }
+        // The snapshot type itself carries no path-shaped fields.
+        let mirror = Mirror(reflecting: try #require(snapshots.first))
+        for child in mirror.children {
+            #expect(child.value is URL == false)
+            #expect(child.value is Data == false)
+        }
+    }
+}
+#endif

--- a/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
+++ b/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
@@ -222,6 +222,36 @@ struct ExtractorRouteTableBuilderTests {
         #expect(pdf?.choices.contains { $0.category == .installedPackage } == false)
     }
 
+    /// A logical registration active for the KIND but not the route's MIME
+    /// must not resolve on that route: it stays an unavailable stale choice,
+    /// and the row reports the fixed fallback instead of Available.
+    @Test func incompatibleMIMERegistrationDoesNotResolveOnRoute() throws {
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.mime"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        var config = ExtractionConfig(backend: .acp)
+        config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
+        let rows = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
+            configuration: config,
+            registrations: [
+                // Same kind (pdf), same logical identity, but a different MIME.
+                try snapshot(
+                    packageID: "org.example.mime",
+                    version: "1.0.0",
+                    digestHex: digest(12),
+                    displayName: "Mime Package",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/epub+zip"]),
+            ]))
+        let pdf = try #require(rows.first { $0.route == .canonicalPDF })
+        #expect(pdf.choices.contains { $0.category == .installedPackage } == false)
+        #expect(pdf.savedSelection == .installed(logical))
+        #expect(pdf.resolvedSelection == .pdfBuiltIn(.localPdf2md))
+        #expect(pdf.status == .usingFallback(description: "Bundled pdf2md extraction"))
+        // The package does contribute its own epub route row.
+        #expect(rows.contains { $0.route.mimeType.rawValue == "application/epub+zip" })
+    }
+
     // MARK: - AC.9: current choice matrix
 
     @Test func currentRouteChoiceMatrix() throws {

--- a/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
+++ b/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
@@ -1,0 +1,292 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import WikiFSEngine
+import WikiFSTypes
+
+/// Pure `ExtractorRouteTableBuilder` coverage: row union, deterministic
+/// ordering, version deduplication, stale-selection visibility, and the
+/// current choice matrix.
+@Suite("Extractor route table builder")
+struct ExtractorRouteTableBuilderTests {
+
+    // MARK: - Helpers
+
+    private func mime(_ raw: String) throws -> ExtractorMIMEType {
+        try ExtractorMIMEType(validating: raw)
+    }
+
+    private func snapshot(
+        packageID: String,
+        version: String,
+        digestHex: String,
+        registrationID: String = "main",
+        displayName: String,
+        packageName: String = "Example Package",
+        kinds: Set<ExtractorKind>,
+        mimeTypes: [String],
+        extensions: Set<String> = []
+    ) throws -> ExtractorRouteRegistrationSnapshot {
+        try ExtractorRouteRegistrationSnapshot(
+            reference: ExtractorReference(
+                revision: ExtractorPackageRevisionID(
+                    packageID: ExtractorPackageID(validating: packageID),
+                    version: ExtractorPackageVersion(validating: version),
+                    digest: ExtractorPackageDigest(hex: digestHex)),
+                registrationID: ExtractorRegistrationID(validating: registrationID)),
+            displayName: displayName,
+            packageName: packageName,
+            kinds: kinds,
+            mimeTypes: Set(mimeTypes.map { try ExtractorMIMEType(validating: $0) }),
+            filenameExtensions: Set(extensions.compactMap { ExtractorFileExtension(rawValue: $0) }))
+    }
+
+    private func digest(_ byte: UInt8) -> String {
+        String(repeating: String(format: "%02x", byte), count: 32)
+    }
+
+    // MARK: - AC.6: union and determinism
+
+    @Test func unionsHostActiveAndSavedRoutes() throws {
+        let futureRoute = try ExtractorRouteID(kind: .pdf, mimeType: mime("application/epub+zip"))
+        var config = ExtractionConfig(backend: .gemini)
+        config.setExtractorSelection(.builtIn(.pdf(.acp)), for: futureRoute)
+        let input = ExtractorRouteTableBuilder.Input(
+            configuration: config,
+            registrations: [
+                try snapshot(
+                    packageID: "org.example.html",
+                    version: "1.0.0",
+                    digestHex: digest(1),
+                    registrationID: "article",
+                    displayName: "Article Extractor",
+                    kinds: [.html],
+                    mimeTypes: ["text/html"]),
+            ])
+        let rows = ExtractorRouteTableBuilder.build(input)
+        // Host PDF + HTML, plus the saved future route. The HTML registration
+        // covers the canonical HTML route and adds no new row.
+        #expect(rows.count == 3)
+        #expect(rows.map(\.route) == [.canonicalPDF, .canonicalHTML, futureRoute])
+        #expect(rows[2].savedSelection == .builtIn(.pdf(.acp)))
+        // No host execution exists for a future route.
+        #expect(rows[2].resolvedSelection == nil)
+    }
+
+    @Test func rowsSortDeterministically() throws {
+        func buildInput() throws -> ExtractorRouteTableBuilder.Input {
+            ExtractorRouteTableBuilder.Input(
+                configuration: ExtractionConfig(backend: .acp),
+                registrations: [
+                    try snapshot(
+                        packageID: "org.example.multi",
+                        version: "1.0.0",
+                        digestHex: digest(2),
+                        displayName: "Multi",
+                        kinds: [.html, .pdf],
+                        mimeTypes: ["application/xhtml+xml", "application/pdf", "text/html"]),
+                ])
+        }
+        let first = ExtractorRouteTableBuilder.build(try buildInput())
+        let second = ExtractorRouteTableBuilder.build(try buildInput())
+        // Host routes first in host order, then registration-derived routes in
+        // typed route order; identical inputs produce identical rows.
+        #expect(first.map(\.route) == second.map(\.route))
+        #expect(first == second)
+        #expect(first.map(\.route).prefix(2) == [.canonicalPDF, .canonicalHTML])
+        #expect(first.dropFirst(2).map(\.route) == first.dropFirst(2).map(\.route).sorted())
+    }
+
+    @Test func unknownMIMEUsesStableFallbackLabel() throws {
+        let input = ExtractorRouteTableBuilder.Input(
+            configuration: ExtractionConfig(backend: .acp),
+            registrations: [
+                try snapshot(
+                    packageID: "org.example.x",
+                    version: "1.0.0",
+                    digestHex: digest(3),
+                    displayName: "X Tracts",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/vnd.exam+x"]),
+            ])
+        let rows = ExtractorRouteTableBuilder.build(input)
+        guard let extra = rows.first(where: { $0.route.mimeType.rawValue == "application/vnd.exam+x" }) else {
+            Issue.record("Expected a row for the registration-declared MIME type")
+            return
+        }
+        #expect(extra.descriptor.displayName == "application/vnd.exam+x")
+        #expect(extra.descriptor.systemImage == nil)
+        #expect(extra.choices.count == 1)
+        #expect(extra.choices[0].displayName == "X Tracts")
+    }
+
+    // MARK: - AC.7: exact version deduplication
+
+    @Test func multipleExactVersionsProduceOneLogicalChoice() throws {
+        let input = ExtractorRouteTableBuilder.Input(
+            configuration: ExtractionConfig(backend: .acp),
+            registrations: [
+                try snapshot(
+                    packageID: "org.example.pdf",
+                    version: "1.0.0",
+                    digestHex: digest(4),
+                    displayName: "Main",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/pdf"]),
+                try snapshot(
+                    packageID: "org.example.pdf",
+                    version: "2.0.0",
+                    digestHex: digest(5),
+                    displayName: "Main",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/pdf"]),
+                try snapshot(
+                    packageID: "org.example.pdf",
+                    version: "2.0.0",
+                    digestHex: digest(6),
+                    displayName: "Main",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/pdf"]),
+            ])
+        let pdf = ExtractorRouteTableBuilder.build(input).first { $0.route == .canonicalPDF }
+        let packageChoices = pdf?.choices.filter { $0.category == .installedPackage } ?? []
+        // Three exact registrations, one logical choice showing the highest revision.
+        #expect(packageChoices.count == 1)
+        #expect(packageChoices[0].exactSummary?.hasPrefix("2.0.0 · \(digest(6).prefix(12))") == true)
+    }
+
+    // MARK: - AC.8: stale selections stay visible with fallback status
+
+    @Test func staleInstalledSelectionRemainsVisibleWithFallback() throws {
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.gone"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        var config = ExtractionConfig(backend: .acp, htmlBackend: .defuddle)
+        config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
+        config.setExtractorSelection(.installed(logical), for: .canonicalHTML)
+        let rows = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
+            configuration: config,
+            registrations: []))
+        let pdf = rows.first { $0.route == .canonicalPDF }
+        let html = rows.first { $0.route == .canonicalHTML }
+        // The saved choices remain selected and visible…
+        #expect(pdf?.savedSelection == .installed(logical))
+        #expect(html?.savedSelection == .installed(logical))
+        // …while the fixed fallbacks are what resolve.
+        #expect(pdf?.resolvedSelection == .pdfBuiltIn(.localPdf2md))
+        #expect(html?.resolvedSelection == .htmlBuiltIn(.tagBased))
+        #expect(pdf?.status == .usingFallback(description: "Bundled pdf2md extraction"))
+        #expect(html?.status == .usingFallback(description: "Tag-based text extraction"))
+    }
+
+    @Test func waitingAndFailedSelectionsReportLifecycleStatus() throws {
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.pending"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        var config = ExtractionConfig(backend: .acp)
+        config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
+
+        let waiting = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
+            configuration: config,
+            registrations: [],
+            activationFailures: [],
+            waitingRevisionIDs: [ExtractorPackageRevisionID(
+                packageID: try ExtractorPackageID(validating: "org.example.pending"),
+                version: try ExtractorPackageVersion(validating: "1.0.0"),
+                digest: try ExtractorPackageDigest(hex: digest(7)))]))
+        #expect(waiting.first?.status == .waitingForHostService)
+
+        let failed = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
+            configuration: config,
+            registrations: [],
+            activationFailures: [ExtractorPackageReconciliationFailure(
+                revision: ExtractorPackageRevisionID(
+                    packageID: try ExtractorPackageID(validating: "org.example.pending"),
+                    version: try ExtractorPackageVersion(validating: "1.0.0"),
+                    digest: try ExtractorPackageDigest(hex: digest(8))),
+                message: "activation refused")]))
+        #expect(failed.first?.status == .failedActivation)
+    }
+
+    // MARK: - AC.9: current choice matrix
+
+    @Test func currentRouteChoiceMatrix() throws {
+        let input = ExtractorRouteTableBuilder.Input(
+            configuration: ExtractionConfig(backend: .acp),
+            registrations: [
+                try snapshot(
+                    packageID: "org.example.pdf",
+                    version: "1.0.0",
+                    digestHex: digest(9),
+                    registrationID: "pdfmain",
+                    displayName: "PDF Package",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/pdf"]),
+                try snapshot(
+                    packageID: "org.example.html",
+                    version: "1.0.0",
+                    digestHex: digest(10),
+                    registrationID: "htmlmain",
+                    displayName: "HTML Package",
+                    kinds: [.html],
+                    mimeTypes: ["text/html"]),
+            ])
+        let rows = ExtractorRouteTableBuilder.build(input)
+        let pdf = rows.first { $0.route == .canonicalPDF }
+        let html = rows.first { $0.route == .canonicalHTML }
+
+        // PDF: reviewed pdf2md, installed PDF packages, ACP, Docling — in that order.
+        #expect(pdf?.choices.map { "\($0.displayName)|\($0.category.rawValue)" } == [
+            "pdf2md|reviewed-package",
+            "PDF Package|installed-package",
+            "ACP Provider|connected-service",
+            "Docling Serve|connected-service",
+        ])
+        // HTML: prompt, reviewed Defuddle, installed HTML packages, tag-based.
+        #expect(html?.choices.map { "\($0.displayName)|\($0.category.rawValue)" } == [
+            "No default (ask each time)|prompt",
+            "Defuddle|reviewed-package",
+            "HTML Package|installed-package",
+            "Tag-based|built-in",
+        ])
+    }
+
+    /// Source-contract guard: the legacy direct Anthropic and Gemini API
+    /// choices never re-enter the route table.
+    @Test func directModelAPIChoicesRemainAbsent() throws {
+        let input = ExtractorRouteTableBuilder.Input(
+            configuration: ExtractionConfig(backend: .anthropic),
+            registrations: [])
+        let rows = ExtractorRouteTableBuilder.build(input)
+        for row in rows {
+            for choice in row.choices {
+                let payload = String(describing: choice)
+                #expect(payload.contains("anthropic") == false)
+                #expect(payload.contains("gemini") == false)
+                #expect(choice.category != .unavailable)
+            }
+        }
+    }
+
+    /// The reviewed packages attach to their canonical routes only — a
+    /// registration-declared future route never inherits host choices.
+    @Test func reviewedChoicesStayOnCanonicalRoutes() throws {
+        let input = ExtractorRouteTableBuilder.Input(
+            configuration: ExtractionConfig(backend: .acp),
+            registrations: [
+                try snapshot(
+                    packageID: "org.example.pdf",
+                    version: "1.0.0",
+                    digestHex: digest(11),
+                    displayName: "Main",
+                    kinds: [.pdf],
+                    mimeTypes: ["application/epub+zip"]),
+            ])
+        let rows = ExtractorRouteTableBuilder.build(input)
+        let epub = rows.first { $0.route.mimeType.rawValue == "application/epub+zip" }
+        #expect(epub?.choices.contains { $0.category == .reviewedPackage } == false)
+        #expect(epub?.choices.contains { $0.category == .connectedService } == false)
+    }
+}
+#endif

--- a/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
+++ b/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
@@ -190,7 +190,7 @@ struct ExtractorRouteTableBuilderTests {
         let waiting = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
             configuration: config,
             registrations: [],
-            activationFailures: [],
+            failedPackageIDs: [],
             waitingRevisionIDs: [ExtractorPackageRevisionID(
                 packageID: try ExtractorPackageID(validating: "org.example.pending"),
                 version: try ExtractorPackageVersion(validating: "1.0.0"),
@@ -200,13 +200,26 @@ struct ExtractorRouteTableBuilderTests {
         let failed = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
             configuration: config,
             registrations: [],
-            activationFailures: [ExtractorPackageReconciliationFailure(
-                revision: ExtractorPackageRevisionID(
-                    packageID: try ExtractorPackageID(validating: "org.example.pending"),
-                    version: try ExtractorPackageVersion(validating: "1.0.0"),
-                    digest: try ExtractorPackageDigest(hex: digest(8))),
-                message: "activation refused")]))
+            failedPackageIDs: ["org.example.pending"],
+            waitingRevisionIDs: []))
         #expect(failed.first?.status == .failedActivation)
+    }
+
+    /// A stale saved installed selection stays selectable in its row's picker:
+    /// the builder inserts one unavailable choice carrying the saved reference.
+    @Test func staleSelectionRemainsSelectableAsUnavailableChoice() throws {
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.gone"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+        var config = ExtractionConfig(backend: .acp)
+        config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
+        let pdf = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
+            configuration: config,
+            registrations: [])).first { $0.route == .canonicalPDF }
+        let stale = pdf?.choices.first { $0.category == .unavailable }
+        #expect(stale?.reference == .installed(logical))
+        #expect(stale?.displayName == "org.example.gone")
+        #expect(pdf?.choices.contains { $0.category == .installedPackage } == false)
     }
 
     // MARK: - AC.9: current choice matrix

--- a/plans/dynamic-extractor-packages.md
+++ b/plans/dynamic-extractor-packages.md
@@ -207,6 +207,25 @@ Dual-write compatibility. A write through `setExtractorSelection(_:for:)` to a c
 
 Decode resilience. A missing key decodes to an empty list. A malformed record is dropped through the logged decode seam. Duplicate records for one route resolve deterministically: the canonically-greatest record wins, independent of file order, with one bounded diagnostic.
 
+## Route presentation: registration-driven rows
+
+The Settings route table is a pure projection. `ExtractorRouteTableBuilder` builds one row per route from a union of three inputs: host-owned descriptors, active exact registration snapshots, and saved selections. No input re-reads a package manifest or directory — the registry projects each active exact registration's manifest-derived presentation (display name, kinds, MIME types, filename extensions) captured when the trusted definition factory built its batch entries.
+
+Union rules:
+
+- Host descriptors seed the canonical PDF and HTML rows, so both stay visible with zero packages installed.
+- Every active exact registration contributes rows for its declared (kind, MIME) pairs. A future registration can add a row without another Settings layout change, but execution adapters for new kinds remain separate work.
+- Saved records seed their route even when nothing active backs it. A stale installed selection stays selected; the row reports what actually resolves.
+
+Ordering and deduplication:
+
+- Rows sort by host order (PDF, then HTML) first, then by typed route order (kind raw value, then MIME raw value).
+- Multiple exact versions of one logical registration deduplicate into one choice showing the highest active revision; the package lifecycle rows below the table keep every exact version for inspection and removal.
+- Choices order like the pickers they replace: prompt (HTML), reviewed package, installed packages by package ID, connected services, built-ins.
+- The reviewed packages attach only to their canonical routes; direct Anthropic and Gemini API choices never appear.
+
+Statuses: available; using a named fixed fallback when a saved installed selection is unavailable; waiting for host service when the selected package has a waiting definition; failed activation when the reconciler retained a failure for it.
+
 ## Phase 2: Add the trusted dynamic Cordis plugin host
 
 1. Keep `PluginCatalog` immutable and link-time. Do not add dynamic module loading to it.

--- a/plans/dynamic-extractor-packages.md
+++ b/plans/dynamic-extractor-packages.md
@@ -215,7 +215,7 @@ Union rules:
 
 - Host descriptors seed the canonical PDF and HTML rows, so both stay visible with zero packages installed.
 - Every active exact registration contributes rows for its declared (kind, MIME) pairs. A future registration can add a row without another Settings layout change, but execution adapters for new kinds remain separate work.
-- Saved records seed their route even when nothing active backs it. A stale installed selection stays selected; the row reports what actually resolves.
+- Saved records seed their route even when nothing active backs it. A stale installed selection stays selected and selectable (one unavailable choice in its picker); the row reports what actually resolves.
 
 Ordering and deduplication:
 

--- a/progress/2026-08-28T070000Z-extractor-route-catalog.md
+++ b/progress/2026-08-28T070000Z-extractor-route-catalog.md
@@ -1,0 +1,55 @@
+---
+timestamp: 2026-08-28T070000Z
+title: Registration-driven route presentation
+branch: feature/extractor-route-catalog
+status: complete
+---
+
+# Registration-driven route presentation
+
+## Progress
+
+The Settings route table's data layer is now a pure, fully tested projection
+on top of PR 1's route selections. The Settings view itself still uses the
+old pickers; the view consumes this in the next PR.
+
+- Batch registrations carry manifest-derived presentation metadata
+  (`ExtractorRegistrationPresentation`: display name, package name, declared
+  kinds, MIME types, filename extensions). The trusted definition factory
+  sources it from the validated manifest — nothing is inferred from package
+  or registration IDs, and the UI never re-reads a manifest.
+- `ExtractionBackendRegistry.installedRegistrationSnapshots()` projects one
+  snapshot per active exact registration; built-ins never appear; snapshots
+  drop with batch disposal.
+- Reconciler observation now reports the exact revisions whose hosted
+  definitions are waiting for activation (`waitingRevisionIDs`), by retaining
+  the desired definition → revision map across reconciles.
+- `ExtractorRouteTableBuilder` builds one deterministic row per route from
+  host descriptors, active registration snapshots, and saved selections:
+  - rows: host order (PDF, HTML) first, then typed route order;
+  - choices: prompt / reviewed / installed (by package ID) / connected /
+    built-in, with multiple exact versions deduplicated into one logical
+    choice showing the highest active revision;
+  - statuses: available, using a named fixed fallback, waiting for host
+    service, failed activation.
+- Presentation value types: `ExtractorRouteDescriptor`, `ExtractorRouteChoice`
+  (closed source-category enum), `ExtractorRouteSettingsRow`,
+  `ExtractorRouteStatus`. Host choices for the canonical routes match the
+  pickers they will replace; no direct Anthropic or Gemini API choice exists.
+
+Design notes: `plans/dynamic-extractor-packages.md` § "Route presentation:
+registration-driven rows".
+
+## Verification
+
+The following gates passed on 2026-08-28:
+
+```text
+swift test --filter 'ExtractorRouteTableBuilderTests|ExtractionBackendRegistryBatchTests|ExtractorPackageSettingsSnapshotTests'
+17 tests passed
+
+make build
+make test
+swift build
+swift test
+```


### PR DESCRIPTION
Stack: PR 2 of 3 on top of #1160 (extractor routing table).

Parent: #1160 (`feature/extractor-route-selections`) at exact head
`a7b21ad1a76291063793862684d7bc2e1e97a015`.

## What this PR does

Builds the route table's data layer as a pure, fully tested projection.
`ExtractionSettingsView` still renders the old pickers; the view consumes
this projection in PR 3.

- **Registration presentations.** `ExtractionBatchEntry` carries
  `ExtractorRegistrationPresentation` — display name, package name, declared
  kinds, MIME types, and filename extensions — sourced by the trusted
  definition factory from the validated manifest. Nothing is inferred from
  package or registration IDs; the UI never re-reads a manifest or package
  directory.
- **Registry projection.** `installedRegistrationSnapshots()` returns one
  snapshot per active exact registration (sorted by reference); built-ins
  never appear; snapshots drop with batch disposal.
- **Waiting revisions.** The reconciler retains a desired definition →
  revision map and reports `waitingRevisionIDs` in `observation()`, so a
  package admitted but not yet activated can be shown as waiting.
- **Pure row builder.** `ExtractorRouteTableBuilder` unions host-owned
  descriptors, active registration snapshots, and saved selections into one
  deterministic row per route:
  - rows sort by host order (PDF, HTML) then typed route order (kind raw
    value, then MIME raw value);
  - multiple exact versions of one logical registration deduplicate into a
    single choice showing the highest active exact revision; lifecycle rows
    keep every exact version for inspection and removal;
  - stale installed selections stay selected and visible while the row
    reports the fixed fallback (reviewed pdf2md for PDF, tag-based for HTML),
    or the package's waiting/failed lifecycle state;
  - choices: prompt (HTML only), reviewed package, installed packages by
    package ID, ACP and Docling (PDF only), tag-based (HTML only). No direct
    Anthropic or Gemini API choice; reviewed packages attach only to their
    canonical routes.
- **Value types.** `ExtractorRouteDescriptor`, `ExtractorRouteChoice` with a
  closed source-category enum, `ExtractorRouteSettingsRow`,
  `ExtractorRouteStatus`.

## What this PR deliberately does not do

No UI change (Settings keeps the old pickers), no execution change, no
manifest/schema or reviewed-package-byte changes, no new MIME registrations,
and no new extractor kind. Future registration-derived rows can appear in
the table but resolve to no selection until execution adapters exist.

## Verification

```text
swift test --filter 'ExtractorRouteTableBuilderTests|ExtractionBackendRegistryBatchTests|ExtractorPackageSettingsSnapshotTests'  # 17 passed
make build
make test
swift build
swift test  # 3877 tests
```

Design notes: `plans/dynamic-extractor-packages.md` § "Route presentation:
registration-driven rows". Progress:
`progress/2026-08-28T070000Z-extractor-route-catalog.md`.
