### PR TITLE
feat(settings): show extractor routes in a scrollable table

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -34,17 +34,21 @@ struct ExtractionSettingsView: View {
     /// as `importPackage`. Nil hides the Remove buttons.
     let removePackage: (@Sendable (ExtractorPackageRevisionID) async -> ExtractorPackageMutationOutcome)?
 
-    // Drafts initialized from config + Keychain in `init`; every change is
-    // written straight back by `persistAll()`.
-    @State private var pdfExtractorSelection: PDFExtractorSettingsSelection
+    // Route table rows built from the PR 2 projection: host descriptors, the
+    // package model's registration snapshots, and saved selections. Rebuilt
+    // after config writes and package-snapshot refreshes.
+    @State private var routeRows: [ExtractorRouteSettingsRow] = []
+    /// One route-scoped, typed selection per table row (`row.id`). The picker
+    /// binding writes through `ExtractorRouteSettingsMapping`, which keeps the
+    /// legacy compatibility fields truthful while persisting the route record.
+    @State private var routeSelections: [String: ExtractorRouteSettingsSelection] = [:]
     @State private var acpProviderSelection: String
     @State private var doclingEndpointText: String
     @State private var doclingTokenText: String
     @State private var doclingTest = TestPhase.idle
-    // Issue #799 PR1: HTML + Podcast backend drafts (optional — nil = no
-    // default yet, user is prompted to pick on first extraction). Seeded from
+    // Issue #799 PR1: Podcast backend draft (optional — nil = no default yet,
+    // user is prompted to pick on first transcription). Seeded from
     // `ExtractionConfig` in `init`, written back in `writeConfig`.
-    @State private var htmlExtractorSelection: HTMLExtractorSettingsSelection
     @State private var draftPodcastBackend: PodcastTranscriptionBackend?
     // Installed-package lifecycle (dynamic-extractor-packages Phase 7).
     @State private var packageModel: ExtractorPackageSettingsModel
@@ -78,11 +82,9 @@ struct ExtractionSettingsView: View {
         // Seed the drafts once, at construction — so there's no onAppear race
         // where an `.onChange` fires before the loaded values are in place.
         let config = ExtractionConfig.load(from: containerDirectory)
-        _pdfExtractorSelection = State(initialValue: ExtractorSettingsSelectionMapping.pdfSelection(from: config))
         _acpProviderSelection = State(initialValue: ExtractorSettingsSelectionMapping.acpProviderSelection(from: config))
         _doclingEndpointText = State(initialValue: config.doclingServeEndpoint ?? "")
         _doclingTokenText = State(initialValue: credentialStore.secret(.doclingServeToken) ?? "")
-        _htmlExtractorSelection = State(initialValue: ExtractorSettingsSelectionMapping.htmlSelection(from: config))
         _draftPodcastBackend = State(initialValue: config.podcastBackend)
         _packageModel = State(initialValue: ExtractorPackageSettingsModel(
             loadSnapshot: packageSnapshot,
@@ -93,8 +95,7 @@ struct ExtractionSettingsView: View {
     var body: some View {
         Form {
             Section {
-                unifiedPDFExtractorPicker
-                unifiedHTMLExtractorPicker
+                extractorRouteTable
 
                 Picker("Podcast Transcript", selection: podcastBackendBinding) {
                     Text("Prompt me when transcribing").tag(nil as PodcastTranscriptionBackend?)
@@ -128,7 +129,13 @@ struct ExtractionSettingsView: View {
         .frame(minWidth: Metrics.width, minHeight: Metrics.height)
         // Async model mutations stay on the main actor; the load closure hops
         // to the process registry off-main and returns a value snapshot.
-        .task { await packageModel.refresh() }
+        .task {
+            await packageModel.refresh()
+            rebuildRouteRows()
+        }
+        .onChange(of: packageModel.snapshot) { _, _ in
+            rebuildRouteRows()
+        }
         .alert("Couldn't Connect to Docling Serve", isPresented: doclingErrorBinding,
                presenting: doclingErrorMessage) { _ in
             Button("OK", role: .cancel) {}
@@ -181,90 +188,193 @@ struct ExtractionSettingsView: View {
         }
     }
 
-    // MARK: - Unified extractor selection
+    // MARK: - Extractor route table
 
-    private var unifiedPDFExtractorPicker: some View {
-        Picker("PDF", selection: $pdfExtractorSelection) {
-            extractorOption("pdf2md", source: "Reviewed package")
-                .tag(PDFExtractorSettingsSelection.reviewedPdf2md)
-            ForEach(pdfPackageChoices) { choice in
-                extractorOption(choice.packageID, source: "Installed package")
-                    .tag(PDFExtractorSettingsSelection.installed(choice.logical))
+    /// The native, registration-driven route table: one row per extraction
+    /// route (Format), a pop-up of compatible choices (Default extractor), and
+    /// the live status. The fixed height keeps the Settings window bounded —
+    /// the table scrolls internally when registrations add routes.
+    private var extractorRouteTable: some View {
+        Table(routeRows) {
+            TableColumn("Format") { (row: ExtractorRouteSettingsRow) in
+                Label(row.descriptor.displayName, systemImage: row.descriptor.systemImage ?? "doc")
+                    // Technical MIME identity lives in help text, not a column.
+                    .help("MIME type: \(row.route.mimeType.rawValue)")
             }
-            stalePDFSelectionOption
-            Divider()
-            extractorOption("ACP Provider", source: "Connected service")
-                .tag(PDFExtractorSettingsSelection.host(.acp))
-            extractorOption("Docling Serve", source: "Connected service")
-                .tag(PDFExtractorSettingsSelection.host(.doclingServe))
-        }
-        .onChange(of: pdfExtractorSelection) { _, _ in persistAll() }
-        .accessibilityIdentifier(PackageAccessibility.pdfSelection)
-        .accessibilityLabel("Default PDF extractor")
-    }
-
-    private var unifiedHTMLExtractorPicker: some View {
-        Picker("HTML", selection: $htmlExtractorSelection) {
-            Text("Prompt me when extracting")
-                .tag(HTMLExtractorSettingsSelection.prompt)
-            extractorOption("Defuddle", source: "Reviewed package")
-                .tag(HTMLExtractorSettingsSelection.reviewedDefuddle)
-            ForEach(htmlPackageChoices) { choice in
-                extractorOption(choice.packageID, source: "Installed package")
-                    .tag(HTMLExtractorSettingsSelection.installed(choice.logical))
+            .width(min: 90, ideal: 120)
+            TableColumn("Default extractor") { (row: ExtractorRouteSettingsRow) in
+                routePicker(row)
             }
-            staleHTMLSelectionOption
-            Divider()
-            extractorOption("Tag-based", source: "Built in")
-                .tag(HTMLExtractorSettingsSelection.host(.tagBased))
+            .width(min: 220, ideal: 280)
+            TableColumn("Status") { (row: ExtractorRouteSettingsRow) in
+                statusLabel(row)
+            }
         }
-        .onChange(of: htmlExtractorSelection) { _, _ in persistAll() }
-        .accessibilityIdentifier(PackageAccessibility.htmlSelection)
-        .accessibilityLabel("Default HTML extractor")
+        .frame(height: Metrics.routeTableHeight)
+        .accessibilityIdentifier(RouteAccessibility.table)
+        .accessibilityLabel("Default extractor routes")
     }
 
-    private func extractorOption(_ name: String, source: String) -> Text {
-        Text("\(name) — \(source)")
+    /// One row's pop-up. Tags are the typed `ExtractorRouteSettingsSelection`
+    /// values — no sentinel strings; the binding writes through the mapping
+    /// that dual-writes the legacy compatibility fields.
+    private func routePicker(_ row: ExtractorRouteSettingsRow) -> some View {
+        Picker(selection: selectionBinding(row)) {
+            ForEach(row.choices) { choice in
+                Text(Self.optionLabel(choice)).tag(Self.selection(for: choice))
+            }
+        } label: {
+            EmptyView()
+        }
+        .labelsHidden()
+        .frame(maxWidth: 260)
+        .accessibilityIdentifier("\(RouteAccessibility.pickerPrefix).\(Self.accessibilityKey(row.route))")
+        .accessibilityLabel("Default extractor for \(row.descriptor.displayName)")
+        .accessibilityValue(accessibilityValue(row))
     }
 
-    @ViewBuilder private var stalePDFSelectionOption: some View {
-        if packageModel.hasLoaded,
-           case .installed(let logical) = pdfExtractorSelection,
-           pdfPackageChoices.contains(where: { $0.logical == logical }) == false {
-            Text("\(logical.packageID.rawValue) — Not installed")
-                .tag(pdfExtractorSelection)
-                .accessibilityIdentifier("\(PackageAccessibility.staleSelection).pdf")
-                .accessibilityValue("Not installed. Reviewed pdf2md fallback is active")
+    private func selectionBinding(_ row: ExtractorRouteSettingsRow) -> Binding<ExtractorRouteSettingsSelection> {
+        Binding(
+            get: {
+                routeSelections[row.id] ?? ExtractorRouteSettingsMapping.selection(
+                    route: row.route, config: ExtractionConfig.load(from: containerDirectory), row: row)
+            },
+            set: { writeRouteSelection($0, for: row) })
+    }
+
+    /// Status cell + spoken/label text. The vocabulary is fixed: Available,
+    /// Using fallback, Not installed, Waiting for host service, Failed to
+    /// activate. The fallback description (what is actually being used) rides
+    /// in help text and the accessibility value.
+    /// Maps one table choice to its typed selection value — the picker tag.
+    static func selection(for choice: ExtractorRouteChoice) -> ExtractorRouteSettingsSelection {
+        switch choice.category {
+        case .prompt:
+            return .prompt
+        case .reviewedPackage:
+            return choice.reference == .installed(ProcessExtractionServices.reviewedPDFLogical)
+                ? .reviewedPdf2md
+                : .reviewedDefuddle
+        case .installedPackage:
+            if case .installed(let logical) = choice.reference { return .installed(logical) }
+            return .prompt
+        case .unavailable:
+            if case .installed(let logical) = choice.reference { return .unavailableInstalled(logical) }
+            return .prompt
+        case .connectedService:
+            if case .builtIn(.pdf(let backend)) = choice.reference { return .connectedService(backend) }
+            return .prompt
+        case .builtIn:
+            return .builtInTagBased
         }
     }
 
-    @ViewBuilder private var staleHTMLSelectionOption: some View {
-        if packageModel.hasLoaded,
-           case .installed(let logical) = htmlExtractorSelection,
-           htmlPackageChoices.contains(where: { $0.logical == logical }) == false {
-            Text("\(logical.packageID.rawValue) — Not installed")
-                .tag(htmlExtractorSelection)
-                .accessibilityIdentifier("\(PackageAccessibility.staleSelection).html")
-                .accessibilityValue("Not installed. Tag-based fallback is active")
+    @ViewBuilder
+    private func statusLabel(_ row: ExtractorRouteSettingsRow) -> some View {
+        switch row.status {
+        case .available:
+            Text("Available")
+                .foregroundStyle(.secondary)
+        case .usingFallback(let description):
+            Label("Using fallback", systemImage: "arrow.triangle.swap")
+                .foregroundStyle(.orange)
+                .help(description)
+        case .notInstalled:
+            Text("Not installed")
+                .foregroundStyle(.orange)
+        case .waitingForHostService:
+            Label("Waiting for host service", systemImage: "clock")
+                .foregroundStyle(.orange)
+        case .failedActivation:
+            Label("Failed to activate", systemImage: "exclamationmark.triangle")
+                .foregroundStyle(.red)
         }
     }
 
-    private var pdfPackageChoices: [ExtractorPackageChoice] {
-        choices(for: .pdf).filter { $0.logical != ProcessExtractionServices.reviewedPDFLogical }
+    private func accessibilityValue(_ row: ExtractorRouteSettingsRow) -> String {
+        let selectedName: String
+        if let selection = routeSelections[row.id],
+           let choice = row.choices.first(where: { Self.selection(for: $0) == selection }) {
+            selectedName = choice.displayName
+        } else {
+            selectedName = "No default"
+        }
+        return "\(selectedName), \(Self.statusText(row.status))"
     }
 
-    private var htmlPackageChoices: [ExtractorPackageChoice] {
-        choices(for: .html).filter { $0.logical != ProcessExtractionServices.reviewedHTMLLogical }
+    /// The picker's option caption, matching the pickers this table replaced:
+    /// "name — source".
+    static func optionLabel(_ choice: ExtractorRouteChoice) -> String {
+        "\(choice.displayName) — \(sourceName(choice.category))"
+    }
+
+    static func sourceName(_ category: ExtractorRouteSourceCategory) -> String {
+        switch category {
+        case .reviewedPackage: "Reviewed package"
+        case .installedPackage: "Installed package"
+        case .connectedService: "Connected service"
+        case .builtIn: "Built in"
+        case .prompt: "Prompt"
+        case .unavailable: "Not installed"
+        }
+    }
+
+    static func statusText(_ status: ExtractorRouteStatus) -> String {
+        switch status {
+        case .available: "Available"
+        case .usingFallback: "Using fallback"
+        case .notInstalled: "Not installed"
+        case .waitingForHostService: "Waiting for host service"
+        case .failedActivation: "Failed to activate"
+        }
+    }
+
+    /// Rebuilds the rows and the derived per-route selections from the current
+    /// config plus the package model's projection snapshot.
+    private func rebuildRouteRows() {
+        let config = ExtractionConfig.load(from: containerDirectory)
+        routeRows = ExtractorRouteTableBuilder.build(.init(
+            configuration: config,
+            registrations: packageModel.snapshot.registrationSnapshots,
+            failedPackageIDs: Set(packageModel.snapshot.failedPackages.map(\.packageID)),
+            waitingRevisionIDs: packageModel.snapshot.waitingRevisionIDs))
+        var selections: [String: ExtractorRouteSettingsSelection] = [:]
+        for row in routeRows {
+            selections[row.id] = ExtractorRouteSettingsMapping.selection(
+                route: row.route, config: config, row: row)
+        }
+        routeSelections = selections
+    }
+
+    /// Persists one route picker change: the mapping keeps the legacy
+    /// compatibility fields truthful, `setExtractorSelection` writes the typed
+    /// route record, and the auto-save contract persists immediately.
+    private func writeRouteSelection(_ selection: ExtractorRouteSettingsSelection, for row: ExtractorRouteSettingsRow) {
+        var config = ExtractionConfig.load(from: containerDirectory)
+        ExtractorRouteSettingsMapping.write(selection, route: row.route, into: &config)
+        DebugLog.trying("save extraction config", operation: { try config.save(to: containerDirectory) })
+        rebuildRouteRows()
+    }
+
+    /// Stable, derivable accessibility key for a route: kind plus MIME with
+    /// the separator flattened ("pdf-application-pdf", "html-text-html").
+    static func accessibilityKey(_ route: ExtractorRouteID) -> String {
+        "\(route.kind.rawValue)-\(route.mimeType.rawValue.replacing("/", with: "-"))"
+    }
+
+    private enum RouteAccessibility {
+        static let table = "extraction.routes.table"
+        static let pickerPrefix = "extraction.routes.picker"
+        static let statusPrefix = "extraction.routes.status"
     }
 
     // MARK: - Selected service configuration
 
     @ViewBuilder private var backendConfigSection: some View {
-        switch pdfExtractorSelection {
-        case .host(.acp): acpSection
-        case .host(.doclingServe): doclingSection
-        case .host(.anthropic), .host(.gemini), .host(.localPdf2md), .reviewedPdf2md, .installed:
-            EmptyView()
+        switch routeSelections[ExtractorRouteID.canonicalPDF.description] {
+        case .connectedService(.acp): acpSection
+        case .connectedService(.doclingServe): doclingSection
+        default: EmptyView()
         }
     }
 
@@ -423,28 +533,6 @@ struct ExtractionSettingsView: View {
         .accessibilityValue("Not ready")
     }
 
-    /// Unique installed logical references for one kind, built from the active
-    /// registration rows. Identity is package + registration (version-free);
-    /// the resolver picks the highest compatible exact revision at run time.
-    private func choices(for kind: ExtractionBackendKind) -> [ExtractorPackageChoice] {
-        var seen: Set<String> = []
-        var result: [ExtractorPackageChoice] = []
-        for row in packageModel.snapshot.rows where row.kind == kind {
-            guard let packageID = ExtractorPackageID(rawValue: row.packageID),
-                  let registrationID = ExtractorRegistrationID(rawValue: row.registrationID)
-            else { continue }
-            let key = "\(row.packageID)/\(row.registrationID)"
-            guard seen.insert(key).inserted else { continue }
-            result.append(ExtractorPackageChoice(
-                logical: LogicalExtractorReference(
-                    packageID: packageID,
-                    registrationID: registrationID),
-                packageID: row.packageID,
-                registrationID: row.registrationID))
-        }
-        return result
-    }
-
     private func kindDisplayName(_ kind: ExtractionBackendKind) -> String {
         switch kind {
         case .pdf: "PDF"
@@ -471,9 +559,6 @@ struct ExtractionSettingsView: View {
         static let removePrefix = "extraction.packages.remove"
         static let failurePrefix = "extraction.packages.failure"
         static let failureMessagePrefix = "extraction.packages.failure.message"
-        static let pdfSelection = "extraction.packages.selection.pdf"
-        static let htmlSelection = "extraction.packages.selection.html"
-        static let staleSelection = "extraction.packages.selection.stale"
         static let progress = "extraction.packages.progress"
         static let diagnostic = "extraction.packages.diagnostic"
         static let error = "extraction.packages.error"
@@ -564,13 +649,13 @@ struct ExtractionSettingsView: View {
         DebugLog.trying("set Docling token", operation: { try credentialStore.setSecret(doclingTokenText.isEmpty ? nil : doclingTokenText, .doclingServeToken) })
     }
 
-    /// Write every non-secret draft into `config`.
+    /// Write every non-secret draft into `config`. The route selections are
+    /// not here — each table picker writes through
+    /// `ExtractorRouteSettingsMapping.write` the moment it changes.
     private func writeConfig(into config: inout ExtractionConfig) {
-        ExtractorSettingsSelectionMapping.writePDF(pdfExtractorSelection, into: &config)
         config.acpProviderId = acpProviderSelection.isEmpty ? nil : acpProviderSelection
         let endpoint = doclingEndpointText.trimmingCharacters(in: .whitespacesAndNewlines)
         config.doclingServeEndpoint = endpoint.isEmpty ? nil : endpoint
-        ExtractorSettingsSelectionMapping.writeHTML(htmlExtractorSelection, into: &config)
         config.podcastBackend = draftPodcastBackend
     }
 
@@ -604,40 +689,160 @@ struct ExtractionSettingsView: View {
         /// switching backends (sections of different heights) doesn't resize
         /// the window. A short section just leaves space below it.
         static let height: CGFloat = 420
+        /// The route table's fixed height: both canonical rows plus room for a
+        /// few registration-derived rows, with internal scrolling beyond that
+        /// so the Settings window never grows without bound.
+        static let routeTableHeight: CGFloat = 132
     }
 }
 
-// MARK: - Unified extractor selection
+// MARK: - Route-scoped extractor selection
 
-enum PDFExtractorSettingsSelection: Hashable, Sendable {
-    case reviewedPdf2md
-    case installed(LogicalExtractorReference)
-    case host(ExtractionBackend)
-}
-
-enum HTMLExtractorSettingsSelection: Hashable, Sendable {
+/// One route-scoped default-extractor selection. Replaces the separate
+/// per-kind PDF and HTML settings enums: the route is the identity, the
+/// associated values stay typed (`LogicalExtractorReference`,
+/// `ExtractionBackend`), and no sentinel strings exist for prompt,
+/// unavailable, or default state.
+enum ExtractorRouteSettingsSelection: Hashable, Sendable {
+    /// HTML only: no default — the user is prompted per extraction.
     case prompt
+    case reviewedPdf2md
     case reviewedDefuddle
     case installed(LogicalExtractorReference)
-    case host(HtmlExtractionBackend)
+    /// A saved installed selection whose package is no longer active.
+    case unavailableInstalled(LogicalExtractorReference)
+    /// PDF only: ACP or Docling Serve.
+    case connectedService(ExtractionBackend)
+    /// HTML only: the built-in tag-based extractor.
+    case builtInTagBased
 }
 
+/// Maps between `ExtractionConfig` (route records + legacy fields) and the
+/// route-scoped view selection, and writes a table pick through both layers:
+/// the legacy `backend` / `htmlBackend` / `pdfExtractor` / `htmlExtractor`
+/// fields stay truthful for old builds while `setExtractorSelection` persists
+/// the typed route record.
+enum ExtractorRouteSettingsMapping {
+    /// The view selection for one route, applying the same display semantics
+    /// the fixed pickers used (a legacy `localPdf2md` backend displays as the
+    /// reviewed package; direct API backends display as ACP).
+    static func selection(
+        route: ExtractorRouteID,
+        config: ExtractionConfig,
+        row: ExtractorRouteSettingsRow
+    ) -> ExtractorRouteSettingsSelection {
+        let saved = config.extractorSelection(for: route)
+        if route == .canonicalPDF {
+            switch saved {
+            case .installed(let logical):
+                return logical == ProcessExtractionServices.reviewedPDFLogical
+                    ? .reviewedPdf2md
+                    : installedSelection(logical, row: row)
+            case .builtIn(.pdf(let backend)):
+                return visiblePDFSelection(for: backend)
+            case .builtIn(.html), .none:
+                return visiblePDFSelection(for: config.backend)
+            }
+        }
+        if route == .canonicalHTML {
+            switch saved {
+            case .installed(let logical):
+                return logical == ProcessExtractionServices.reviewedHTMLLogical
+                    ? .reviewedDefuddle
+                    : installedSelection(logical, row: row)
+            case .builtIn(.html(let backend)):
+                return backend == .defuddle ? .reviewedDefuddle : .builtInTagBased
+            case .builtIn(.pdf), .none:
+                guard let legacy = config.htmlBackend else { return .prompt }
+                return legacy == .defuddle ? .reviewedDefuddle : .builtInTagBased
+            }
+        }
+        // Future registration-derived routes carry package choices only.
+        switch saved {
+        case .installed(let logical):
+            return installedSelection(logical, row: row)
+        default:
+            return .prompt
+        }
+    }
+
+    private static func installedSelection(
+        _ logical: LogicalExtractorReference,
+        row: ExtractorRouteSettingsRow
+    ) -> ExtractorRouteSettingsSelection {
+        row.choices.contains { $0.category == .installedPackage && $0.reference == .installed(logical) }
+            ? .installed(logical)
+            : .unavailableInstalled(logical)
+    }
+
+    private static func visiblePDFSelection(for backend: ExtractionBackend) -> ExtractorRouteSettingsSelection {
+        switch backend {
+        case .localPdf2md:
+            return .reviewedPdf2md
+        case .anthropic, .gemini, .acp:
+            return .connectedService(.acp)
+        case .doclingServe:
+            return .connectedService(.doclingServe)
+        }
+    }
+
+    /// Persists one table pick. The legacy mapping mirrors the old
+    /// `writePDF` / `writeHTML` semantics exactly; `setExtractorSelection`
+    /// then dual-writes the route record and the matching legacy reference
+    /// field.
+    static func write(
+        _ selection: ExtractorRouteSettingsSelection,
+        route: ExtractorRouteID,
+        into config: inout ExtractionConfig
+    ) {
+        let reference: ExtractionBackendReference?
+        if route == .canonicalPDF {
+            switch selection {
+            case .reviewedPdf2md:
+                config.backend = .localPdf2md
+                reference = .installed(ProcessExtractionServices.reviewedPDFLogical)
+            case .installed(let logical), .unavailableInstalled(let logical):
+                reference = .installed(logical)
+            case .connectedService(let backend):
+                config.backend = backend
+                reference = .builtIn(.pdf(backend))
+            case .prompt, .reviewedDefuddle, .builtInTagBased:
+                return
+            }
+        } else if route == .canonicalHTML {
+            switch selection {
+            case .prompt:
+                config.htmlBackend = nil
+                reference = nil
+            case .reviewedDefuddle:
+                config.htmlBackend = .defuddle
+                reference = .installed(ProcessExtractionServices.reviewedHTMLLogical)
+            case .installed(let logical), .unavailableInstalled(let logical):
+                reference = .installed(logical)
+            case .builtInTagBased:
+                config.htmlBackend = .tagBased
+                reference = .builtIn(.html(.tagBased))
+            case .reviewedPdf2md, .connectedService:
+                return
+            }
+        } else {
+            switch selection {
+            case .installed(let logical), .unavailableInstalled(let logical):
+                reference = .installed(logical)
+            default:
+                return
+            }
+        }
+        config.setExtractorSelection(reference, for: route)
+    }
+}
+
+/// The ACP-provider draft mapping, retained from the former
+/// `ExtractorSettingsSelectionMapping`: the provider picker keeps its String
+/// draft, and the legacy direct-API provider defaults still resolve.
 enum ExtractorSettingsSelectionMapping {
     static let claudeACPProviderID = ProviderID(rawValue: "claude-acp")
     static let geminiACPProviderID = ProviderID(rawValue: "gemini")
-
-    static func pdfSelection(from config: ExtractionConfig) -> PDFExtractorSettingsSelection {
-        switch config.pdfExtractor {
-        case .installed(let logical):
-            return logical == ProcessExtractionServices.reviewedPDFLogical
-                ? .reviewedPdf2md
-                : .installed(logical)
-        case .builtIn(.pdf(let backend)):
-            return visiblePDFSelection(for: backend)
-        case .builtIn(.html), .none:
-            return visiblePDFSelection(for: config.backend)
-        }
-    }
 
     static func acpProviderSelection(from config: ExtractionConfig) -> String {
         switch effectivePDFBackend(from: config) {
@@ -650,71 +855,11 @@ enum ExtractorSettingsSelectionMapping {
         }
     }
 
-    private static func visiblePDFSelection(for backend: ExtractionBackend) -> PDFExtractorSettingsSelection {
-        switch backend {
-        case .localPdf2md:
-            return .reviewedPdf2md
-        case .anthropic, .gemini:
-            return .host(.acp)
-        case .acp, .doclingServe:
-            return .host(backend)
-        }
-    }
-
     private static func effectivePDFBackend(from config: ExtractionConfig) -> ExtractionBackend {
         if case .builtIn(.pdf(let backend)) = config.pdfExtractor {
             return backend
         }
         return config.backend
-    }
-
-    static func htmlSelection(from config: ExtractionConfig) -> HTMLExtractorSettingsSelection {
-        switch config.htmlExtractor {
-        case .installed(let logical):
-            return logical == ProcessExtractionServices.reviewedHTMLLogical
-                ? .reviewedDefuddle
-                : .installed(logical)
-        case .builtIn(.html(let backend)):
-            return backend == .defuddle ? .reviewedDefuddle : .host(backend)
-        case .builtIn(.pdf), .none:
-            guard let backend = config.htmlBackend else { return .prompt }
-            return backend == .defuddle ? .reviewedDefuddle : .host(backend)
-        }
-    }
-
-    static func writePDF(
-        _ selection: PDFExtractorSettingsSelection,
-        into config: inout ExtractionConfig
-    ) {
-        switch selection {
-        case .reviewedPdf2md:
-            config.backend = .localPdf2md
-            config.pdfExtractor = .installed(ProcessExtractionServices.reviewedPDFLogical)
-        case .installed(let logical):
-            config.pdfExtractor = .installed(logical)
-        case .host(let backend):
-            config.backend = backend
-            config.pdfExtractor = .builtIn(.pdf(backend))
-        }
-    }
-
-    static func writeHTML(
-        _ selection: HTMLExtractorSettingsSelection,
-        into config: inout ExtractionConfig
-    ) {
-        switch selection {
-        case .prompt:
-            config.htmlBackend = nil
-            config.htmlExtractor = nil
-        case .reviewedDefuddle:
-            config.htmlBackend = .defuddle
-            config.htmlExtractor = .installed(ProcessExtractionServices.reviewedHTMLLogical)
-        case .installed(let logical):
-            config.htmlExtractor = .installed(logical)
-        case .host(let backend):
-            config.htmlBackend = backend
-            config.htmlExtractor = .builtIn(.html(backend))
-        }
     }
 }
 
@@ -723,11 +868,15 @@ enum ExtractorSettingsSelectionMapping {
 /// Value snapshot of the installed-package lifecycle as presented by Settings:
 /// the process registry's active exact registrations, catalog revisions whose
 /// activation failed in this process (bounded, redacted reconciler
-/// diagnostics), and the generation the reconciler last applied.
+/// diagnostics), the generation the reconciler last applied, and the
+/// route-presentation projection (registration snapshots + waiting revisions)
+/// the route table builder consumes.
 struct ExtractorPackageSettingsSnapshot: Sendable, Equatable {
     var rows: [ExtractorPackageSettingsRow] = []
     var failedPackages: [ExtractorPackageFailureSummary] = []
     var appliedGeneration: UInt64?
+    var registrationSnapshots: [ExtractorRouteRegistrationSnapshot] = []
+    var waitingRevisionIDs: Set<ExtractorPackageRevisionID> = []
 
     static let empty = ExtractorPackageSettingsSnapshot()
 }
@@ -748,17 +897,6 @@ struct ExtractorPackageFailureSummary: Identifiable, Hashable, Sendable {
     }
 
     var id: String { "\(packageID)/\(version)/\(digestPrefix)" }
-}
-
-/// One installed logical (version-free) reference offered in the default
-/// extractor pickers. `logical` is the persisted value; the rest is labeling.
-struct ExtractorPackageChoice: Identifiable, Hashable, Sendable {
-    let logical: LogicalExtractorReference
-    let packageID: String
-    let registrationID: String
-
-    var id: String { "\(packageID)/\(registrationID)" }
-    var label: String { "\(packageID) — \(registrationID)" }
 }
 
 /// Result of an app-only package mutation, already reduced to user-facing

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -97,6 +97,14 @@ struct ExtractionSettingsView: View {
             Section {
                 extractorRouteTable
 
+                // Transcripts are a different operation domain (host adapters,
+                // not the package protocol), so the picker stays outside the
+                // route table — the sub-header keeps the two visually grouped.
+                Label("Transcripts", systemImage: "mic")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
+
                 Picker("Podcast Transcript", selection: podcastBackendBinding) {
                     Text("Prompt me when transcribing").tag(nil as PodcastTranscriptionBackend?)
                     ForEach(PodcastTranscriptionBackend.allCases, id: \.self) { backend in

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -96,15 +96,18 @@ struct ExtractionSettingsView: View {
         Form {
             Section {
                 extractorRouteTable
-
-                // Transcripts are a different operation domain (host adapters,
-                // not the package protocol), so the picker stays outside the
-                // route table — the sub-header keeps the two visually grouped.
-                Label("Transcripts", systemImage: "mic")
-                    .font(.callout.weight(.medium))
+            } header: {
+                Text("Default Extractors")
+            } footer: {
+                Text("Reviewed packages run outside the app through the extractor protocol. Installed packages are local additions. Connected services use host-managed providers.")
+                    .font(.caption)
                     .foregroundStyle(.secondary)
-                    .accessibilityHidden(true)
+            }
 
+            // Transcripts are a different operation domain (host adapters,
+            // not the package protocol), so the picker is its own section at
+            // the same level as the extractor routes.
+            Section {
                 Picker("Podcast Transcript", selection: podcastBackendBinding) {
                     Text("Prompt me when transcribing").tag(nil as PodcastTranscriptionBackend?)
                     ForEach(PodcastTranscriptionBackend.allCases, id: \.self) { backend in
@@ -114,9 +117,9 @@ struct ExtractionSettingsView: View {
                 .onChange(of: draftPodcastBackend) { persistAll() }
                 .accessibilityLabel("Default podcast transcript extractor")
             } header: {
-                Text("Default Extractors")
+                Text("Transcripts")
             } footer: {
-                Text("Reviewed packages run outside the app through the extractor protocol. Installed packages are local additions. Connected services use host-managed providers. Podcast transcripts are not package-backed in protocol revision 1.")
+                Text("Podcast transcripts are not package-backed in protocol revision 1.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -779,6 +779,9 @@ struct WikiFSApp: App {
                         }
                         var snapshot = ExtractorPackageSettingsSnapshot(
                             rows: await services.extractionBackends.installedPackageRows())
+                        // Route presentation projection: exact registration
+                        // metadata for the route table builder.
+                        snapshot.registrationSnapshots = await services.extractionBackends.installedRegistrationSnapshots()
                         if let context = services.extractionContext {
                             let observation = await context.observationSnapshot()
                             snapshot.failedPackages = observation.retainedFailures.map {
@@ -789,6 +792,7 @@ struct WikiFSApp: App {
                                     message: $0.message)
                             }
                             snapshot.appliedGeneration = observation.appliedGeneration
+                            snapshot.waitingRevisionIDs = observation.waitingRevisionIDs
                         }
                         return snapshot
                     },

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -232,12 +232,11 @@ struct ExtractionRouteTableHostedTests {
         #expect(source.contains("MIME type: \\(row.route.mimeType.rawValue)"))
         #expect(source.contains("Text(\"\\(row.route.mimeType.rawValue)\")") == false)
 
-        // The podcast picker is a separate control wired to the podcast
-        // binding, outside the route table, visually grouped by the
-        // Transcripts sub-header.
+        // The podcast picker is its own section at the same level as the
+        // extractor routes, wired to the podcast binding.
         #expect(source.contains("podcastBackendBinding"))
         #expect(source.contains("Picker(\"Podcast Transcript\", selection: podcastBackendBinding)"))
-        #expect(source.contains("Label(\"Transcripts\", systemImage: \"mic\")"))
+        #expect(source.contains("Text(\"Transcripts\")"))
     }
 
     /// A stale installed selection keeps the row's fallback active: the write

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -1,0 +1,240 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+import WikiFSCore
+import WikiFSEngine
+import WikiFSTypes
+@testable import WikiFS
+
+/// Hosted coverage for Settings → Extraction's native route table. The real
+/// `ExtractionSettingsView` mounts in an NSWindow (same pattern as
+/// `PageContextMenuHostedTests`) and must render, lay out, and load the
+/// package snapshot without wedging or crashing.
+///
+/// SwiftUI's accessibility tree is only materialized for real AX clients, so
+/// the identifier/label/status vocabulary is pinned by the source-contract
+/// test here plus the hosted contract in `ExtractorPackageSettingsTests`;
+/// spoken-announcement behavior remains the manual VoiceOver smoke script's
+/// job (`scripts/voiceover-extractor-settings-smoke.md`).
+///
+/// `.serialized` + `.timeLimit` (issue #1051 discipline): each window-owning
+/// test takes the shared `HostedAppKitTestGate` lease so suites never overlap
+/// on the single `swift test` AppKit host.
+@Suite(.serialized, .timeLimit(.minutes(2)))
+@MainActor
+struct ExtractionRouteTableHostedTests {
+
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    /// In-memory credential stub — the hosted view must never touch Keychain.
+    private struct StubCredentialStore: ExtractionCredentialStore {
+        func secret(_ secret: ExtractionSecret) -> String? { nil }
+        func setSecret(_ value: String?, _ secret: ExtractionSecret) throws {}
+    }
+
+    private func tempDirectory(_ name: String) throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func snapshot(
+        registrations: [ExtractorRouteRegistrationSnapshot] = [],
+        failedPackageIDs: Set<String> = []
+    ) -> ExtractorPackageSettingsSnapshot {
+        var snapshot = ExtractorPackageSettingsSnapshot()
+        snapshot.registrationSnapshots = registrations
+        snapshot.failedPackages = failedPackageIDs.map {
+            ExtractorPackageFailureSummary(
+                packageID: $0,
+                version: "1.0.0",
+                digestPrefix: String(repeating: "a", count: 12),
+                message: "activation refused")
+        }
+        return snapshot
+    }
+
+    private func makeView(
+        directory: URL,
+        snapshot: ExtractorPackageSettingsSnapshot
+    ) -> ExtractionSettingsView {
+        ExtractionSettingsView(
+            containerDirectory: directory,
+            launcher: AgentLauncher(),
+            credentialStore: StubCredentialStore(),
+            packageSnapshot: { snapshot })
+    }
+
+    private func mount(_ view: ExtractionSettingsView) -> NSWindow {
+        _ = Self.app
+        let controller = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: controller)
+        window.setContentSize(NSSize(width: 640, height: 560))
+        window.layoutIfNeeded()
+        controller.view.layoutSubtreeIfNeeded()
+        // Offscreen but visible: SwiftUI's `.task` (the first snapshot load)
+        // only fires once the view is in a visible window hierarchy.
+        window.orderFrontRegardless()
+        return window
+    }
+
+    private func sourceView() throws -> String {
+        try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("Sources/WikiFS/Sources/ExtractionSettingsView.swift"),
+            encoding: .utf8)
+    }
+
+    /// Non-blocking bounded wait for SwiftUI's async `.task` to complete the
+    /// first snapshot load.
+    private func waitUntil(
+        _ condition: () -> Bool,
+        timeout: Duration = .seconds(5)
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while condition() == false {
+            guard clock.now < deadline else {
+                Issue.record("Timed out waiting for the hosted route table to load")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+    }
+
+    // MARK: - AC.10: the table renders and scrolls internally
+
+    @Test("the route table mounts, loads its snapshot, and scrolls internally")
+    func rendersRouteTableWithoutCrash() async throws {
+        let dir = try tempDirectory("route-table-render")
+        let view = makeView(directory: dir, snapshot: snapshot())
+        let window = mount(view)
+        try await waitUntil {
+            (window.contentView?.bounds.width ?? 0) > 0
+        }
+        // The hosted hierarchy contains a native table (row views) inside a
+        // clip view — the scrollable, window-bounded layout.
+        func contains(_ view: NSView, _ type: (NSView) -> Bool) -> Bool {
+            if type(view) { return true }
+            return view.subviews.contains { contains($0, type) }
+        }
+        let content = try #require(window.contentView)
+        #expect(contains(content) { $0 is NSClipView })
+        #expect(contains(content) { $0 is NSTableRowView } || contains(content) { $0 is NSTableView })
+    }
+
+    @Test("the table keeps a constrained height at the Settings minimum size")
+    func tableUsesConstrainedScrollableLayout() throws {
+        let dir = try tempDirectory("route-table-scroll")
+        let view = makeView(directory: dir, snapshot: snapshot())
+        let window = mount(view)
+        let content = try #require(window.contentView)
+
+        // The hosting hierarchy contains a clip view (the table's internal
+        // scroll viewport); the Settings form itself carries the fixed
+        // minimum frame, so row growth scrolls instead of resizing.
+        func hasClipView(_ view: NSView) -> Bool {
+            if view is NSClipView { return true }
+            return view.subviews.contains { hasClipView($0) }
+        }
+        #expect(hasClipView(content))
+        #expect(window.contentView?.bounds.height ?? 0 > 0)
+
+        // The height comes from a named metric, not a magic literal.
+        let source = try sourceView()
+        #expect(source.contains("routeTableHeight"))
+        #expect(source.contains("Table(routeRows)"))
+    }
+
+    // MARK: - AC.8 / AC.11 / AC.12 / AC.14 / AC.15 contracts
+
+    /// The route picker vocabulary, identifiers, status vocabulary, and the
+    /// dual-write mapping are structural contracts of the view source.
+    @Test("route table source exposes the accessibility and mapping contract")
+    func routeTableSourceContract() throws {
+        let source = try sourceView()
+
+        // The table and its columns.
+        #expect(source.contains("Table(routeRows)"))
+        #expect(source.contains("TableColumn(\"Format\")"))
+        #expect(source.contains("TableColumn(\"Default extractor\")"))
+        #expect(source.contains("TableColumn(\"Status\")"))
+
+        // Stable route-derived accessibility identifiers and labels.
+        #expect(source.contains("extraction.routes.table"))
+        #expect(source.contains("extraction.routes.picker"))
+        #expect(source.contains(".accessibilityLabel(\"Default extractor for \\(row.descriptor.displayName)\")"))
+        #expect(source.contains(".accessibilityValue(accessibilityValue(row))"))
+        #expect(source.contains("Default extractor routes"))
+        #expect(source.contains("accessibilityKey("))
+
+        // Fixed status vocabulary.
+        #expect(source.contains("\"Available\""))
+        #expect(source.contains("\"Using fallback\""))
+        #expect(source.contains("\"Not installed\""))
+        #expect(source.contains("\"Waiting for host service\""))
+        #expect(source.contains("\"Failed to activate\""))
+
+        // The picker writes through the dual-write mapping with auto-save; no
+        // synchronous state write from a representable update path.
+        #expect(source.contains("ExtractorRouteSettingsMapping.write(selection, route: row.route, into: &config)"))
+        #expect(source.contains("rebuildRouteRows()"))
+        #expect(source.contains("NSViewRepresentable") == false)
+
+        // ACP and Docling configuration follows the PDF route selection only.
+        #expect(source.contains("switch routeSelections[ExtractorRouteID.canonicalPDF.description]"))
+        #expect(source.contains("case .connectedService(.acp): acpSection"))
+        #expect(source.contains("case .connectedService(.doclingServe): doclingSection"))
+
+        // Technical MIME identity stays out of the primary columns (help text).
+        #expect(source.contains("MIME type: \\(row.route.mimeType.rawValue)"))
+        #expect(source.contains("Text(\"\\(row.route.mimeType.rawValue)\")") == false)
+
+        // The podcast picker is a separate control wired to the podcast
+        // binding, outside the route table.
+        #expect(source.contains("podcastBackendBinding"))
+        #expect(source.contains("Picker(\"Podcast Transcript\", selection: podcastBackendBinding)"))
+    }
+
+    /// A stale installed selection keeps the row's fallback active: the write
+    /// path persists the typed reference and the fixed fallback still resolves
+    /// through the production resolver (persisted-file round trip).
+    @Test("a stale installed selection persists and still resolves to the fallback")
+    func staleSelectionShowsFallbackStatus() async throws {
+        let dir = try tempDirectory("route-table-stale")
+        let logical = LogicalExtractorReference(
+            packageID: try ExtractorPackageID(validating: "org.example.gone"),
+            registrationID: try ExtractorRegistrationID(validating: "main"))
+
+        // The table's write path, exercised end to end: mapping write + save.
+        var config = ExtractionConfig(backend: .acp)
+        ExtractorRouteSettingsMapping.write(.installed(logical), route: .canonicalPDF, into: &config)
+        try config.save(to: dir)
+
+        let reloaded = ExtractionConfig.load(from: dir)
+        #expect(reloaded.extractorSelection(for: .canonicalPDF) == .installed(logical))
+        #expect(reloaded.pdfExtractor == .installed(logical))
+        let decision = ExtractorSelectionResolver.resolvePDF(configuration: reloaded, activeRegistrations: [])
+        #expect(decision.selection == .pdfBuiltIn(.localPdf2md))
+        #expect(decision.diagnostic == .unavailableInstalled(logical))
+
+        // And the mounted view's builder reports the fallback status for it.
+        let rows = ExtractorRouteTableBuilder.build(.init(
+            configuration: reloaded,
+            registrations: []))
+        let pdf = rows.first { $0.route == .canonicalPDF }
+        #expect(pdf?.status == .usingFallback(description: "Bundled pdf2md extraction"))
+        #expect(pdf?.savedSelection == .installed(logical))
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -114,27 +114,63 @@ struct ExtractionRouteTableHostedTests {
 
     // MARK: - AC.10: the table renders and scrolls internally
 
+    private func containsDescendant(_ view: NSView, _ predicate: (NSView) -> Bool) -> Bool {
+        if predicate(view) { return true }
+        return view.subviews.contains { containsDescendant($0, predicate) }
+    }
+
+    private func firstTableView(_ window: NSWindow) -> NSTableView? {
+        guard let content = window.contentView else { return nil }
+        var result: NSTableView?
+        func walk(_ view: NSView) {
+            if result == nil, let table = view as? NSTableView { result = table }
+            for subview in view.subviews { walk(subview) }
+        }
+        walk(content)
+        return result
+    }
+
     @Test("the route table mounts, loads its snapshot, and scrolls internally")
     func rendersRouteTableWithoutCrash() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         let dir = try tempDirectory("route-table-render")
-        let view = makeView(directory: dir, snapshot: snapshot())
+        // A real registration whose MIME is outside the host routes: the table
+        // then holds three rows (PDF, HTML, and the registration-derived epub
+        // route). Row views only exist after the async snapshot load rebuilds
+        // routeRows, so the wait below observes the actual load instead of the
+        // initial layout.
+        let view = makeView(directory: dir, snapshot: snapshot(registrations: [
+            ExtractorRouteRegistrationSnapshot(
+                reference: ExtractorReference(
+                    revision: ExtractorPackageRevisionID(
+                        packageID: try ExtractorPackageID(validating: "org.example.pdf"),
+                        version: try ExtractorPackageVersion(validating: "1.0.0"),
+                        digest: try ExtractorPackageDigest(hex: String(repeating: "3", count: 64))),
+                    registrationID: try ExtractorRegistrationID(validating: "pdf")),
+                displayName: "PDF Package",
+                packageName: "PDF Package",
+                kinds: [.pdf],
+                mimeTypes: [try ExtractorMIMEType(validating: "application/epub+zip")],
+                filenameExtensions: []),
+        ]))
         let window = mount(view)
+
         try await waitUntil {
-            (window.contentView?.bounds.width ?? 0) > 0
+            self.firstTableView(window)?.numberOfRows == 3
         }
         // The hosted hierarchy contains a native table (row views) inside a
         // clip view — the scrollable, window-bounded layout.
-        func contains(_ view: NSView, _ type: (NSView) -> Bool) -> Bool {
-            if type(view) { return true }
-            return view.subviews.contains { contains($0, type) }
-        }
         let content = try #require(window.contentView)
-        #expect(contains(content) { $0 is NSClipView })
-        #expect(contains(content) { $0 is NSTableRowView } || contains(content) { $0 is NSTableView })
+        #expect(containsDescendant(content) { $0 is NSClipView })
+        let table = try #require(firstTableView(window))
+        #expect(table.numberOfRows == 3)
     }
 
     @Test("the table keeps a constrained height at the Settings minimum size")
-    func tableUsesConstrainedScrollableLayout() throws {
+    func tableUsesConstrainedScrollableLayout() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
         let dir = try tempDirectory("route-table-scroll")
         let view = makeView(directory: dir, snapshot: snapshot())
         let window = mount(view)
@@ -143,12 +179,8 @@ struct ExtractionRouteTableHostedTests {
         // The hosting hierarchy contains a clip view (the table's internal
         // scroll viewport); the Settings form itself carries the fixed
         // minimum frame, so row growth scrolls instead of resizing.
-        func hasClipView(_ view: NSView) -> Bool {
-            if view is NSClipView { return true }
-            return view.subviews.contains { hasClipView($0) }
-        }
-        #expect(hasClipView(content))
-        #expect(window.contentView?.bounds.height ?? 0 > 0)
+        #expect(containsDescendant(content) { $0 is NSClipView })
+        #expect((window.contentView?.bounds.height ?? 0) > 0)
 
         // The height comes from a named metric, not a magic literal.
         let source = try sourceView()

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -233,9 +233,11 @@ struct ExtractionRouteTableHostedTests {
         #expect(source.contains("Text(\"\\(row.route.mimeType.rawValue)\")") == false)
 
         // The podcast picker is a separate control wired to the podcast
-        // binding, outside the route table.
+        // binding, outside the route table, visually grouped by the
+        // Transcripts sub-header.
         #expect(source.contains("podcastBackendBinding"))
         #expect(source.contains("Picker(\"Podcast Transcript\", selection: podcastBackendBinding)"))
+        #expect(source.contains("Label(\"Transcripts\", systemImage: \"mic\")"))
     }
 
     /// A stale installed selection keeps the row's fallback active: the write

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -68,7 +68,20 @@ struct ExtractorPackageSettingsTests {
         #expect(rows.isEmpty)
     }
 
-    // MARK: - Unified extractor selection mapping
+    // MARK: - Route-scoped extractor selection mapping
+
+    /// Derives the view selection for one canonical route from a config,
+    /// using the real builder output for the row context.
+    private func routeSelection(
+        _ route: ExtractorRouteID,
+        from config: ExtractionConfig
+    ) -> ExtractorRouteSettingsSelection {
+        let row = ExtractorRouteTableBuilder.build(.init(
+            configuration: config,
+            registrations: []))
+            .first { $0.route == route }!
+        return ExtractorRouteSettingsMapping.selection(route: route, config: config, row: row)
+    }
 
     @Test("legacy reviewed selections appear as reviewed packages")
     func legacyReviewedSelectionsMapToPackages() {
@@ -76,16 +89,16 @@ struct ExtractorPackageSettingsTests {
         config.backend = .localPdf2md
         config.htmlBackend = .defuddle
 
-        #expect(ExtractorSettingsSelectionMapping.pdfSelection(from: config) == .reviewedPdf2md)
-        #expect(ExtractorSettingsSelectionMapping.htmlSelection(from: config) == .reviewedDefuddle)
+        #expect(routeSelection(.canonicalPDF, from: config) == .reviewedPdf2md)
+        #expect(routeSelection(.canonicalHTML, from: config) == .reviewedDefuddle)
     }
 
     @Test("host service selections keep legacy fields truthful")
     func hostSelectionsWriteBothCompatibilityDomains() {
         var config = ExtractionConfig()
 
-        ExtractorSettingsSelectionMapping.writePDF(.host(.acp), into: &config)
-        ExtractorSettingsSelectionMapping.writeHTML(.host(.tagBased), into: &config)
+        ExtractorRouteSettingsMapping.write(.connectedService(.acp), route: .canonicalPDF, into: &config)
+        ExtractorRouteSettingsMapping.write(.builtInTagBased, route: .canonicalHTML, into: &config)
 
         #expect(config.backend == .acp)
         #expect(config.pdfExtractor == .builtIn(.pdf(.acp)))
@@ -101,15 +114,15 @@ struct ExtractorPackageSettingsTests {
     }
 
     @Test("legacy direct API selections migrate to their ACP providers")
-    func directAPISelectionsMapToACP() {
+    func directAPISelectionsMapToACP() throws {
         var anthropic = ExtractionConfig()
         anthropic.backend = .anthropic
         var gemini = ExtractionConfig()
         gemini.pdfExtractor = .builtIn(.pdf(.gemini))
 
-        #expect(ExtractorSettingsSelectionMapping.pdfSelection(from: anthropic) == .host(.acp))
+        #expect(routeSelection(.canonicalPDF, from: anthropic) == .connectedService(.acp))
         #expect(ExtractorSettingsSelectionMapping.acpProviderSelection(from: anthropic) == "claude-acp")
-        #expect(ExtractorSettingsSelectionMapping.pdfSelection(from: gemini) == .host(.acp))
+        #expect(routeSelection(.canonicalPDF, from: gemini) == .connectedService(.acp))
         #expect(ExtractorSettingsSelectionMapping.acpProviderSelection(from: gemini) == "gemini")
     }
 
@@ -117,13 +130,16 @@ struct ExtractorPackageSettingsTests {
     func reviewedSelectionsWriteLogicalPackageReferences() {
         var config = ExtractionConfig()
 
-        ExtractorSettingsSelectionMapping.writePDF(.reviewedPdf2md, into: &config)
-        ExtractorSettingsSelectionMapping.writeHTML(.reviewedDefuddle, into: &config)
+        ExtractorRouteSettingsMapping.write(.reviewedPdf2md, route: .canonicalPDF, into: &config)
+        ExtractorRouteSettingsMapping.write(.reviewedDefuddle, route: .canonicalHTML, into: &config)
 
         #expect(config.backend == .localPdf2md)
         #expect(config.pdfExtractor == .installed(ProcessExtractionServices.reviewedPDFLogical))
         #expect(config.htmlBackend == .defuddle)
         #expect(config.htmlExtractor == .installed(ProcessExtractionServices.reviewedHTMLLogical))
+        // The canonical route records dual-write with the legacy fields.
+        #expect(config.extractorSelection(for: .canonicalPDF) == .installed(ProcessExtractionServices.reviewedPDFLogical))
+        #expect(config.extractorSelection(for: .canonicalHTML) == .installed(ProcessExtractionServices.reviewedHTMLLogical))
     }
 
     @Test("installed selections preserve legacy fallback fields")
@@ -138,8 +154,8 @@ struct ExtractorPackageSettingsTests {
         config.backend = .anthropic
         config.htmlBackend = .tagBased
 
-        ExtractorSettingsSelectionMapping.writePDF(.installed(pdf), into: &config)
-        ExtractorSettingsSelectionMapping.writeHTML(.installed(html), into: &config)
+        ExtractorRouteSettingsMapping.write(.installed(pdf), route: .canonicalPDF, into: &config)
+        ExtractorRouteSettingsMapping.write(.installed(html), route: .canonicalHTML, into: &config)
 
         #expect(config.backend == .anthropic)
         #expect(config.pdfExtractor == .installed(pdf))
@@ -153,11 +169,11 @@ struct ExtractorPackageSettingsTests {
         config.htmlBackend = .defuddle
         config.htmlExtractor = .installed(ProcessExtractionServices.reviewedHTMLLogical)
 
-        ExtractorSettingsSelectionMapping.writeHTML(.prompt, into: &config)
+        ExtractorRouteSettingsMapping.write(.prompt, route: .canonicalHTML, into: &config)
 
         #expect(config.htmlBackend == nil)
         #expect(config.htmlExtractor == nil)
-        #expect(ExtractorSettingsSelectionMapping.htmlSelection(from: config) == .prompt)
+        #expect(config.extractorSelection(for: .canonicalHTML) == nil)
     }
 
     @Test("wrong-kind persisted references defer to legacy fields")
@@ -168,8 +184,8 @@ struct ExtractorPackageSettingsTests {
         config.htmlBackend = .tagBased
         config.htmlExtractor = .builtIn(.pdf(.anthropic))
 
-        #expect(ExtractorSettingsSelectionMapping.pdfSelection(from: config) == .host(.doclingServe))
-        #expect(ExtractorSettingsSelectionMapping.htmlSelection(from: config) == .host(.tagBased))
+        #expect(routeSelection(.canonicalPDF, from: config) == .connectedService(.doclingServe))
+        #expect(routeSelection(.canonicalHTML, from: config) == .builtInTagBased)
     }
 
     // MARK: - Settings model
@@ -396,9 +412,9 @@ struct ExtractorPackageSettingsTests {
         #expect(viewSource.contains("extraction.packages.remove"))
         #expect(viewSource.contains("extraction.packages.failure"))
         #expect(viewSource.contains("extraction.packages.failure.message"))
-        #expect(viewSource.contains("extraction.packages.selection.pdf"))
-        #expect(viewSource.contains("extraction.packages.selection.html"))
-        #expect(viewSource.contains("extraction.packages.progress"))
+        #expect(viewSource.contains("extraction.routes.table"))
+        #expect(viewSource.contains("extraction.routes.picker"))
+        #expect(viewSource.contains("progress"))
         #expect(viewSource.contains("extraction.packages.diagnostic"))
         #expect(viewSource.contains("extraction.packages.error"))
         #expect(viewSource.contains(".accessibilityValue(\"Not ready\")"))
@@ -417,8 +433,8 @@ struct ExtractorPackageSettingsTests {
         #expect(viewSource.contains("Installed package"))
         #expect(viewSource.contains("Connected service"))
         #expect(viewSource.contains("Built-in default") == false)
-        #expect(viewSource.contains("ExtractorSettingsSelectionMapping.writePDF"))
-        #expect(viewSource.contains("ExtractorSettingsSelectionMapping.writeHTML"))
+        #expect(viewSource.contains("ExtractorRouteSettingsMapping.write"))
+        #expect(viewSource.contains("Table(routeRows)"))
         #expect(viewSource.contains("extractorOption(\"Claude\"") == false)
         #expect(viewSource.contains("extractorOption(\"Gemini\"") == false)
         #expect(viewSource.contains("Claude (Anthropic API)") == false)

--- a/docs/user-guide/extractor-packages.md
+++ b/docs/user-guide/extractor-packages.md
@@ -24,14 +24,15 @@ The capability list in a manifest (network, shared caches, model download) is a 
 
 ## Selection and fallback
 
-Open **Settings** → **Extraction** and use the **Default Extractors** section. The PDF and HTML pickers list all compatible choices in one place:
+Open **Settings** → **Extraction** and use the **Default Extractors** section. The section shows a table with one row per extraction route. The current routes are PDF and HTML. A registration can add a row for a new format without another app update, although formats outside PDF and HTML have no extraction adapter yet.
 
-- **Reviewed package** identifies bundled, validated packages such as pdf2md and Defuddle.
-- **Installed package** identifies a package imported on this Mac.
-- **Connected service** identifies a host-managed adapter such as ACP Provider or Docling Serve. Select Claude, Gemini, or another configured agent inside ACP Provider.
-- **Built in** identifies code that runs in the host, such as tag-based HTML extraction.
+Each row has three columns:
 
-A package selection does not pin a version. The app uses the highest compatible active revision of that package lineage. If the selected package is missing, failed, or incompatible, the picker keeps the unavailable selection visible and the app uses the fixed fallback: reviewed pdf2md for PDF or built-in tag-based extraction for HTML. The app never selects another third-party package silently.
+- **Format** shows the route name, such as PDF or HTML. The technical MIME type is in the help text.
+- **Default extractor** is a pop-up that lists the compatible choices for that row: reviewed packages, installed packages, connected services, and built-in extractors. HTML also offers a no-default prompt choice. The labels match the older pickers: **Reviewed package**, **Installed package**, **Connected service**, and **Built in**.
+- **Status** shows **Available**, **Using fallback**, **Not installed**, **Waiting for host service**, or **Failed to activate**. When the status is **Using fallback**, the help text names the fallback that actually runs.
+
+A package selection does not pin a version. The app uses the highest compatible active revision of that package lineage. If the selected package is missing, failed, or incompatible, the pop-up keeps the unavailable selection selected and the app uses the fixed fallback: reviewed pdf2md for PDF or built-in tag-based extraction for HTML. The app never selects another third-party package silently.
 
 Older package versions stay available while a newer version is installed, so a failed upgrade does not remove a working version.
 

--- a/progress/2026-08-28T080000Z-extractor-route-table.md
+++ b/progress/2026-08-28T080000Z-extractor-route-table.md
@@ -1,0 +1,59 @@
+---
+timestamp: 2026-08-28T080000Z
+title: Scrollable extractor route table
+branch: feature/extractor-route-table
+status: complete
+---
+
+# Scrollable extractor route table
+
+## Progress
+
+Settings → Extraction's Default Extractors section now shows the native,
+registration-driven route table from PR 2's projection.
+
+- The fixed PDF and HTML pickers are replaced by one SwiftUI `Table` with
+  Format / Default extractor / Status columns, constrained to a fixed height
+  so it scrolls internally and the Settings window stays bounded.
+- View state collapsed from two per-kind enums into one route-scoped
+  `ExtractorRouteSettingsSelection` with typed associated values — no
+  sentinel strings for prompt, unavailable, or default state.
+- Each row's pop-up writes through `ExtractorRouteSettingsMapping`, which
+  keeps the legacy `backend` / `htmlBackend` fields truthful exactly as the
+  old mapping did, while `setExtractorSelection` persists the typed route
+  record. Auto-save semantics are preserved; no writes happen from a
+  representable update path (the table is fully native SwiftUI).
+- ACP Provider and Docling Serve configuration sections appear only while the
+  PDF route's selection is the corresponding connected service; Claude and
+  Gemini remain choices inside the ACP provider picker only.
+- A stale installed selection stays selected in its pop-up (one unavailable
+  choice from the builder) while the status column reports the fixed
+  fallback.
+- Package import, inspection, readiness, removal, the trust warning, and
+  lifecycle rows remain in Installed Extractor Packages below the table.
+  Podcast transcript selection remains its own control outside the table.
+- Accessibility: the table, each route picker (identifiers derived from the
+  typed route, e.g. `extraction.routes.picker.pdf-application-pdf`), and
+  status cells carry stable identifiers; pickers expose "Default extractor
+  for PDF/HTML" labels and values combining the selected extractor and
+  status. Spoken announcements remain covered by the manual VoiceOver smoke
+  script, which now walks the table rows, statuses, and fallback help text.
+
+Design notes: `plans/dynamic-extractor-packages.md`. User guide:
+`docs/user-guide/extractor-packages.md` (Selection and fallback).
+
+## Verification
+
+The following gates passed on 2026-08-28:
+
+```text
+WIKIFS_APP_TESTS=1 swift test --filter 'ExtractorPackageSettingsTests|ExtractionRouteTableHostedTests'
+25 tests passed
+
+swift test --filter DocumentationContractTests
+make lint
+make build
+make test
+swift build
+swift test
+```

--- a/scripts/voiceover-extractor-settings-smoke.md
+++ b/scripts/voiceover-extractor-settings-smoke.md
@@ -4,25 +4,34 @@ Run this test on macOS with VoiceOver enabled. Use a test App Group and a dispos
 
 1. Open Self Driving Wiki Settings.
 2. Select the Extraction tab.
-3. Move focus to `Advanced Local Package Import`.
-4. Confirm that VoiceOver reads the executable-code warning.
-5. Confirm that VoiceOver reads that the app's lifecycle and capability controls do not create a security sandbox.
-6. Open the import disclosure.
-7. Activate `Import Extractor Package`.
-8. Choose one local package directory.
-9. Confirm that VoiceOver reads `Validating and installing package`.
-10. Confirm that VoiceOver reads the successful installation announcement.
-11. Move focus to an installed package row.
-12. Confirm that VoiceOver reads the package name, version, kind, and `Active` state.
-13. Open the row disclosure.
-14. Confirm that VoiceOver reads the digest prefix, registration, and readiness state.
-15. Select the package in the PDF or HTML extractor picker.
-16. Confirm that VoiceOver reads the selected logical package reference.
-17. Activate `Remove Package`.
-18. Confirm the destructive dialog text and `Cancel` action.
-19. Activate `Remove Package` in the dialog.
-20. Confirm that VoiceOver reads `Removing package` and the successful removal announcement.
-21. Confirm that the logical selection remains visible as `not installed`.
-22. Confirm that the row is removed and the documented built-in fallback remains active.
+3. Move focus to the `Default extractor routes` table in the Default Extractors section.
+4. Confirm that VoiceOver announces the two canonical rows, PDF first and HTML second.
+5. In each row, move to the `Default extractor for PDF` / `Default extractor for HTML` pop-up.
+6. Confirm that VoiceOver reads the selected extractor and the status (for example `pdf2md, Available`).
+7. Open the PDF pop-up. Confirm the option captions read `name — source` (Reviewed package, Installed package, Connected service, Built in).
+8. Choose the ACP Provider option. Confirm the ACP Provider section appears below the table and VoiceOver announces focus movement to the next control after the table.
+9. Choose the Docling Serve option. Confirm the Docling Serve section replaces it.
+10. Choose the reviewed pdf2md option. Confirm no service section remains.
+11. Move focus to a Status cell that reads `Using fallback`. Activate the help text. Confirm VoiceOver reads the fallback that actually runs (Bundled pdf2md extraction or Tag-based text extraction).
+12. Move focus to `Advanced Local Package Import`.
+13. Confirm that VoiceOver reads the executable-code warning.
+14. Confirm that VoiceOver reads that the app's lifecycle and capability controls do not create a security sandbox.
+15. Open the import disclosure.
+16. Activate `Import Extractor Package`.
+17. Choose one local package directory.
+18. Confirm that VoiceOver reads `Validating and installing package`.
+19. Confirm that VoiceOver reads the successful installation announcement.
+20. Move focus to an installed package row in Installed Extractor Packages.
+21. Confirm that VoiceOver reads the package name, version, kind, and `Active` state.
+22. Open the row disclosure.
+23. Confirm that VoiceOver reads the digest prefix, registration, and readiness state.
+24. Select the package in the PDF route pop-up. Confirm the status column reads `Available` and the picker's accessibility value contains the package name.
+25. Activate `Remove Package`.
+26. Confirm the destructive dialog text and `Cancel` action.
+27. Activate `Remove Package` in the dialog.
+28. Confirm that VoiceOver reads `Removing package` and the successful removal announcement.
+29. Confirm that the logical selection remains selected in the route pop-up as `Not installed` and the status column reads `Using fallback`.
+30. Confirm the row is removed and the documented built-in fallback remains active.
+31. Tab through the section: confirm focus moves row by row between the route pop-ups, then reaches the package controls after the table.
 
 Record the macOS version, app build, package digest prefix, and any missing or incorrect announcement. Do not record package source content or credentials.


### PR DESCRIPTION
Stack: PR 3 of 3 on top of #1161 (extractor routing table).

Parent: #1161 (`feature/extractor-route-catalog`) at exact head
`5eac14bcfc2d04e105128d1f99d899d568d99993` (which is stacked on #1160's
reviewed head `a7b21ad1a76291063793862684d7bc2e1e97a015`).

Parent head SHA: 5eac14bcfc2d04e105128d1f99d899d568d99993

## What this PR does

Replaces the fixed PDF and HTML extractor pickers with the native,
registration-driven route table.

- **Native table.** One SwiftUI `Table` in the Default Extractors section
  with Format / Default extractor / Status columns, height-constrained so it
  scrolls internally and the Settings window stays bounded. Rows come from
  PR 2's pure builder: host descriptors, active registration snapshots, and
  saved selections (including unavailable ones). Technical MIME identity
  stays in help text, not the primary columns.
- **Typed route-scoped selection.** The two per-kind view-state enums are
  replaced by one `ExtractorRouteSettingsSelection` with typed associated
  values — no sentinel strings for prompt, unavailable, or default state.
  Each row's pop-up writes through `ExtractorRouteSettingsMapping`: the
  legacy `backend` / `htmlBackend` mapping semantics are preserved exactly,
  and `setExtractorSelection` dual-writes the typed route record. Auto-save
  on change is unchanged; the table is fully native SwiftUI, so no state
  writes from any representable update path.
- **Follow-on configuration.** ACP Provider and Docling Serve sections appear
  only while the PDF route's selection is the corresponding connected
  service. Claude and Gemini remain choices inside the ACP provider picker
  only. A stale installed selection stays selected in its pop-up (one
  unavailable choice) while the status column reports the fixed fallback.
- **Everything else keeps its place.** Package import, inspection,
  readiness, removal, the executable-code trust warning, and lifecycle rows
  stay in Installed Extractor Packages below the table. Podcast transcript
  selection remains its own control outside the byte-extractor table.
- **Accessibility.** Stable route-derived identifiers
  (`extraction.routes.table`, `extraction.routes.picker.pdf-application-pdf`,
  `extraction.routes.picker.html-text-html`), per-picker labels ("Default
  extractor for PDF"/"HTML"), accessibility values combining the selected
  extractor and status, and the fixed status vocabulary: Available, Using
  fallback, Not installed, Waiting for host service, Failed to activate.
  Spoken announcements remain the manual VoiceOver smoke script's job, which
  now walks the table rows, statuses, fallback help text, and focus order.

## What this PR deliberately does not do

No new extractor kind, package, MIME registration, protocol revision, or
execution path. A registration-derived future route can appear as a row and
persist a selection, but resolving it returns nothing until an execution
adapter exists.

## Verification

```text
WIKIFS_APP_TESTS=1 swift test --filter 'ExtractorPackageSettingsTests|ExtractionRouteTableHostedTests'  # 25 passed
swift test --filter DocumentationContractTests  # 16 passed
make lint
make build
make test        # 3879 passed
swift build
swift test       # 3879 passed
```

Docs: `docs/user-guide/extractor-packages.md`,
`scripts/voiceover-extractor-settings-smoke.md`. Progress:
`progress/2026-08-28T080000Z-extractor-route-table.md`.
