### PR TITLE
feat(credentials): add shared credential service

### DIFF
--- a/Sources/WikiFS/Renderer/RendererCompositionOwner.swift
+++ b/Sources/WikiFS/Renderer/RendererCompositionOwner.swift
@@ -262,6 +262,11 @@ final class AppProcessPluginCatalog {
                         readCredential: { providerID in
                             KeychainACPCredentialStore().apiKey(forProvider: providerID.rawValue)
                         },
+                        readSpawnSecrets: { providerID in
+                            ProviderSecretEnvironment.resolvedSpawnSecrets(
+                                for: providerID,
+                                resolving: KeychainCredentialService())
+                        },
                         resolvePermissionPolicy: { operation in
                             let key: String
                             switch operation {

--- a/Sources/WikiFS/Settings/AgentsSettingsView.swift
+++ b/Sources/WikiFS/Settings/AgentsSettingsView.swift
@@ -382,6 +382,9 @@ private struct ProviderDetailPane: View {
     @Binding var config: AgentProvidersConfig
     let containerDirectory: URL
     let providerServices: any AgentProviderServices
+    /// UI-safe credential authority (#1159): describe + write only — no API
+    /// here can return a stored secret value.
+    let credentials: any CredentialDescribing & CredentialWriting
 
     @State private var label: String
     @State private var commandText: String
@@ -393,6 +396,14 @@ private struct ProviderDetailPane: View {
     @State private var isAvailable: Bool = false
     @State private var modelRefreshState: ModelRefreshState = .idle
     @State private var modelRefreshTask: Task<Void, Never>?
+    /// Write-only credential drafts (#1159), keyed by known secret variable.
+    /// Never preloaded from the credential service.
+    @State private var credentialDrafts: [ProviderSecretEnvironmentVariable: String] = [:]
+    /// Which known secret variables have a stored value (CredentialDescribing).
+    @State private var configuredSecrets: Set<ProviderSecretEnvironmentVariable> = []
+    /// Known secret keys the env editor rejected on the last commit. Names
+    /// only — never values.
+    @State private var rejectedSecretKeys: [String] = []
 
     /// The probe's lifecycle state. Equatable so SwiftUI skips body re-renders
     /// when the state hasn't changed.
@@ -407,12 +418,14 @@ private struct ProviderDetailPane: View {
         provider: AgentProvider,
         config: Binding<AgentProvidersConfig>,
         containerDirectory: URL,
-        providerServices: any AgentProviderServices
+        providerServices: any AgentProviderServices,
+        credentials: (any CredentialDescribing & CredentialWriting)? = nil
     ) {
         self.provider = provider
         self._config = config
         self.containerDirectory = containerDirectory
         self.providerServices = providerServices
+        self.credentials = credentials ?? KeychainCredentialService()
         self._label = State(initialValue: provider.label)
         self._commandText = State(initialValue: provider.command.map(ShellWords.join) ?? "")
         self._envText = State(initialValue: EnvVarText.seed(for: provider))
@@ -427,8 +440,23 @@ private struct ProviderDetailPane: View {
             .padding(.bottom, 20)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .onAppear { refreshAvailability() }
+        .onAppear {
+            refreshAvailability()
+            refreshConfiguredSecrets()
+        }
         .onDisappear { cancelModelRefresh() }
+    }
+
+    private func refreshConfiguredSecrets() {
+        var configured: Set<ProviderSecretEnvironmentVariable> = []
+        for variable in ProviderSecretEnvironmentVariable.allCases {
+            guard let reference = CredentialReference.providerSecret(
+                providerID: provider.id, variable: variable) else { continue }
+            if credentials.describe(reference).isConfigured {
+                configured.insert(variable)
+            }
+        }
+        configuredSecrets = configured
     }
 
     // MARK: - Header
@@ -496,8 +524,94 @@ private struct ProviderDetailPane: View {
             }
 
             environmentSection
+            providerCredentialsSection
         }
         .formStyle(.grouped)
+    }
+
+    // MARK: - Provider credentials (#1159)
+
+    /// One write-only row per known secret environment variable. The field
+    /// never preloads a stored value; saving is explicit; removal is explicit;
+    /// the configured state comes from `CredentialDescribing` (no value).
+    @ViewBuilder
+    private var providerCredentialsSection: some View {
+        Section {
+            ForEach(ProviderSecretEnvironmentVariable.allCases, id: \.self) { variable in
+                credentialRow(variable)
+            }
+        } header: {
+            Text("Credentials")
+        } footer: {
+            Text("API keys live in your Keychain — never in the JSON config or the Environment list above. Enter a key and press Save; press Remove to delete the stored key. Rotation takes effect the next time this provider launches.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func credentialRow(
+        _ variable: ProviderSecretEnvironmentVariable
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack {
+                Text(variable.rawValue)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                if configuredSecrets.contains(variable) {
+                    Label("Configured", systemImage: "checkmark.seal")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("agents.credentials.\(variable.rawValue).status")
+                } else {
+                    Text("Not configured")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .accessibilityIdentifier("agents.credentials.\(variable.rawValue).status")
+                }
+                Spacer()
+                Button("Save") { saveCredential(variable) }
+                    .disabled(CredentialValue.normalized(credentialDrafts[variable]) == nil)
+                    .accessibilityIdentifier("agents.credentials.\(variable.rawValue).save")
+                Button("Remove", role: .destructive) { removeCredential(variable) }
+                    .disabled(!configuredSecrets.contains(variable))
+                    .accessibilityIdentifier("agents.credentials.\(variable.rawValue).remove")
+            }
+            SecureField(
+                "Enter \(variable.rawValue)",
+                text: Binding(
+                    get: { credentialDrafts[variable] ?? "" },
+                    set: { credentialDrafts[variable] = $0 }),
+                prompt: Text(configuredSecrets.contains(variable)
+                             ? "Configured — enter a new value to replace"
+                             : "Enter value"))
+                .font(.system(.body, design: .monospaced))
+                .accessibilityIdentifier("agents.credentials.\(variable.rawValue).field")
+        }
+    }
+
+    /// Explicit write through the UI-safe authority, then clear the draft and
+    /// refresh the configured state.
+    private func saveCredential(_ variable: ProviderSecretEnvironmentVariable) {
+        guard let value = CredentialValue.normalized(credentialDrafts[variable]),
+              let reference = CredentialReference.providerSecret(
+                  providerID: provider.id, variable: variable)
+        else { return }
+        DebugLog.trying("set provider credential \(variable.rawValue)", operation: {
+            try credentials.set(value, for: reference)
+        })
+        credentialDrafts[variable] = ""
+        refreshConfiguredSecrets()
+    }
+
+    /// Explicit removal — a blank untouched field never deletes anything.
+    private func removeCredential(_ variable: ProviderSecretEnvironmentVariable) {
+        guard let reference = CredentialReference.providerSecret(
+            providerID: provider.id, variable: variable) else { return }
+        DebugLog.trying("remove provider credential \(variable.rawValue)", operation: {
+            try credentials.unset(reference)
+        })
+        credentialDrafts[variable] = ""
+        refreshConfiguredSecrets()
     }
 
     /// The provider's default model — used unless an operation pins a different
@@ -570,9 +684,15 @@ private struct ProviderDetailPane: View {
             Text("Environment")
         } footer: {
             VStack(alignment: .leading, spacing: 4) {
-                Text("One KEY=value per line — paste a block of variables directly. Lines starting with # are ignored. Values are used literally: surrounding \"quotes\" are removed, but $VAR references are not expanded. Non-secret configuration only (stored in plain JSON).")
+                Text("One KEY=value per line — paste a block of variables directly. Lines starting with # are ignored. Values are used literally: surrounding \"quotes\" are removed, but $VAR references are not expanded. Non-secret configuration only (stored in plain JSON). API keys belong in the Credentials section below, not here.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if !rejectedSecretKeys.isEmpty {
+                    Text("Ignored secret key\(rejectedSecretKeys.count == 1 ? "" : "s") \(rejectedSecretKeys.joined(separator: ", ")) — store API keys in the Credentials section instead.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .accessibilityIdentifier("agents.env.rejectedSecrets")
+                }
                 if !malformed.isEmpty {
                     Text("Ignoring \(malformed.count) line\(malformed.count == 1 ? "" : "s") without a KEY=value: \(malformed.joined(separator: ", "))")
                         .font(.caption)
@@ -588,11 +708,19 @@ private struct ProviderDetailPane: View {
     /// back into `config.providers` (preserving `enabled`/`isDefault`, which the
     /// toggle and "Make Default" own), then persist. Called on every field
     /// change — the sidecar is tiny and written atomically.
+    ///
+    /// #1159 rejection boundary: known secret variables typed into the
+    /// Environment editor are dropped here (and named in the footer) — they
+    /// can only be stored through the Credentials controls.
     private func commitProviderConfig() {
         guard let idx = config.providers.firstIndex(where: { $0.id == provider.id }) else { return }
         let existing = config.providers[idx]
         let cleanLabel = label.trimmingCharacters(in: .whitespaces)
-        let env = EnvVarText.parse(envText)
+        let parsed = EnvVarText.parse(envText)
+        rejectedSecretKeys = parsed.keys
+            .filter(ProviderSecretEnvironmentVariable.isKnownSecret)
+            .sorted()
+        let env = ProviderSecretEnvironment.strippingSecrets(from: parsed)
         let command = ShellWords.split(commandText)
         var providers = config.providers
         providers[idx] = AgentProvider(

--- a/Sources/WikiFS/Settings/EnvVarHints.swift
+++ b/Sources/WikiFS/Settings/EnvVarHints.swift
@@ -10,6 +10,11 @@ import WikiFSCore
 /// (PATH, HOME) are NOT listed because the app already injects/manages those
 /// (`ACPBackend.buildAgentEnv` owns WIKI_DB / WIKICTL / PATH).
 ///
+/// #1159: API-key variables are NO LONGER suggested here. Known secret
+/// variables (`ProviderSecretEnvironmentVariable`) are rejected by the env-var
+/// editor and surface through the provider credential controls instead — an
+/// env hint must never invite plaintext secret entry.
+///
 /// PURE + Sendable so it is unit-testable without rendering.
 struct EnvVarHints {
 
@@ -23,38 +28,30 @@ struct EnvVarHints {
     /// when there are no known hints (the editor renders no hint line). The
     /// provider id follows `AgentProvider.id` / `KnownACPAgent.id` — e.g.
     /// "claude-acp", "gemini", "hermes", "codex", "custom".
+    ///
+    /// Every returned key is guaranteed non-secret: the factory filters out
+    /// `ProviderSecretEnvironmentVariable` names so a future edit cannot
+    /// re-introduce an API-key suggestion by accident.
     static func hints(forProviderID id: String) -> [Hint]? {
+        let suggestions: [Hint]?
         switch id {
         case "claude-acp":
-            return [
+            suggestions = [
                 .init(key: "CLAUDE_CODE_EXECUTABLE",
                       description: "Path to the `claude` binary when it is not on PATH."),
-                .init(key: "ANTHROPIC_API_KEY",
-                      description: "Anthropic API key."),
             ]
         case "gemini":
-            return [
-                .init(key: "GEMINI_API_KEY",
-                      description: "Google AI API key."),
+            suggestions = [
                 .init(key: "GOOGLE_GENAI_USE_VERTEXAI",
                       description: "Set to \"1\" to use Vertex AI instead of the Gemini API."),
             ]
         case "codex":
-            return [
+            suggestions = [
                 .init(key: "CODEX_PATH",
                       description: "Path to the `codex` binary when it is not on PATH."),
-                .init(key: "OPENAI_API_KEY",
-                      description: "OpenAI API key."),
-            ]
-        case "opencode":
-            return [
-                .init(key: "OPENAI_API_KEY",
-                      description: "OpenAI API key."),
-                .init(key: "ANTHROPIC_API_KEY",
-                      description: "Anthropic API key."),
             ]
         case "goose":
-            return [
+            suggestions = [
                 .init(key: "GOOSE_PROVIDER",
                       description: "The model provider Goose should use (e.g. \"anthropic\", \"openai\")."),
                 .init(key: "GOOSE_MODEL",
@@ -64,10 +61,12 @@ struct EnvVarHints {
              "codewhale", "kilo":
             // Known catalogs with no app-specific env hints yet — return nil so
             // the editor shows the generic guidance line instead.
-            return nil
+            suggestions = nil
         default:
             // Custom / unknown provider ids: no provider-specific hints.
-            return nil
+            suggestions = nil
         }
+        // Contract: hints never suggest a known secret variable.
+        return suggestions?.filter { !ProviderSecretEnvironmentVariable.isKnownSecret($0.key) }
     }
 }

--- a/Sources/WikiFS/Settings/ZoteroSettingsView.swift
+++ b/Sources/WikiFS/Settings/ZoteroSettingsView.swift
@@ -8,15 +8,27 @@ import WikiFSCore
 /// failures via `.alert`, mirroring `WikiFSApp`'s `FileProviderSetupWarning`
 /// pattern.
 ///
-/// Changes persist immediately via `.onChange(of:)` — no explicit save step.
-/// The Keychain-backed API key is written on every keystroke; the config JSON
-/// is written whenever the library ID or directory override change.
+/// # Credential authority (#1159, plans/credential-service.md)
+/// The API key is WRITE-ONLY from this view's perspective: the field starts
+/// blank, never preloads the stored key, and `credentials` (a
+/// `CredentialDescribing & CredentialWriting` handle) has NO method that can
+/// return a value. Saving is explicit (Save Key button); removal is explicit
+/// (Remove Key) — an untouched blank field no longer means "delete".
+/// "Test Connection" resolves the stored key OUTSIDE the view through the
+/// host-owned `verifyConnection` action and returns only a redacted outcome.
+///
+/// Library ID and directory override persist immediately via `.onChange(of:)`.
 struct ZoteroSettingsView: View {
     let containerDirectory: URL
-    let credentialStore: any ZoteroCredentialStore
-    let fetcher: any ZoteroClient.RequestFetcher
+    /// UI-safe credential authority: describe (configured state) + write.
+    /// Deliberately NOT a `CredentialResolving` — the view cannot read values.
+    let credentials: any CredentialDescribing & CredentialWriting
+    /// Host-owned privileged action: resolves the stored key outside the view
+    /// and verifies it. Returns `nil` on success or a redacted failure message.
+    let verifyConnection: @Sendable (_ libraryID: String) async -> String?
 
     @State private var apiKeyText = ""
+    @State private var isKeyConfigured = false
     @State private var libraryIDText = ""
     @State private var zoteroDirText = ""
     @State private var testPhase: TestPhase = .idle
@@ -30,23 +42,38 @@ struct ZoteroSettingsView: View {
 
     init(
         containerDirectory: URL,
-        credentialStore: any ZoteroCredentialStore = KeychainZoteroCredentialStore(),
+        credentials: (any CredentialDescribing & CredentialWriting)? = nil,
+        verifyConnection: (@Sendable (_ libraryID: String) async -> String?)? = nil,
         fetcher: any ZoteroClient.RequestFetcher = URLSessionZoteroFetcher()
     ) {
         self.containerDirectory = containerDirectory
-        self.credentialStore = credentialStore
-        self.fetcher = fetcher
+        self.credentials = credentials ?? KeychainCredentialService()
+        // Default action: host-owned privileged resolution (see
+        // HostCredentialActions) — the view itself never resolves a value.
+        self.verifyConnection = verifyConnection
+            ?? HostCredentialActions.verifyZotero(fetcher: fetcher)
     }
 
     var body: some View {
         Form {
             Section {
-                SecureField("API Key", text: $apiKeyText)
+                SecureField("API Key", text: $apiKeyText, prompt: Text(isKeyConfigured ? "Configured — enter a new key to replace" : "Enter API key"))
+                    .accessibilityIdentifier("zotero.apiKey.field")
+                HStack {
+                    configuredStatusLabel
+                    Spacer()
+                    Button("Save Key") { saveCredential() }
+                        .disabled(CredentialValue.normalized(apiKeyText) == nil)
+                        .accessibilityIdentifier("zotero.apiKey.save")
+                    Button("Remove Key", role: .destructive) { removeCredential() }
+                        .disabled(!isKeyConfigured)
+                        .accessibilityIdentifier("zotero.apiKey.remove")
+                }
                 TextField("Library ID", text: $libraryIDText)
             } header: {
                 Text("Zotero Account")
             } footer: {
-                Text("Generate a key at zotero.org/settings/keys. Your library ID is the numeric userID shown on that page.")
+                Text("Generate a key at zotero.org/settings/keys. Your library ID is the numeric userID shown on that page. The key is stored in your Keychain and is never shown after you save it.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -83,9 +110,23 @@ struct ZoteroSettingsView: View {
         } message: { message in
             Text(message)
         }
-        .onChange(of: apiKeyText) { _, _ in saveCredential() }
         .onChange(of: libraryIDText) { _, _ in saveConfig() }
         .onChange(of: zoteroDirText) { _, _ in saveConfig() }
+    }
+
+    /// Configured state from `CredentialDescribing` — never a value.
+    private var configuredStatusLabel: some View {
+        Group {
+            if isKeyConfigured {
+                Label("Key configured", systemImage: "checkmark.seal")
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("No key stored")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption)
+        .accessibilityIdentifier("zotero.apiKey.status")
     }
 
     // MARK: - Test Connection row
@@ -93,7 +134,8 @@ struct ZoteroSettingsView: View {
     private var testConnectionRow: some View {
         HStack(spacing: 10) {
             Button("Test Connection") { testConnection() }
-                .disabled(testPhase == .testing || libraryIDText.isEmpty || apiKeyText.isEmpty)
+                .disabled(testPhase == .testing || libraryIDText.isEmpty || !isKeyConfigured)
+                .accessibilityIdentifier("zotero.testConnection")
             switch testPhase {
             case .testing:
                 ProgressView().controlSize(.small)
@@ -122,14 +164,33 @@ struct ZoteroSettingsView: View {
     // MARK: - Load / save
 
     private func load() {
-        apiKeyText = credentialStore.apiKey() ?? ""
+        // Write-only: the key field starts BLANK. Only the configured state
+        // is read back (CredentialDescribing — no value surface).
+        isKeyConfigured = credentials.describe(.zoteroAPIKey()).isConfigured
         let config = ZoteroConfig.load(from: containerDirectory)
         libraryIDText = config.libraryID ?? ""
         zoteroDirText = config.zoteroDirOverride ?? ""
     }
 
+    /// Explicit save: normalized write (whitespace-only = no-op), then clear
+    /// the draft and refresh the configured state.
     private func saveCredential() {
-        DebugLog.trying("set Zotero API key", operation: { try credentialStore.setAPIKey(apiKeyText.isEmpty ? nil : apiKeyText) })
+        let value = CredentialValue.normalized(apiKeyText)
+        guard value != nil else { return }
+        DebugLog.trying("set Zotero API key", operation: {
+            try credentials.set(value, for: .zoteroAPIKey())
+        })
+        apiKeyText = ""
+        isKeyConfigured = credentials.describe(.zoteroAPIKey()).isConfigured
+    }
+
+    /// Explicit removal — an untouched blank field never deletes anything.
+    private func removeCredential() {
+        DebugLog.trying("remove Zotero API key", operation: {
+            try credentials.unset(.zoteroAPIKey())
+        })
+        apiKeyText = ""
+        isKeyConfigured = credentials.describe(.zoteroAPIKey()).isConfigured
     }
 
     private func saveConfig() {
@@ -148,20 +209,17 @@ struct ZoteroSettingsView: View {
         zoteroDirText = url.path
     }
 
+    /// Host-owned action: the view never sees the key; the outcome is only
+    /// connected / failed-with-redacted-message.
     private func testConnection() {
-        let config = ZoteroClient.Config(
-            libraryID: libraryIDText.trimmingCharacters(in: .whitespacesAndNewlines),
-            apiKey: apiKeyText)
-        let client = ZoteroClient(config: config, fetcher: fetcher)
+        let libraryID = libraryIDText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let action = verifyConnection
         testPhase = .testing
         Task {
-            do {
-                try await client.verifyConnection()
+            if let failureMessage = await action(libraryID) {
+                testPhase = .failed(failureMessage)
+            } else {
                 testPhase = .succeeded
-            } catch {
-                let message = (error as? ZoteroClient.ZoteroError)?.errorDescription
-                    ?? error.localizedDescription
-                testPhase = .failed(message)
             }
         }
     }

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -17,7 +17,14 @@ import WikiFSTypes
 /// is unambiguous (it always targets the visible section).
 struct ExtractionSettingsView: View {
     let containerDirectory: URL
-    let credentialStore: any ExtractionCredentialStore
+    /// UI-safe credential authority (#1159): describe (configured state) +
+    /// write for the Docling token. NOT a `CredentialResolving` — the view
+    /// cannot read a secret value, only store or remove one.
+    let credentials: any CredentialDescribing & CredentialWriting
+    /// Host-owned privileged action for Test Connection: resolves the stored
+    /// Docling token OUTSIDE the view and verifies the endpoint. Returns
+    /// `nil` on success or a redacted failure message.
+    let verifyDoclingConnection: @Sendable (_ endpoint: String) async -> String?
     let fetcher: any HTTPRequestFetcher
     /// Provides the enabled-provider list for the ACP backend picker.
     let launcher: AgentLauncher
@@ -44,7 +51,10 @@ struct ExtractionSettingsView: View {
     @State private var routeSelections: [String: ExtractorRouteSettingsSelection] = [:]
     @State private var acpProviderSelection: String
     @State private var doclingEndpointText: String
-    @State private var doclingTokenText: String
+    /// Write-only token draft (#1159): starts blank, never preloads the
+    /// stored token. `doclingTokenConfigured` drives the status + Remove.
+    @State private var doclingTokenText = ""
+    @State private var doclingTokenConfigured = false
     @State private var doclingTest = TestPhase.idle
     // Issue #799 PR1: Podcast backend draft (optional — nil = no default yet,
     // user is prompted to pick on first transcription). Seeded from
@@ -65,7 +75,8 @@ struct ExtractionSettingsView: View {
     init(
         containerDirectory: URL,
         launcher: AgentLauncher,
-        credentialStore: any ExtractionCredentialStore = KeychainExtractionCredentialStore(),
+        credentials: (any CredentialDescribing & CredentialWriting)? = nil,
+        verifyDoclingConnection: (@Sendable (_ endpoint: String) async -> String?)? = nil,
         fetcher: any HTTPRequestFetcher = URLSessionRequestFetcher(),
         packageSnapshot: (@Sendable () async -> ExtractorPackageSettingsSnapshot)? = nil,
         importPackage: (@Sendable (URL) async -> ExtractorPackageMutationOutcome)? = nil,
@@ -73,7 +84,11 @@ struct ExtractionSettingsView: View {
     ) {
         self.containerDirectory = containerDirectory
         self.launcher = launcher
-        self.credentialStore = credentialStore
+        self.credentials = credentials ?? KeychainCredentialService()
+        // Default action: host-owned privileged resolution (see
+        // HostCredentialActions) — the view itself never resolves a value.
+        self.verifyDoclingConnection = verifyDoclingConnection
+            ?? HostCredentialActions.verifyDocling(fetcher: fetcher)
         self.fetcher = fetcher
         self.packageSnapshot = packageSnapshot
         self.importPackage = importPackage
@@ -81,10 +96,10 @@ struct ExtractionSettingsView: View {
 
         // Seed the drafts once, at construction — so there's no onAppear race
         // where an `.onChange` fires before the loaded values are in place.
+        // The token draft is deliberately NOT seeded (#1159): write-only.
         let config = ExtractionConfig.load(from: containerDirectory)
         _acpProviderSelection = State(initialValue: ExtractorSettingsSelectionMapping.acpProviderSelection(from: config))
         _doclingEndpointText = State(initialValue: config.doclingServeEndpoint ?? "")
-        _doclingTokenText = State(initialValue: credentialStore.secret(.doclingServeToken) ?? "")
         _draftPodcastBackend = State(initialValue: config.podcastBackend)
         _packageModel = State(initialValue: ExtractorPackageSettingsModel(
             loadSnapshot: packageSnapshot,
@@ -141,6 +156,7 @@ struct ExtractionSettingsView: View {
         // Async model mutations stay on the main actor; the load closure hops
         // to the process registry off-main and returns a value snapshot.
         .task {
+            doclingTokenConfigured = refreshDoclingTokenState()
             await packageModel.refresh()
             rebuildRouteRows()
         }
@@ -601,13 +617,34 @@ struct ExtractionSettingsView: View {
         Section {
             TextField("Endpoint", text: $doclingEndpointText, prompt: Text(ExtractionConfig.defaultDoclingServeEndpoint))
                 .onChange(of: doclingEndpointText) { persistAll() }
-            SecureField("API Token (optional)", text: $doclingTokenText)
-                .onChange(of: doclingTokenText) { persistAll() }
+            // Write-only token entry (#1159): the field starts blank and
+            // never shows the stored token; Save/Remove are explicit.
+            SecureField("API Token (optional)", text: $doclingTokenText, prompt: Text(doclingTokenConfigured ? "Configured — enter a new token to replace" : "Enter token"))
+                .accessibilityIdentifier("extraction.docling.token.field")
+            HStack {
+                Group {
+                    if doclingTokenConfigured {
+                        Label("Token configured", systemImage: "checkmark.seal")
+                    } else {
+                        Text("No token stored")
+                    }
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("extraction.docling.token.status")
+                Spacer()
+                Button("Save Token") { saveDoclingToken() }
+                    .disabled(CredentialValue.normalized(doclingTokenText) == nil)
+                    .accessibilityIdentifier("extraction.docling.token.save")
+                Button("Remove Token", role: .destructive) { removeDoclingToken() }
+                    .disabled(!doclingTokenConfigured)
+                    .accessibilityIdentifier("extraction.docling.token.remove")
+            }
             testConnectionRow(phase: $doclingTest, action: testDocling)
         } header: {
             Text("Docling Serve")
         } footer: {
-            Text("Run `docling-serve run` locally, then point this at its base URL. Private to your network. The token is only needed if the server was started with DOCLING_SERVE_API_KEY.")
+            Text("Run `docling-serve run` locally, then point this at its base URL. Private to your network. The token is only needed if the server was started with DOCLING_SERVE_API_KEY; it is stored in your Keychain and never shown after you save it.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -649,15 +686,44 @@ struct ExtractionSettingsView: View {
 
     // MARK: - Auto-save
 
-    /// Persist every non-secret draft into `ExtractionConfig` and every secret
-    /// into Keychain. Called from each field's `.onChange`, so the panel is
-    /// always up to date — no Save button, no lost-on-close window.
+    /// Persist every non-secret draft into `ExtractionConfig`. Called from
+    /// each field's `.onChange`, so the panel is always up to date — no Save
+    /// button, no lost-on-close window. The Docling token is NOT here: it is
+    /// write-only (#1159) with explicit Save/Remove buttons.
     private func persistAll() {
         var config = ExtractionConfig.load(from: containerDirectory)
         writeConfig(into: &config)
         DebugLog.trying("save extraction config", operation: { try config.save(to: containerDirectory) })
+    }
 
-        DebugLog.trying("set Docling token", operation: { try credentialStore.setSecret(doclingTokenText.isEmpty ? nil : doclingTokenText, .doclingServeToken) })
+    /// Explicit token save (write-only authority): normalized write, then
+    /// clear the draft and refresh the configured state.
+    private func saveDoclingToken() {
+        guard let value = CredentialValue.normalized(doclingTokenText),
+              let reference = CredentialReference.extraction(.doclingServeToken)
+        else { return }
+        DebugLog.trying("set Docling token", operation: {
+            try credentials.set(value, for: reference)
+        })
+        doclingTokenText = ""
+        doclingTokenConfigured = refreshDoclingTokenState()
+    }
+
+    /// Explicit removal — an untouched blank field never deletes the token.
+    private func removeDoclingToken() {
+        guard let reference = CredentialReference.extraction(.doclingServeToken) else { return }
+        DebugLog.trying("remove Docling token", operation: {
+            try credentials.unset(reference)
+        })
+        doclingTokenText = ""
+        doclingTokenConfigured = refreshDoclingTokenState()
+    }
+
+    private func refreshDoclingTokenState() -> Bool {
+        guard let reference = CredentialReference.extraction(.doclingServeToken) else {
+            return false
+        }
+        return credentials.describe(reference).isConfigured
     }
 
     /// Write every non-secret draft into `config`. The route selections are
@@ -672,17 +738,17 @@ struct ExtractionSettingsView: View {
 
     // MARK: - Test Connection
 
+    /// Host-owned action: the view passes only the endpoint; the stored token
+    /// resolves OUTSIDE the view and the outcome is redacted.
     private func testDocling() {
         doclingTest = .testing
         let endpoint = doclingEndpointText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let client = DoclingServeClient(
-            endpoint: endpoint, apiToken: doclingTokenText, fetcher: fetcher)
+        let action = verifyDoclingConnection
         Task {
-            do {
-                try await client.verifyConnection()
+            if let failureMessage = await action(endpoint) {
+                doclingTest = .failed(failureMessage)
+            } else {
                 doclingTest = .succeeded
-            } catch {
-                doclingTest = .failed((error as? LocalizedError)?.errorDescription ?? error.localizedDescription)
             }
         }
     }

--- a/Sources/WikiFS/Sources/HostCredentialActions.swift
+++ b/Sources/WikiFS/Sources/HostCredentialActions.swift
@@ -1,0 +1,67 @@
+import Foundation
+import WikiFSCore
+
+/// Host-owned privileged credential actions for Settings (issue #1159,
+/// plans/credential-service.md). A Settings VIEW may request an operation by
+/// typed reference, but the value resolution happens HERE — outside the view
+/// — and only a redacted outcome (nil = success, message = failure) crosses
+/// back into SwiftUI. `CredentialSettingsHostedTests` enforces that the view
+/// files contain no value-returning credential calls; these actions are the
+/// sanctioned seam.
+enum HostCredentialActions {
+
+    /// Verify the stored Zotero API key against the Zotero API. Resolves
+    /// `.zoteroAPIKey()` in the privileged layer and returns only a redacted
+    /// outcome.
+    static func verifyZotero(
+        fetcher: any ZoteroClient.RequestFetcher
+    ) -> @Sendable (_ libraryID: String) async -> String? {
+        { libraryID in
+            let credentials = KeychainCredentialService()
+            do {
+                let resolved = try credentials.resolve(.zoteroAPIKey())
+                let config = ZoteroClient.Config(
+                    libraryID: libraryID, apiKey: resolved.value)
+                let client = ZoteroClient(config: config, fetcher: fetcher)
+                try await client.verifyConnection()
+                return nil
+            } catch CredentialStoreError.notConfigured {
+                return "No API key is stored. Save a key first."
+            } catch {
+                return (error as? ZoteroClient.ZoteroError)?.errorDescription
+                    ?? error.localizedDescription
+            }
+        }
+    }
+
+    /// Verify Docling Serve connectivity with the STORED token (resolved in
+    /// the privileged layer; never handed to the caller). Absent token → an
+    /// anonymous probe, matching the optional-token server mode.
+    static func verifyDocling(
+        fetcher: any HTTPRequestFetcher
+    ) -> @Sendable (_ endpoint: String) async -> String? {
+        { endpoint in
+            let credentials = KeychainCredentialService()
+            let token: String
+            do {
+                guard let reference = CredentialReference.extraction(
+                    ExtractionSecret.doclingServeToken)
+                else { return "Could not read the stored token." }
+                token = try credentials.resolve(reference).value
+            } catch CredentialStoreError.notConfigured {
+                token = ""
+            } catch {
+                return "Could not read the stored token."
+            }
+            let client = DoclingServeClient(
+                endpoint: endpoint, apiToken: token, fetcher: fetcher)
+            do {
+                try await client.verifyConnection()
+                return nil
+            } catch {
+                return (error as? LocalizedError)?.errorDescription
+                    ?? error.localizedDescription
+            }
+        }
+    }
+}

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -225,7 +225,9 @@ struct ContentView: View {
 
     private var isZoteroConfigured: Bool {
         ZoteroConfig.load(from: zoteroContainerDirectory).isConfigured
-            && KeychainZoteroCredentialStore().apiKey() != nil
+            // #1159: presence check goes through the UI-safe describing
+            // authority — no value is read here.
+            && KeychainCredentialService().describe(.zoteroAPIKey()).isConfigured
     }
 
     /// The active wiki's configured home page, if any (issue #280). `nil` hides

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -163,6 +163,24 @@ struct WikiFSApp: App {
         // (tests / fresh clones) and idempotent in production. See
         // plans/keychain-sharing.md.
         KeychainSecretStore.migrateLegacyItemsToDataProtection()
+        // One-shot (#1159): move legacy plaintext provider API keys out of
+        // `agent-providers.json` into the shared credential service (Keychain).
+        // App-owned: runs under the sidecar store's cross-process lock, never
+        // deletes a sidecar value before Keychain holds it, and preserves
+        // plaintext when Keychain already holds a DIFFERENT value (bounded
+        // conflict). Idempotent — see plans/credential-service.md.
+        let providerConfigStore = AgentProvidersConfigStore(directory: directory)
+        Task.detached(priority: .utility) {
+            let report = await AgentProviderCredentialMigrator.migrateIfNeeded(
+                directory: directory,
+                store: providerConfigStore,
+                credentials: KeychainCredentialService())
+            if !report.isClean {
+                let conflicts = report.conflicts + report.failures + report.unmappable
+                DebugLog.config(
+                    "Provider credential migration needs attention for \(conflicts.count) entr(y/ies); plaintext preserved.")
+            }
+        }
         containerDirectory = directory
         // Populate wikis BEFORE handing the registry to @State so SwiftUI's
         // first render sees a non-empty list.  activateNow: false means

--- a/Sources/WikiFSCore/Core/AgentProvider.swift
+++ b/Sources/WikiFSCore/Core/AgentProvider.swift
@@ -30,6 +30,14 @@ public struct AgentProvider: Codable, Equatable, Sendable, Identifiable {
     public var command: [String]?
 
     /// Extra environment merged into the spawn (after app-owned keys).
+    ///
+    /// #1159: NON-SECRET configuration only. Known API-key variables
+    /// (`ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY` — see
+    /// `ProviderSecretEnvironmentVariable`) are stripped at decode, at the
+    /// write boundary, and rejected by the Settings editor. They live in the
+    /// Keychain under provider-scoped `CredentialReference.providerSecret`
+    /// references and are resolved into spawn hints by the trusted host at
+    /// preparation time. See `plans/credential-service.md`.
     public var env: [String: String]
 
     /// Whether the provider appears in the active set. The launcher only ever

--- a/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
+++ b/Sources/WikiFSCore/Core/AgentProvidersConfig.swift
@@ -177,7 +177,11 @@ private actor AgentProvidersConfigInProcessGate {
 /// **Secrets:** the API key for an ACP provider lives in the Keychain via
 /// `ACPCredentialStore`, keyed by provider `id` — it is NEVER in this JSON file.
 /// This mirrors the existing `ACPAgentConfig` (plain prefs) +
-/// `KeychainACPCredentialStore` (secret) split.
+/// `KeychainACPCredentialStore` (secret) split. #1159 extends this to the
+/// provider's `env` map: known API-key variables are stripped at decode and
+/// at every write boundary (`ProviderSecretEnvironmentVariable`), migrate to
+/// Keychain via `AgentProviderCredentialMigrator`, and resolve into spawn
+/// hints only in the trusted host (see `plans/credential-service.md`).
 ///
 /// **Per-provider model discovery (#329):** two extra secrets-free caches live
 /// here so the chat-composer model picker can list each provider's models and
@@ -344,11 +348,18 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
     /// - At most one `isDefault`: the FIRST one keeps it, the rest are
     ///   demoted.
     /// - If none is default, the FIRST ENABLED provider is promoted.
+    /// - Known secret environment variables (`ProviderSecretEnvironmentVariable`)
+    ///   are stripped from every provider's `env` (#1159): this is the decode
+    ///   + value-mutation funnel, so a legacy plaintext key in the file can
+    ///   never resurface as in-memory state that a later save would persist.
+    ///   The one-shot `AgentProviderCredentialMigrator` moves legacy values
+    ///   into Keychain at app launch.
     static func normalized(_ providers: [AgentProvider]) -> [AgentProvider] {
         if providers.isEmpty {
             return [.claudeAcpDefault]
         }
-        var list = providers
+        let stripped = ProviderSecretEnvironment.strippingSecrets(from: providers).providers
+        var list = stripped
         // Single-default: keep the first `isDefault == true`, demote the rest.
         var sawDefault = false
         list = list.map { p in
@@ -913,11 +924,22 @@ public struct AgentProvidersConfig: JSONSidecarConfig {
 
     /// Writes the JSON payload without emitting notifications. This is the store
     /// seam; application code must use `AgentProvidersConfigStore` instead.
+    ///
+    /// #1159 write boundary: known secret environment variables are stripped
+    /// immediately before encoding, so an in-memory mutation that smuggled a
+    /// plaintext API key into `provider.env` still cannot reach the disk.
+    /// Only the stripped KEY NAMES are logged — never values.
     public func writeAtomically(to directory: URL) throws {
+        let scrubbed = ProviderSecretEnvironment.strippingSecrets(from: providers)
+        for name in scrubbed.strippedKeyNames {
+            DebugLog.store(
+                "AgentProvidersConfig: stripped plaintext secret from sidecar at write: \(name)")
+        }
+        let payload = scrubbed.providers.isEmpty ? self : replacingProviders(scrubbed.providers)
         let url = directory.appendingPathComponent(Self.fileName, isDirectory: false)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(self)
+        let data = try encoder.encode(payload)
         try data.write(to: url, options: .atomic)
     }
 

--- a/Sources/WikiFSCore/Core/CredentialService.swift
+++ b/Sources/WikiFSCore/Core/CredentialService.swift
@@ -1,0 +1,282 @@
+import Foundation
+import WikiFSTypes
+
+// Credential-location catalog (issue #1159, plans/credential-service.md).
+// Maps each typed `CredentialReference` to its PHYSICAL Keychain
+// service/account pair. The existing ACP, Extraction, and Zotero pairs are
+// compatibility contracts: the shared service reads and writes them in place
+// and NEVER copies or renames those items merely because the service ships.
+// Any reference outside the legacy mapping lands under the shared
+// `org.sockpuppet.WikiFS.credentials` service, with the validated reference
+// itself as the account.
+//
+// This file also hosts the typed reference factories for the legacy domains —
+// keeping WikiFSTypes domain-neutral (AC.2) while call sites never concatenate
+// unchecked raw strings into references.
+
+/// A physical generic-password Keychain location (service + account).
+public struct CredentialKeychainLocation: Hashable, Sendable, CustomStringConvertible {
+    public let service: String
+    public let account: String
+
+    public init(service: String, account: String) {
+        self.service = service
+        self.account = account
+    }
+
+    public var description: String { "\(service)::\(account)" }
+}
+
+/// The host-owned mapping from typed references to Keychain locations.
+public enum CredentialLocations {
+
+    /// The Keychain service for credentials first created through the shared
+    /// service (no legacy location). The account is the validated reference.
+    public static let sharedCredentialService = "org.sockpuppet.WikiFS.credentials"
+
+    // Legacy services — exact existing pairs, unchanged (AC.3).
+    static let acpService = "org.sockpuppet.WikiFS.acp"
+    static let extractionService = "org.sockpuppet.WikiFS.extraction"
+    static let zoteroService = "org.sockpuppet.WikiFS.zotero"
+
+    /// Map a reference to its physical location.
+    public static func location(for reference: CredentialReference) -> CredentialKeychainLocation {
+        let labels = reference.labels
+        let second = labels.count > 1 ? labels[1] : nil
+        let third = labels.count > 2 ? labels[2] : nil
+        if labels.first == "acp", second == "agent-api-key", third == nil {
+            return CredentialKeychainLocation(
+                service: acpService, account: "acp-agent-api-key")
+        }
+        if labels.first == "acp", second == "provider", let providerID = third {
+            return CredentialKeychainLocation(
+                service: acpService, account: "acp-provider:\(providerID)")
+        }
+        if labels.first == "extraction", third == nil {
+            switch second {
+            case "anthropic-api-key":
+                return CredentialKeychainLocation(
+                    service: extractionService, account: "anthropic-api-key")
+            case "gemini-api-key":
+                return CredentialKeychainLocation(
+                    service: extractionService, account: "gemini-api-key")
+            case "docling-serve-token":
+                return CredentialKeychainLocation(
+                    service: extractionService, account: "docling-serve-token")
+            default:
+                break
+            }
+        }
+        if labels.first == "zotero", second == "api-key", third == nil {
+            return CredentialKeychainLocation(
+                service: zoteroService, account: "zotero-api-key")
+        }
+        return CredentialKeychainLocation(
+            service: sharedCredentialService, account: reference.rawValue)
+    }
+}
+
+// MARK: - Typed reference factories (legacy + provider domains)
+
+extension CredentialReference {
+
+    /// Builds a reference from a FIXED list of literals that provably satisfy
+    /// the grammar. A failing literal is a programming error, so this
+    /// crashes loudly rather than returning an optional.
+    private static func fixed(_ labels: [String]) -> CredentialReference {
+        guard let reference = CredentialReference(validatingLabels: labels) else {
+            preconditionFailure("static credential labels must satisfy the reference grammar: \(labels.joined(separator: "."))")
+        }
+        return reference
+    }
+
+    /// The ACP agent's legacy single-key credential
+    /// (`org.sockpuppet.WikiFS.acp` / `acp-agent-api-key`).
+    public static func acpAgent() -> CredentialReference {
+        fixed(["acp", "agent-api-key"])
+    }
+
+    /// A provider-scoped ACP API-key credential, mapped to the legacy
+    /// `acp-provider:<id>` account. Returns `nil` when the provider id cannot
+    /// form a valid reference label — callers (the adapters) keep their
+    /// legacy direct path for such ids so no existing secret is orphaned.
+    public static func acpProvider(_ id: ProviderID) -> CredentialReference? {
+        CredentialReference(validatingLabels: ["acp", "provider", id.rawValue])
+    }
+
+    /// An extraction secret credential (Anthropic, Gemini, Docling token) at
+    /// its legacy extraction-service location.
+    public static func extraction(_ key: String) -> CredentialReference? {
+        CredentialReference(validatingLabels: ["extraction", key])
+    }
+
+    /// The Zotero API-key credential at its legacy zotero-service location.
+    public static func zoteroAPIKey() -> CredentialReference {
+        fixed(["zotero", "api-key"])
+    }
+}
+
+// MARK: - Keychain-backed service
+
+/// The production `CredentialService`: the shared facade over
+/// `KeychainSecretStore` (the only file allowed to call Security). Every
+/// operation resolves its reference through `CredentialLocations` first, so
+/// legacy items are read and written exactly where they always lived.
+///
+/// Diagnostics are bounded and value-free: failures log the operation and
+/// reference, never a secret. The type is stateless, hence `Sendable`.
+public struct KeychainCredentialService: CredentialService {
+
+    public init() {}
+
+    // MARK: CredentialDescribing
+
+    public func describe(_ reference: CredentialReference) -> CredentialInfo {
+        let location = CredentialLocations.location(for: reference)
+        do {
+            let value = try KeychainSecretStore.readOrThrow(
+                service: location.service, account: location.account)
+            return CredentialInfo(
+                reference: reference,
+                isConfigured: value != nil,
+                source: .keychain,
+                isWritable: true)
+        } catch {
+            // A read failure is surfaced as not-configured to UI callers via
+            // `describe`'s no-throw contract; privileged `resolve` callers get
+            // the typed error. Bounded, value-free diagnostic:
+            DebugLog.config(
+                "CredentialService: describe failed for \(reference.rawValue): \(error)")
+            return CredentialInfo(
+                reference: reference,
+                isConfigured: false,
+                source: .keychain,
+                isWritable: true)
+        }
+    }
+
+    public func describe(
+        _ references: [CredentialReference]
+    ) -> [CredentialReference: CredentialInfo] {
+        let bounded = references.prefix(maximumDescribeBatchSize)
+        var result: [CredentialReference: CredentialInfo] = [:]
+        result.reserveCapacity(bounded.count)
+        for reference in bounded {
+            result[reference] = describe(reference)
+        }
+        return result
+    }
+
+    public var maximumDescribeBatchSize: Int { 64 }
+
+    // MARK: CredentialWriting
+
+    public func set(_ value: String?, for reference: CredentialReference) throws {
+        let normalized = CredentialValue.normalized(value)
+        let location = CredentialLocations.location(for: reference)
+        do {
+            try KeychainSecretStore.write(
+                service: location.service, account: location.account,
+                value: normalized,
+                error: { operation, status in
+                    CredentialStoreError.writeFailed(operation: operation, status: status)
+                })
+        } catch let error as CredentialStoreError {
+            throw error
+        } catch {
+            throw CredentialStoreError.writeFailed(operation: "write", status: -1)
+        }
+    }
+
+    public func unset(_ reference: CredentialReference) throws {
+        try set(nil, for: reference)
+    }
+
+    // MARK: CredentialResolving
+
+    public func resolve(_ reference: CredentialReference) throws -> ResolvedCredential {
+        let location = CredentialLocations.location(for: reference)
+        guard let value = try KeychainSecretStore.readOrThrow(
+            service: location.service, account: location.account)
+        else { throw CredentialStoreError.notConfigured(reference) }
+        return ResolvedCredential(reference: reference, value: value, source: .keychain)
+    }
+}
+
+// MARK: - In-memory service (tests + previews)
+
+/// Concurrency-safe in-memory `CredentialService` for tests and previews.
+/// NOT for production use.
+///
+/// # Internal-lock safety proof (Swift 6 Sendable)
+/// The single mutable field `values` is guarded by `lock` on EVERY access —
+/// each accessor acquires the lock for its whole body and no accessor calls
+/// another accessor while holding it (no re-entrancy), and no escape of the
+/// guarded storage exists. The class is `final`. That is exactly the
+/// lock-discipline the type checker cannot see, documented here per
+/// plans/credential-service.md; the `@unchecked` scope is limited to this
+/// type.
+// swiftlint:disable:next unchecked_sendable
+public final class InMemoryCredentialService: CredentialService, @unchecked Sendable {
+
+    private var values: [CredentialReference: String] = [:]
+    private let lock = NSLock()
+    private let writable: Bool
+
+    public init(writable: Bool = true) {
+        self.writable = writable
+    }
+
+    public convenience init(seed: [CredentialReference: String]) {
+        self.init()
+        lock.lock()
+        values = seed.filter { $0.value.isEmpty == false }
+        lock.unlock()
+    }
+
+    public func describe(_ reference: CredentialReference) -> CredentialInfo {
+        lock.lock(); defer { lock.unlock() }
+        return CredentialInfo(
+            reference: reference,
+            isConfigured: values[reference] != nil,
+            source: .keychain,
+            isWritable: writable)
+    }
+
+    public func describe(
+        _ references: [CredentialReference]
+    ) -> [CredentialReference: CredentialInfo] {
+        let bounded = references.prefix(maximumDescribeBatchSize)
+        var result: [CredentialReference: CredentialInfo] = [:]
+        result.reserveCapacity(bounded.count)
+        for reference in bounded {
+            result[reference] = describe(reference)
+        }
+        return result
+    }
+
+    public var maximumDescribeBatchSize: Int { 64 }
+
+    public func set(_ value: String?, for reference: CredentialReference) throws {
+        guard writable else { throw CredentialStoreError.notWritable(reference) }
+        let normalized = CredentialValue.normalized(value)
+        lock.lock(); defer { lock.unlock() }
+        if let normalized {
+            values[reference] = normalized
+        } else {
+            values.removeValue(forKey: reference)
+        }
+    }
+
+    public func unset(_ reference: CredentialReference) throws {
+        try set(nil, for: reference)
+    }
+
+    public func resolve(_ reference: CredentialReference) throws -> ResolvedCredential {
+        lock.lock(); defer { lock.unlock() }
+        guard let value = values[reference] else {
+            throw CredentialStoreError.notConfigured(reference)
+        }
+        return ResolvedCredential(reference: reference, value: value, source: .keychain)
+    }
+}

--- a/Sources/WikiFSCore/Core/KeychainSecretStore.swift
+++ b/Sources/WikiFSCore/Core/KeychainSecretStore.swift
@@ -50,6 +50,15 @@ public enum KeychainSecretStore {
              useDP: useDataProtectionKeychain, accessGroup: accessGroup)
     }
 
+    /// Throwing read for the credential service (`CredentialResolving`): an
+    /// absent item returns `nil`; any OTHER `OSStatus` throws so the caller can
+    /// distinguish "no secret" from "Keychain refused". A present-but-empty
+    /// item is treated as absent (the service never resolves an empty value).
+    static func readOrThrow(service: String, account: String) throws -> String? {
+        try readOrThrow(service: service, account: account,
+                        useDP: useDataProtectionKeychain, accessGroup: accessGroup)
+    }
+
     /// Write (set or delete) a generic-password secret. On a non-success
     /// `OSStatus` the failing `(operation, status)` is passed to `error` and
     /// whatever it throws propagates; a delete of a missing item is a no-op
@@ -67,6 +76,31 @@ public enum KeychainSecretStore {
     }
 
     // MARK: - Internal primitive (parameterized for the migration + tests)
+
+    /// Throwing read primitive (parameterized keychain context, mirroring
+    /// `read`). `errSecItemNotFound` → `nil`; any other status throws
+    /// `CredentialStoreError.readFailed` with the status — value-free.
+    static func readOrThrow(
+        service: String, account: String,
+        useDP: Bool, accessGroup: String
+    ) throws -> String? {
+        var query = baseQuery(service: service, account: account,
+                              useDP: useDP, accessGroup: accessGroup)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else {
+            throw CredentialStoreError.readFailed(operation: "read", status: status)
+        }
+        guard let data = item as? Data else { return nil }
+        // An empty (or non-UTF8) item is absence, not a value: `resolve` never
+        // returns an empty secret.
+        guard let value = String(data: data, encoding: .utf8),
+              !value.isEmpty else { return nil }
+        return value
+    }
 
     /// Read a generic-password secret from a specific keychain context. The
     /// `useDP`/`accessGroup` knobs let the migration read the LEGACY file

--- a/Sources/WikiFSCore/Core/ProviderSecretEnvironment.swift
+++ b/Sources/WikiFSCore/Core/ProviderSecretEnvironment.swift
@@ -1,0 +1,320 @@
+import Foundation
+import WikiFSTypes
+
+// Provider environment secrets (issue #1159, plans/credential-service.md).
+// `AgentProvider.env` (persisted in `agent-providers.json`) has ALWAYS had a
+// no-secret contract, but the file historically accepted plaintext API-key
+// variables. This module closes that hole:
+//
+// - `ProviderSecretEnvironmentVariable` — the CLOSED set of known secret
+//   environment variable names, so classification is exhaustive and
+//   compiler-checked;
+// - `CredentialReference.providerSecret(providerID:variable:)` — the typed
+//   provider-scoped reference for each (new credentials live under the shared
+//   `org.sockpuppet.WikiFS.credentials` service);
+// - `ProviderSecretEnvironment` — decode/write-boundary stripping and the
+//   trusted-host spawn-secret resolution.
+
+/// The known API-key environment variables that must never persist as
+/// plaintext sidecar data. Closed: a new provider key requirement extends
+/// this enum, and every boundary below picks it up automatically.
+public enum ProviderSecretEnvironmentVariable: String, CaseIterable, Codable,
+    Sendable, Hashable {
+    case anthropic = "ANTHROPIC_API_KEY"
+    case gemini = "GEMINI_API_KEY"
+    case openAI = "OPENAI_API_KEY"
+
+    /// The known secret variable with this exact name, or `nil` for any
+    /// non-secret name (including case variants — matching is exact, the
+    /// same way shells match env keys).
+    public static func knownSecret(named name: String) -> ProviderSecretEnvironmentVariable? {
+        allCases.first { $0.rawValue == name }
+    }
+
+    /// Whether this exact environment variable name carries a secret.
+    public static func isKnownSecret(_ name: String) -> Bool {
+        knownSecret(named: name) != nil
+    }
+
+    /// The canonical reference key for this variable — the lowercased kebab
+    /// form (`ANTHROPIC_API_KEY` → `anthropic-api-key`), which satisfies the
+    /// `CredentialReference` label grammar by construction.
+    public var referenceKey: String {
+        rawValue.lowercased().replacing("_", with: "-")
+    }
+}
+
+extension CredentialReference {
+
+    /// The provider-scoped credential reference for one known secret
+    /// variable: `provider.<providerID>.<referenceKey>`. Returns `nil` when
+    /// the provider id cannot form a valid reference label; such a provider
+    /// keeps its plaintext sidecar value (the migration records a bounded
+    /// failure rather than losing or misplacing the credential).
+    public static func providerSecret(
+        providerID: ProviderID,
+        variable: ProviderSecretEnvironmentVariable
+    ) -> CredentialReference? {
+        CredentialReference(validatingLabels: [
+            "provider", providerID.rawValue, variable.referenceKey,
+        ])
+    }
+}
+
+/// Boundary helpers keeping plaintext secrets out of `AgentProvider.env`.
+public enum ProviderSecretEnvironment {
+
+    /// Strip every known secret variable from one provider's env map.
+    /// Returns the cleaned map (non-secret entries unchanged). PURE.
+    public static func strippingSecrets(
+        from env: [String: String]
+    ) -> [String: String] {
+        env.filter { !ProviderSecretEnvironmentVariable.isKnownSecret($0.key) }
+    }
+
+    /// Strip known secret variables from every provider in the list, returning
+    /// the cleaned providers plus the stripped KEY NAMES (never values) for a
+    /// bounded diagnostic. PURE.
+    public static func strippingSecrets(
+        from providers: [AgentProvider]
+    ) -> (providers: [AgentProvider], strippedKeyNames: [String]) {
+        var strippedNames: [String] = []
+        let cleaned = providers.map { provider in
+            var updated = provider
+            let before = Set(updated.env.keys)
+            updated.env = strippingSecrets(from: updated.env)
+            for key in before.subtracting(updated.env.keys).sorted() {
+                strippedNames.append("\(provider.id.rawValue).\(key)")
+            }
+            return updated
+        }
+        return (cleaned, strippedNames)
+    }
+
+    /// Resolve a provider's known secret environment variables from the
+    /// credential service — the TRUSTED HOST spawn path (plan item 18). The
+    /// result carries only configured values for the closed variable set; it
+    /// is merged into the provider's private spawn hints immediately before
+    /// preparation and never persisted anywhere. A missing credential is
+    /// omitted (the provider runs without it, exactly like a missing env var
+    /// today); a real read failure is logged value-free.
+    public static func resolvedSpawnSecrets(
+        for providerID: ProviderID,
+        resolving: CredentialResolving
+    ) -> [String: String] {
+        var resolved: [String: String] = [:]
+        for variable in ProviderSecretEnvironmentVariable.allCases {
+            guard let reference = CredentialReference.providerSecret(
+                providerID: providerID, variable: variable)
+            else { continue }
+            do {
+                resolved[variable.rawValue] = try resolving.resolve(reference).value
+            } catch CredentialStoreError.notConfigured {
+                continue
+            } catch {
+                DebugLog.config(
+                    "Provider credential resolve failed for \(reference.rawValue): \(error)")
+                continue
+            }
+        }
+        return resolved
+    }
+}
+
+// MARK: - One-shot sidecar → Keychain migration
+
+/// One entry in a migration report: which provider/variable the entry is
+/// about. Names only — never a value.
+public struct AgentProviderCredentialMigrationEntry: Hashable, Sendable,
+    CustomStringConvertible {
+    public let providerID: String
+    public let variable: ProviderSecretEnvironmentVariable
+
+    public init(providerID: String, variable: ProviderSecretEnvironmentVariable) {
+        self.providerID = providerID
+        self.variable = variable
+    }
+
+    public var description: String { "\(providerID).\(variable.rawValue)" }
+}
+
+/// The bounded, value-free outcome of one migration pass.
+public struct AgentProviderCredentialMigrationReport: Equatable, Sendable {
+    /// Plaintext values that were written to Keychain and removed from the
+    /// sidecar.
+    public var migrated: [AgentProviderCredentialMigrationEntry] = []
+    /// Plaintext duplicates removed because Keychain already held the SAME
+    /// value.
+    public var removedDuplicates: [AgentProviderCredentialMigrationEntry] = []
+    /// Keychain holds a DIFFERENT value: the plaintext entry is preserved and
+    /// NEITHER value was overwritten. The user resolves the conflict (Risk 13).
+    public var conflicts: [AgentProviderCredentialMigrationEntry] = []
+    /// The Keychain write failed: the plaintext entry is preserved so the
+    /// credential is never lost.
+    public var failures: [AgentProviderCredentialMigrationEntry] = []
+    /// The provider id / variable could not form a typed reference; plaintext
+    /// preserved untouched.
+    public var unmappable: [AgentProviderCredentialMigrationEntry] = []
+
+    public init() {}
+
+    /// True when the sidecar holds no plaintext secrets after this pass.
+    public var isClean: Bool {
+        conflicts.isEmpty && failures.isEmpty && unmappable.isEmpty
+    }
+}
+
+/// The one app-owned, lock-safe migration of legacy plaintext provider API
+/// keys from `agent-providers.json` into the shared credential service
+/// (Keychain). Deterministic conflict semantics (plan step 17):
+///
+/// - Keychain ABSENT → write the plaintext value, and only after the write
+///   succeeds remove the sidecar entry;
+/// - Keychain SAME value → remove the duplicate plaintext;
+/// - Keychain DIFFERENT value → preserve the plaintext, overwrite nothing,
+///   surface a bounded conflict status.
+///
+/// # Why the scan reads RAW file bytes
+/// `AgentProvidersConfig`'s decode boundary (#1159) strips known secret
+/// variables, so a DECODED config can never show the legacy plaintext. The
+/// migrator therefore scans the raw JSON for known secret keys, resolves the
+/// values into the service, and only then lets the normal config pipeline
+/// persist the secret-free sidecar (any encode of a decoded config is already
+/// secret-free). The sidecar is rewritten ONLY when every discovered entry
+/// resolved (migrated or duplicate-removed) — a conflicted or failed entry is
+/// preserved untouched and retried on the next launch, so a credential is
+/// never lost.
+///
+/// The persist runs inside `AgentProvidersConfigStore.mutate` (in-process +
+/// cross-process file lock). Idempotent: a sidecar without plaintext secrets
+/// is detected up front and never rewritten.
+///
+/// Called from the app's launch path (WikiFSApp); the daemon and CLI never
+/// invoke it. THE APP IS THE ONLY WRITER of credentials into Keychain via
+/// this migration.
+public enum AgentProviderCredentialMigrator {
+
+    /// One plaintext entry found in the raw sidecar bytes. Names + value;
+    /// the value exists only inside this pass and never enters `report`.
+    struct RawSidecarEntry {
+        let providerID: String
+        let variable: ProviderSecretEnvironmentVariable
+        let value: String
+    }
+
+    /// Scan the RAW `agent-providers.json` for known secret variables with
+    /// non-empty values.
+    static func rawPlaintextEntries(at directory: URL) -> [RawSidecarEntry] {
+        let url = directory.appendingPathComponent(
+            AgentProvidersConfig.fileName, isDirectory: false)
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            return []  // missing/unreadable sidecar: nothing to migrate
+        }
+        let parsedObject: Any?
+        do {
+            parsedObject = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            DebugLog.store(
+                "AgentProvider credential migration: sidecar JSON scan failed: \(error)")
+            return []
+        }
+        guard let object = parsedObject as? [String: Any],
+              let providers = object["providers"] as? [[String: Any]]
+        else {
+            DebugLog.store(
+                "AgentProvider credential migration: sidecar is not parseable JSON; skipping")
+            return []
+        }
+        var entries: [RawSidecarEntry] = []
+        for provider in providers {
+            guard let id = provider["id"] as? String,
+                  let env = provider["env"] as? [String: Any] else { continue }
+            for variable in ProviderSecretEnvironmentVariable.allCases {
+                if let value = env[variable.rawValue] as? String,
+                   CredentialValue.normalized(value) != nil {
+                    entries.append(
+                        RawSidecarEntry(
+                            providerID: id, variable: variable, value: value))
+                }
+            }
+        }
+        return entries
+    }
+
+    /// Scan + migrate (see the type's doc comment for the full contract).
+    public static func migrateIfNeeded(
+        directory: URL,
+        store: AgentProvidersConfigStore,
+        credentials: CredentialDescribing & CredentialWriting & CredentialResolving
+    ) async -> AgentProviderCredentialMigrationReport {
+        var report = AgentProviderCredentialMigrationReport()
+        let entries = rawPlaintextEntries(at: directory)
+        guard !entries.isEmpty else { return report }
+
+        var anyChange = false
+        var allResolved = true
+        for entry in entries {
+            let item = AgentProviderCredentialMigrationEntry(
+                providerID: entry.providerID, variable: entry.variable)
+            guard let reference = CredentialReference.providerSecret(
+                providerID: ProviderID(rawValue: entry.providerID),
+                variable: entry.variable)
+            else {
+                report.unmappable.append(item)
+                allResolved = false
+                continue
+            }
+            let configuredInfo = credentials.describe(reference)
+            if !configuredInfo.isConfigured {
+                // Absent → write BEFORE removing the sidecar entry; a failed
+                // write preserves the plaintext (never lose a key).
+                do {
+                    try credentials.set(entry.value, for: reference)
+                } catch {
+                    report.failures.append(item)
+                    allResolved = false
+                    continue
+                }
+                report.migrated.append(item)
+                anyChange = true
+                continue
+            }
+            // Configured → same value removes the duplicate plaintext; a
+            // different value preserves BOTH and records the conflict.
+            do {
+                let existing = try credentials.resolve(reference)
+                if existing.value == entry.value {
+                    report.removedDuplicates.append(item)
+                    anyChange = true
+                } else {
+                    report.conflicts.append(item)
+                    allResolved = false
+                }
+            } catch {
+                report.failures.append(item)
+                allResolved = false
+            }
+        }
+
+        // Persist the secret-free sidecar only when EVERY entry resolved —
+        // the decoded config has already dropped the secrets, so this write
+        // is exactly "the removal", under the sidecar lock.
+        if anyChange, allResolved {
+            do {
+                let committed = try await store.mutate { config in config }
+                DebugLog.store(
+                    "AgentProvider credential migration: persisted secret-free sidecar (generation \(committed.generation), \(report.migrated.count) migrated, \(report.removedDuplicates.count) duplicates removed)")
+            } catch {
+                // The locked write failed: the sidecar keeps its plaintext
+                // and the next launch retries. Keychain already holds the
+                // values, so the retry reports duplicates-and-removes.
+                DebugLog.store(
+                    "AgentProvider credential migration: locked persist failed: \(error)")
+            }
+        }
+        return report
+    }
+}

--- a/Sources/WikiFSCore/Integrations/ACPCredentialStore.swift
+++ b/Sources/WikiFSCore/Integrations/ACPCredentialStore.swift
@@ -49,10 +49,21 @@ public struct ACPKeychainError: Error, Equatable {
 /// The production `ACPCredentialStore`: generic-password Keychain items under
 /// a shared `service` + account. The legacy single-key API uses a fixed account;
 /// the per-provider API (#324) namespaces by provider id so each ACP provider
-/// keeps its own secret. `KeychainSecretStore` (the shared helper this delegates
-/// to) writes items to the DataProtection keychain under a shared
-/// `keychain-access-groups` access group so the un-sandboxed `wikid` daemon can
-/// read them — see `plans/keychain-sharing.md`.
+/// keeps its own secret.
+///
+/// Issue #1159: this store is now a THIN ADAPTER over the shared
+/// `KeychainCredentialService` — it translates its per-domain API into typed
+/// `CredentialReference` values (`.acpAgent()` / `.acpProvider(_:)`) and maps
+/// service errors back to this store's historical `ACPKeychainError` shape.
+/// The physical locations are unchanged: the location catalog maps those
+/// references to the exact `org.sockpuppet.WikiFS.acp` accounts this store
+/// always used, so existing secrets are read and written in place with no
+/// copy (AC.3, plans/credential-service.md).
+///
+/// Provider ids that cannot form a valid reference label (arbitrary
+/// user-chosen ids with characters outside the credential grammar) keep the
+/// legacy direct `KeychainSecretStore` path — the exact pre-service behavior —
+/// so no existing secret is orphaned by the grammar.
 public struct KeychainACPCredentialStore: ACPCredentialStore {
     private static let service = "org.sockpuppet.WikiFS.acp"
     private static let account = "acp-agent-api-key"
@@ -60,35 +71,77 @@ public struct KeychainACPCredentialStore: ACPCredentialStore {
     public init() {}
 
     public func apiKey() -> String? {
-        KeychainSecretStore.read(service: Self.service, account: Self.account)
+        Self.read(reference: .acpAgent())
     }
 
     public func setAPIKey(_ value: String?) throws {
-        try KeychainSecretStore.write(
-            service: Self.service, account: Self.account, value: value,
-            error: { operation, status in
-                ACPKeychainError(operation: "\(operation)(\(Self.account))", status: status)
-            })
+        try Self.write(
+            CredentialValue.normalized(value), reference: .acpAgent(),
+            errorAccount: Self.account)
     }
 
     // MARK: - Per-provider (#324)
 
     public func apiKey(forProvider id: String) -> String? {
-        KeychainSecretStore.read(service: Self.service, account: Self.providerAccount(id))
+        guard let reference = CredentialReference.acpProvider(ProviderID(rawValue: id)) else {
+            // Provider id outside the credential grammar: legacy direct path,
+            // preserving the physical `acp-provider:<id>` account exactly.
+            return KeychainSecretStore.read(
+                service: Self.service, account: Self.providerAccount(id))
+        }
+        return Self.read(reference: reference)
     }
 
     public func setAPIKey(_ value: String?, forProvider id: String) throws {
         let account = Self.providerAccount(id)
-        try KeychainSecretStore.write(
-            service: Self.service, account: account, value: value,
-            error: { operation, status in
-                ACPKeychainError(operation: "\(operation)(\(account))", status: status)
-            })
+        guard let reference = CredentialReference.acpProvider(ProviderID(rawValue: id)) else {
+            try KeychainSecretStore.write(
+                service: Self.service, account: account, value: value,
+                error: { operation, status in
+                    ACPKeychainError(operation: "\(operation)(\(account))", status: status)
+                })
+            return
+        }
+        try Self.write(
+            CredentialValue.normalized(value), reference: reference,
+            errorAccount: account)
     }
 
     /// Namespace a per-provider account so each provider's key is isolated.
     private static func providerAccount(_ id: String) -> String {
         "acp-provider:\(id)"
+    }
+
+    /// Shared read: resolve through the service; preserve the historical
+    /// "missing OR failed = nil" optional contract with a bounded, value-free
+    /// diagnostic for real Keychain failures (Risk 4, plans/credential-service.md).
+    private static func read(reference: CredentialReference) -> String? {
+        do {
+            return try KeychainCredentialService().resolve(reference).value
+        } catch CredentialStoreError.notConfigured {
+            return nil
+        } catch {
+            DebugLog.config(
+                "ACP credential read failed for \(reference.rawValue): \(error)")
+            return nil
+        }
+    }
+
+    /// Shared write: normalize through `CredentialValue` (whitespace-only =
+    /// unset), then map the typed service error back to `ACPKeychainError`.
+    private static func write(
+        _ value: String?, reference: CredentialReference, errorAccount: String
+    ) throws {
+        do {
+            try KeychainCredentialService().set(value, for: reference)
+        } catch let error as CredentialStoreError {
+            switch error {
+            case .writeFailed(let operation, let status):
+                throw ACPKeychainError(operation: "\(operation)(\(errorAccount))", status: status)
+            default:
+                throw ACPKeychainError(operation: "write(\(errorAccount))", status: -1)
+            }
+        }
     }
 }
 #endif // os(macOS)

--- a/Sources/WikiFSCore/Integrations/ExtractionCredentialStore.swift
+++ b/Sources/WikiFSCore/Integrations/ExtractionCredentialStore.swift
@@ -20,6 +20,18 @@ public enum ExtractionSecret: String, Sendable {
     case doclingServeToken
 }
 
+extension CredentialReference {
+    /// The typed reference for an extraction secret at its legacy
+    /// extraction-service location (`org.sockpuppet.WikiFS.extraction`).
+    public static func extraction(_ secret: ExtractionSecret) -> CredentialReference? {
+        switch secret {
+        case .anthropicAPIKey: return extraction("anthropic-api-key")
+        case .geminiAPIKey: return extraction("gemini-api-key")
+        case .doclingServeToken: return extraction("docling-serve-token")
+        }
+    }
+}
+
 #if os(macOS)
 import Security
 
@@ -30,10 +42,13 @@ public struct ExtractionKeychainError: Error, Equatable {
 }
 
 /// The production `ExtractionCredentialStore`: one generic-password Keychain
-/// item per secret, under a shared `service`. `KeychainSecretStore` (the shared
-/// helper) writes items to the DataProtection keychain under a shared
-/// `keychain-access-groups` access group so the un-sandboxed `wikid` daemon can
-/// read them — see `plans/keychain-sharing.md`.
+/// item per secret, under a shared `service`.
+///
+/// Issue #1159: a thin adapter over the shared `KeychainCredentialService`.
+/// Each `ExtractionSecret` maps to a typed reference under the `extraction`
+/// domain; the location catalog resolves those references to the exact
+/// `org.sockpuppet.WikiFS.extraction` accounts this store always used, so
+/// existing secrets are read and written in place with no copy (AC.3).
 public struct KeychainExtractionCredentialStore: ExtractionCredentialStore {
     private static let service = "org.sockpuppet.WikiFS.extraction"
 
@@ -47,17 +62,47 @@ public struct KeychainExtractionCredentialStore: ExtractionCredentialStore {
         }
     }
 
+    private func reference(for secret: ExtractionSecret) -> CredentialReference? {
+        CredentialReference.extraction(account(for: secret))
+    }
+
     public func secret(_ secret: ExtractionSecret) -> String? {
-        KeychainSecretStore.read(service: Self.service, account: account(for: secret))
+        guard let reference = reference(for: secret) else {
+            return KeychainSecretStore.read(
+                service: Self.service, account: account(for: secret))
+        }
+        do {
+            return try KeychainCredentialService().resolve(reference).value
+        } catch CredentialStoreError.notConfigured {
+            return nil
+        } catch {
+            DebugLog.config(
+                "Extraction credential read failed for \(reference.rawValue): \(error)")
+            return nil
+        }
     }
 
     public func setSecret(_ value: String?, _ secret: ExtractionSecret) throws {
-        let account = account(for: secret)
-        try KeychainSecretStore.write(
-            service: Self.service, account: account, value: value,
-            error: { operation, status in
-                ExtractionKeychainError(operation: "\(operation)(\(account))", status: status)
-            })
+        let accountName = account(for: secret)
+        guard let reference = reference(for: secret) else {
+            try KeychainSecretStore.write(
+                service: Self.service, account: accountName, value: value,
+                error: { operation, status in
+                    ExtractionKeychainError(operation: "\(operation)(\(accountName))", status: status)
+                })
+            return
+        }
+        do {
+            try KeychainCredentialService().set(
+                CredentialValue.normalized(value), for: reference)
+        } catch let error as CredentialStoreError {
+            switch error {
+            case .writeFailed(let operation, let status):
+                throw ExtractionKeychainError(operation: "\(operation)(\(accountName))", status: status)
+            default:
+                throw ExtractionKeychainError(operation: "write(\(accountName))", status: -1)
+            }
+        }
     }
 }
 #endif // os(macOS)

--- a/Sources/WikiFSCore/Integrations/ZoteroCredentialStore.swift
+++ b/Sources/WikiFSCore/Integrations/ZoteroCredentialStore.swift
@@ -23,9 +23,11 @@ public struct ZoteroKeychainError: Error, Equatable {
 }
 
 /// The production `ZoteroCredentialStore`: a generic-password Keychain item.
-/// `KeychainSecretStore` (the shared helper) writes items to the DataProtection
-/// keychain under a shared `keychain-access-groups` access group so the
-/// un-sandboxed `wikid` daemon can read them — see `plans/keychain-sharing.md`.
+///
+/// Issue #1159: a thin adapter over the shared `KeychainCredentialService`.
+/// The typed `.zoteroAPIKey()` reference maps to the exact
+/// `org.sockpuppet.WikiFS.zotero` / `zotero-api-key` location this store
+/// always used — existing keys are read and written in place, no copy.
 public struct KeychainZoteroCredentialStore: ZoteroCredentialStore {
     private static let service = "org.sockpuppet.WikiFS.zotero"
     private static let account = "zotero-api-key"
@@ -33,15 +35,29 @@ public struct KeychainZoteroCredentialStore: ZoteroCredentialStore {
     public init() {}
 
     public func apiKey() -> String? {
-        KeychainSecretStore.read(service: Self.service, account: Self.account)
+        do {
+            return try KeychainCredentialService()
+                .resolve(.zoteroAPIKey()).value
+        } catch CredentialStoreError.notConfigured {
+            return nil
+        } catch {
+            DebugLog.config("Zotero credential read failed: \(error)")
+            return nil
+        }
     }
 
     public func setAPIKey(_ key: String?) throws {
-        try KeychainSecretStore.write(
-            service: Self.service, account: Self.account, value: key,
-            error: { operation, status in
-                ZoteroKeychainError(operation: operation, status: status)
-            })
+        do {
+            try KeychainCredentialService().set(
+                CredentialValue.normalized(key), for: .zoteroAPIKey())
+        } catch let error as CredentialStoreError {
+            switch error {
+            case .writeFailed(let operation, let status):
+                throw ZoteroKeychainError(operation: operation, status: status)
+            default:
+                throw ZoteroKeychainError(operation: "write", status: -1)
+            }
+        }
     }
 }
 #endif // os(macOS)

--- a/Sources/WikiFSEngine/AgentProviderRuntime.swift
+++ b/Sources/WikiFSEngine/AgentProviderRuntime.swift
@@ -284,6 +284,12 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
     public typealias ConfigurationReader = @Sendable () throws -> AgentProvidersConfig
     public typealias CommandResolver = @Sendable ([AgentProvider]) async -> [ProviderID: [String]]
     public typealias CredentialReader = @Sendable (ProviderID) -> String?
+    /// #1159: resolves the SELECTED provider's known secret environment
+    /// variables (`ProviderSecretEnvironmentVariable`) from the shared
+    /// credential service. Trusted host only — the returned map merges into
+    /// this provider's private spawn hints at preparation time and is never
+    /// persisted or logged.
+    public typealias SpawnSecretReader = @Sendable (ProviderID) -> [String: String]
     public typealias PermissionPolicyResolver = @Sendable (PermissionOperationKind) -> PermissionPolicy
     public typealias BackendFactory = @Sendable (PermissionPolicy, Duration?, TimeInterval) -> any AgentBackend
     public typealias CatalogProbe = @Sendable (
@@ -299,6 +305,7 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
     private let readConfiguration: ConfigurationReader
     private let resolveCommand: CommandResolver
     private let readCredential: CredentialReader
+    private let readSpawnSecrets: SpawnSecretReader
     private let resolvePermissionPolicy: PermissionPolicyResolver
     private let makeBackend: BackendFactory
     private let probeCatalog: CatalogProbe
@@ -311,6 +318,7 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
         readConfiguration: @escaping ConfigurationReader,
         resolveCommand: @escaping CommandResolver,
         readCredential: @escaping CredentialReader,
+        readSpawnSecrets: @escaping SpawnSecretReader = { _ in [:] },
         resolvePermissionPolicy: @escaping PermissionPolicyResolver,
         makeBackend: @escaping BackendFactory = {
             AgentBackendFactory.makeBackend(
@@ -329,6 +337,7 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
         self.readConfiguration = readConfiguration
         self.resolveCommand = resolveCommand
         self.readCredential = readCredential
+        self.readSpawnSecrets = readSpawnSecrets
         self.resolvePermissionPolicy = resolvePermissionPolicy
         self.makeBackend = makeBackend
         self.probeCatalog = probeCatalog
@@ -534,6 +543,12 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
         let commands = await resolveCommand(Array(uniqueProviders.values))
         let credentials = Dictionary(
             uniqueKeysWithValues: uniqueProviders.keys.map { ($0, readCredential($0)) })
+        // #1159: resolve each provider's known secret environment variables
+        // ONCE per preparation, here in the trusted host. Rotation is visible
+        // on the NEXT preparation because this snapshot is rebuilt per prepare
+        // call and resolved values are never cached beyond it.
+        let spawnSecrets = Dictionary(
+            uniqueKeysWithValues: uniqueProviders.keys.map { ($0, readSpawnSecrets($0)) })
         for stage in stages {
             let providers = stageProviders[stage] ?? []
             var records: [SpawnRecord] = []
@@ -552,11 +567,18 @@ public actor AgentProviderRuntime: AgentProviderPrivateServices {
                         forStage: stage.configurationKey,
                         fallbackProvider: provider.id)
                 }
-                let hints = AgentBackendFactory.providerHints(
+                var hints = AgentBackendFactory.providerHints(
                     provider: provider,
                     resolvedCommand: commands[provider.id] ?? [],
                     apiKey: credentials[provider.id] ?? nil,
                     selectedModelId: model?.rawValue)
+                // Resolved secrets ride the established `env.` hint prefix.
+                // They override any same-named entry — `provider.env` cannot
+                // carry known secret keys anymore (stripped at every
+                // boundary), so this is additive in practice.
+                for (key, value) in spawnSecrets[provider.id] ?? [:] {
+                    hints[HintKey.env(key)] = value
+                }
                 records.append(SpawnRecord(provider: provider, model: model, hints: hints))
             }
             chains[stage] = records

--- a/Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift
+++ b/Sources/WikiFSEngine/AgentProviderRuntimeFactory.swift
@@ -13,6 +13,7 @@ public struct AgentProviderRuntimeFactory: Sendable {
         case configurationReader
         case commandResolver
         case credentialReader
+        case spawnSecretReader
         case permissionPolicyResolver
         case backendFactory
         case catalogProbe
@@ -24,6 +25,7 @@ public struct AgentProviderRuntimeFactory: Sendable {
         static let configurationReader = ServiceKey<AgentProviderRuntime.ConfigurationReader>(label: "agent-provider.configuration-reader")
         static let commandResolver = ServiceKey<AgentProviderRuntime.CommandResolver>(label: "agent-provider.command-resolver")
         static let credentialReader = ServiceKey<AgentProviderRuntime.CredentialReader>(label: "agent-provider.credential-reader")
+        static let spawnSecretReader = ServiceKey<AgentProviderRuntime.SpawnSecretReader>(label: "agent-provider.spawn-secret-reader")
         static let permissionPolicyResolver = ServiceKey<AgentProviderRuntime.PermissionPolicyResolver>(label: "agent-provider.permission-policy-resolver")
         static let backendFactory = ServiceKey<AgentProviderRuntime.BackendFactory>(label: "agent-provider.backend-factory")
         static let catalogProbe = ServiceKey<AgentProviderRuntime.CatalogProbe>(label: "agent-provider.catalog-probe")
@@ -34,6 +36,7 @@ public struct AgentProviderRuntimeFactory: Sendable {
     public let readConfiguration: AgentProviderRuntime.ConfigurationReader
     public let resolveCommand: AgentProviderRuntime.CommandResolver
     public let readCredential: AgentProviderRuntime.CredentialReader
+    public let readSpawnSecrets: AgentProviderRuntime.SpawnSecretReader
     public let resolvePermissionPolicy: AgentProviderRuntime.PermissionPolicyResolver
     public let makeBackend: AgentProviderRuntime.BackendFactory
     public let probeCatalog: AgentProviderRuntime.CatalogProbe
@@ -42,6 +45,7 @@ public struct AgentProviderRuntimeFactory: Sendable {
         readConfiguration: @escaping AgentProviderRuntime.ConfigurationReader,
         resolveCommand: @escaping AgentProviderRuntime.CommandResolver,
         readCredential: @escaping AgentProviderRuntime.CredentialReader,
+        readSpawnSecrets: @escaping AgentProviderRuntime.SpawnSecretReader = { _ in [:] },
         resolvePermissionPolicy: @escaping AgentProviderRuntime.PermissionPolicyResolver,
         makeBackend: @escaping AgentProviderRuntime.BackendFactory = { policy, budget, ceiling in
             AgentBackendFactory.makeBackend(policy: policy, budget: budget, turnCeilingTimeout: ceiling)
@@ -57,6 +61,7 @@ public struct AgentProviderRuntimeFactory: Sendable {
         self.readConfiguration = readConfiguration
         self.resolveCommand = resolveCommand
         self.readCredential = readCredential
+        self.readSpawnSecrets = readSpawnSecrets
         self.resolvePermissionPolicy = resolvePermissionPolicy
         self.makeBackend = makeBackend
         self.probeCatalog = probeCatalog
@@ -120,6 +125,10 @@ public struct AgentProviderRuntimeFactory: Sendable {
             return try ComponentDefinition(label: component.rawValue, provisions: [ServiceDependency(Keys.credentialReader)]) { activation in
                 _ = try await activation.supply(Keys.credentialReader, value: readCredential)
             }
+        case .spawnSecretReader:
+            return try ComponentDefinition(label: component.rawValue, provisions: [ServiceDependency(Keys.spawnSecretReader)]) { activation in
+                _ = try await activation.supply(Keys.spawnSecretReader, value: readSpawnSecrets)
+            }
         case .permissionPolicyResolver:
             return try ComponentDefinition(label: component.rawValue, provisions: [ServiceDependency(Keys.permissionPolicyResolver)]) { activation in
                 _ = try await activation.supply(Keys.permissionPolicyResolver, value: resolvePermissionPolicy)
@@ -135,12 +144,13 @@ public struct AgentProviderRuntimeFactory: Sendable {
         case .runtime:
             return try ComponentDefinition(
                 label: component.rawValue,
-                dependencies: [ServiceDependency(Keys.configurationReader), ServiceDependency(Keys.commandResolver), ServiceDependency(Keys.credentialReader), ServiceDependency(Keys.permissionPolicyResolver), ServiceDependency(Keys.backendFactory), ServiceDependency(Keys.catalogProbe)],
+                dependencies: [ServiceDependency(Keys.configurationReader), ServiceDependency(Keys.commandResolver), ServiceDependency(Keys.credentialReader), ServiceDependency(Keys.spawnSecretReader), ServiceDependency(Keys.permissionPolicyResolver), ServiceDependency(Keys.backendFactory), ServiceDependency(Keys.catalogProbe)],
                 provisions: [ServiceDependency(Keys.runtime)]) { activation in
                     let runtime = AgentProviderRuntime(
                         readConfiguration: try await activation.require(Keys.configurationReader),
                         resolveCommand: try await activation.require(Keys.commandResolver),
                         readCredential: try await activation.require(Keys.credentialReader),
+                        readSpawnSecrets: try await activation.require(Keys.spawnSecretReader),
                         resolvePermissionPolicy: try await activation.require(Keys.permissionPolicyResolver),
                         makeBackend: try await activation.require(Keys.backendFactory),
                         probeCatalog: try await activation.require(Keys.catalogProbe))

--- a/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
+++ b/Sources/WikiFSEngine/ProductionPluginCatalogs.swift
@@ -46,6 +46,10 @@ public struct AgentProviderProcessInput: Sendable {
     public let readConfiguration: AgentProviderRuntime.ConfigurationReader
     public let resolveCommand: AgentProviderRuntime.CommandResolver
     public let readCredential: AgentProviderRuntime.CredentialReader
+    /// #1159: resolves the selected provider's known secret env variables
+    /// from the shared credential service at preparation time. Defaults to an
+    /// empty map (no spawn secrets).
+    public let readSpawnSecrets: AgentProviderRuntime.SpawnSecretReader
     public let resolvePermissionPolicy: AgentProviderRuntime.PermissionPolicyResolver
     public let makeBackend: AgentProviderRuntime.BackendFactory
     public let probeCatalog: AgentProviderRuntime.CatalogProbe
@@ -55,6 +59,7 @@ public struct AgentProviderProcessInput: Sendable {
         readConfiguration: @escaping AgentProviderRuntime.ConfigurationReader,
         resolveCommand: @escaping AgentProviderRuntime.CommandResolver,
         readCredential: @escaping AgentProviderRuntime.CredentialReader,
+        readSpawnSecrets: @escaping AgentProviderRuntime.SpawnSecretReader = { _ in [:] },
         resolvePermissionPolicy: @escaping AgentProviderRuntime.PermissionPolicyResolver,
         makeBackend: @escaping AgentProviderRuntime.BackendFactory = { policy, budget, ceiling in
             AgentBackendFactory.makeBackend(policy: policy, budget: budget, turnCeilingTimeout: ceiling)
@@ -68,6 +73,7 @@ public struct AgentProviderProcessInput: Sendable {
         self.readConfiguration = readConfiguration
         self.resolveCommand = resolveCommand
         self.readCredential = readCredential
+        self.readSpawnSecrets = readSpawnSecrets
         self.resolvePermissionPolicy = resolvePermissionPolicy
         self.makeBackend = makeBackend
         self.probeCatalog = probeCatalog
@@ -487,6 +493,11 @@ public actor DaemonProcessProfileOwner {
                     readCredential: { providerID in
                         KeychainACPCredentialStore().apiKey(forProvider: providerID.rawValue)
                     },
+                    readSpawnSecrets: { providerID in
+                        ProviderSecretEnvironment.resolvedSpawnSecrets(
+                            for: providerID,
+                            resolving: KeychainCredentialService())
+                    },
                     resolvePermissionPolicy: { _ in .bypass }),
                 extraction: ExtractionProcessInput(
                     services: extractionServices,
@@ -863,6 +874,7 @@ public enum ProcessRuntimePlugins {
                     readConfiguration: input.readConfiguration,
                     resolveCommand: input.resolveCommand,
                     readCredential: input.readCredential,
+                    readSpawnSecrets: input.readSpawnSecrets,
                     resolvePermissionPolicy: input.resolvePermissionPolicy,
                     makeBackend: input.makeBackend,
                     probeCatalog: input.probeCatalog)

--- a/Sources/WikiFSTypes/CredentialTypes.swift
+++ b/Sources/WikiFSTypes/CredentialTypes.swift
@@ -1,0 +1,293 @@
+import Foundation
+
+// Domain-neutral credential identity and service contracts (issue #1159,
+// plans/credential-service.md). These types live in `WikiFSTypes` so every
+// layer (app, daemon, engine, CLI) shares ONE vocabulary for "which secret"
+// without ever carrying the secret itself.
+//
+// The split this file encodes:
+// - `CredentialReference` — the stable CONFIGURATION identity of a credential
+//   (what Settings, catalogs, and authorization records store);
+// - `CredentialInfo` — the UI-SAFE description of a credential (configured
+//   state, source, writability) — no value surface;
+// - `ResolvedCredential` — the PRIVILEGED value container, for trusted host
+//   runtime code only (spawn preparation, client construction);
+// - `CredentialWriting` — write-only mutation; values travel INTO the service
+//   and never back out.
+//
+// There is deliberately NO reference-enumeration API: hosts supply the
+// references they know about (typed factories, host catalogs, Settings
+// schemas). See `plans/credential-service.md` §"No enumeration".
+
+// MARK: - Reference
+
+/// Validation failures for credential identity construction. `value` fields
+/// carry only the rejected COMPONENT (a label or a raw dotted string) — never
+/// a secret value; references are non-secret identifiers by construction.
+public enum CredentialReferenceError: Error, Equatable, Sendable {
+    case invalidLabel(component: String)
+    case invalidStructure(rawValue: String)
+}
+
+/// A credential's stable, validated configuration identity — two or three
+/// dot-separated labels such as `acp.agent-api-key`,
+/// `acp.provider.claude-acp`, or `provider.claude-acp.anthropic-api-key`.
+///
+/// # Grammar (normative)
+///
+/// A reference is 2–3 **labels** joined by `.` (U+002E):
+/// - a label is 1–64 characters of ASCII letters, digits, `_`, or `-`;
+/// - a label starts and ends with an ASCII letter or digit;
+/// - the whole reference is ≤ 132 characters.
+///
+/// The grammar is deliberately wider than kebab-case so dynamic domains can
+/// embed existing identifiers verbatim (e.g. a user-chosen `ProviderID` such
+/// as `my_agent`) while staying injective: `A.B` and `A_B` are distinct
+/// labels, and no label can contain `.`, so the split is unambiguous.
+///
+/// # Typed factories over unchecked strings
+///
+/// Call sites do NOT concatenate raw strings into references. Dynamic domains
+/// go through validated factories — `acpProvider(_:)` for provider-scoped ACP
+/// keys, and (in `WikiFSCore`) `ProviderSecretEnvironmentVariable`-scoped
+/// factories for provider environment secrets. A factory returns `nil` for a
+/// component that cannot form a valid label, and the caller decides the
+/// fallback (adapters keep their legacy physical path for such ids).
+///
+/// `Codable` encodes the joined `rawValue` string — that wire shape is a
+/// compatibility surface for authorization records (PR 2) and future stores.
+/// `Comparable` orders by `rawValue` so snapshots and stores can be
+/// deterministic without exposing insertion order.
+public struct CredentialReference:
+    Hashable, Codable, Comparable, Sendable, CustomStringConvertible {
+
+    /// The validated, dot-joined identity (e.g. `"acp.agent-api-key"`).
+    public let rawValue: String
+
+    /// The individual validated labels (e.g. `["acp", "agent-api-key"]`).
+    public var labels: [String] { rawValue.split(separator: ".").map(String.init) }
+
+    /// The first label — the reference's namespace (e.g. `"acp"`).
+    public var domain: String { labels[0] }
+
+    /// Validates and builds a reference from raw text. The ONLY general
+    /// constructor; every other initializer routes through here.
+    public init(validating rawValue: String) throws {
+        let labels = rawValue.split(
+            separator: ".", omittingEmptySubsequences: false).map(String.init)
+        guard labels.count >= Self.minimumLabelCount,
+              labels.count <= Self.maximumLabelCount,
+              labels.allSatisfy(Self.isValidLabel),
+              rawValue.count <= Self.maximumRawValueLength
+        else { throw CredentialReferenceError.invalidStructure(rawValue: rawValue) }
+        self.rawValue = rawValue
+    }
+
+    /// Builds a reference from already-validated components. Internal so
+    /// factories cannot bypass validation, while staying allocation-cheap.
+    init(validatedLabels: [String]) {
+        precondition(validatedLabels.count >= Self.minimumLabelCount
+                     && validatedLabels.count <= Self.maximumLabelCount,
+                     "validatedLabels must carry 2–3 labels")
+        precondition(validatedLabels.allSatisfy(Self.isValidLabel),
+                     "validatedLabels must already satisfy the label grammar")
+        self.rawValue = validatedLabels.joined(separator: ".")
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+    public var description: String { rawValue }
+
+    public init(from decoder: any Decoder) throws {
+        try self.init(validating: String(from: decoder))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    // MARK: Label grammar
+
+    static let minimumLabelCount = 2
+    static let maximumLabelCount = 3
+    static let maximumRawValueLength = 132
+    static let maximumLabelLength = 64
+
+    /// One validated label: 1–64 ASCII alphanumerics, `_`, or `-`; starts and
+    /// ends with an ASCII letter or digit; contains at least one of them.
+    public static func isValidLabel(_ label: String) -> Bool {
+        guard !label.isEmpty, label.count <= maximumLabelLength,
+              let first = label.first, first.isASCII,
+              let last = label.last, last.isASCII,
+              first.isLetter || first.isNumber,
+              last.isLetter || last.isNumber,
+              label.contains(where: { $0.isLetter || $0.isNumber })
+        else { return false }
+        return label.allSatisfy { character in
+            guard character.isASCII else { return false }
+            return character.isLetter || character.isNumber
+                || character == "_" || character == "-"
+        }
+    }
+
+    /// Returns a reference built by joining validated labels, or `nil` when
+    /// any component fails the grammar — the failable shape typed factories
+    /// expose for dynamic domains.
+    public init?(validatingLabels labels: [String]) {
+        guard labels.count >= Self.minimumLabelCount,
+              labels.count <= Self.maximumLabelCount,
+              labels.allSatisfy(Self.isValidLabel),
+              labels.joined(separator: ".").count <= Self.maximumRawValueLength
+        else { return nil }
+        self.rawValue = labels.joined(separator: ".")
+    }
+}
+
+// MARK: - Source and description
+
+/// The closed set of physical credential sources. Initially Keychain only;
+/// future sources (a synced vault, a hardware token) extend this enum rather
+/// than growing per-domain service APIs.
+public enum CredentialSource: String, Codable, Sendable, CaseIterable {
+    case keychain
+}
+
+/// The UI-safe description of one credential: whether it is configured, where
+/// it lives, and whether the current process may write it. **No value field
+/// exists** — Settings and inspection snapshots render this type directly, so
+/// a secret cannot leak through a description API.
+public struct CredentialInfo: Hashable, Sendable, CustomStringConvertible {
+    public let reference: CredentialReference
+    public let isConfigured: Bool
+    public let source: CredentialSource
+    public let isWritable: Bool
+
+    public init(
+        reference: CredentialReference,
+        isConfigured: Bool,
+        source: CredentialSource,
+        isWritable: Bool
+    ) {
+        self.reference = reference
+        self.isConfigured = isConfigured
+        self.source = source
+        self.isWritable = isWritable
+    }
+
+    public var description: String {
+        let state = isConfigured ? "configured" : "not configured"
+        return "CredentialInfo(\(reference.rawValue): \(state), \(source.rawValue))"
+    }
+}
+
+// MARK: - Privileged value container
+
+/// A resolved secret value plus its source. PRIVILEGED: only trusted host
+/// runtime code (spawn preparation, client construction, the migration)
+/// handles this type. Its descriptions are redacted so an accidental
+/// interpolation or log line can never carry the value.
+public struct ResolvedCredential: Sendable, CustomStringConvertible,
+    CustomDebugStringConvertible {
+    public let reference: CredentialReference
+    /// The secret value. Never rendered by `description`/`debugDescription`.
+    public let value: String
+    public let source: CredentialSource
+
+    public init(reference: CredentialReference, value: String, source: CredentialSource) {
+        self.reference = reference
+        self.value = value
+        self.source = source
+    }
+
+    public var description: String {
+        "ResolvedCredential(\(reference.rawValue): <redacted>)"
+    }
+
+    public var debugDescription: String { description }
+}
+
+// MARK: - Errors
+
+/// Bounded service failures. Every case is value-free: errors name the
+/// operation and the underlying OS status (an integer), never the secret.
+public enum CredentialStoreError: Error, Equatable, Sendable,
+    CustomStringConvertible {
+    /// `resolve` of a reference with no configured value.
+    case notConfigured(CredentialReference)
+    /// A Keychain read failed. `status` is the raw `OSStatus`.
+    case readFailed(operation: String, status: Int32)
+    /// A Keychain write or delete failed. `status` is the raw `OSStatus`.
+    case writeFailed(operation: String, status: Int32)
+    /// The source rejects mutation (e.g. a read-only future source).
+    case notWritable(CredentialReference)
+
+    public var description: String {
+        switch self {
+        case .notConfigured(let reference):
+            return "credential not configured: \(reference.rawValue)"
+        case .readFailed(let operation, let status):
+            return "credential read failed (\(operation), status \(status))"
+        case .writeFailed(let operation, let status):
+            return "credential write failed (\(operation), status \(status))"
+        case .notWritable(let reference):
+            return "credential is not writable: \(reference.rawValue)"
+        }
+    }
+}
+
+// MARK: - Value normalization
+
+/// The ONE named boundary deciding whether a write carries a value. `nil`,
+/// empty, and whitespace-only input all normalize to `nil` (= absence → the
+/// service unsets). A real value is preserved byte-for-byte — the service
+/// never trims a secret.
+public enum CredentialValue {
+    public static func normalized(_ value: String?) -> String? {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return value
+    }
+}
+
+// MARK: - Service protocols
+
+/// UI-safe credential description. Settings views, snapshots, and host
+/// catalogs conform to (or call) THIS protocol — it has no method that can
+/// return a secret value.
+public protocol CredentialDescribing: Sendable {
+    /// Describe one reference. A missing item describes as not-configured;
+    /// this never throws.
+    func describe(_ reference: CredentialReference) -> CredentialInfo
+
+    /// Describe a bounded batch. The host caps batch sizes; exceeding the
+    /// cap truncates the result rather than ballooning Keychain traffic.
+    func describe(_ references: [CredentialReference]) -> [CredentialReference: CredentialInfo]
+
+    /// The largest batch `describe([:])` will answer.
+    var maximumDescribeBatchSize: Int { get }
+}
+
+/// Write-only credential mutation. Values travel INTO the conformer only —
+/// there is no read shape on this protocol, so a Settings-facing handle can
+/// accept saves without being able to echo a secret back.
+public protocol CredentialWriting: Sendable {
+    /// Store `value` for `reference`. `nil`, empty, and whitespace-only
+    /// values normalize to unset (see `CredentialValue`) through exactly one
+    /// boundary — callers cannot store an empty secret.
+    func set(_ value: String?, for reference: CredentialReference) throws
+
+    /// Remove the credential. Removing an absent credential succeeds.
+    func unset(_ reference: CredentialReference) throws
+}
+
+/// Privileged value resolution. Trusted host runtime code only — never
+/// exposed to Settings views, package scripts, the File Provider, or XPC.
+public protocol CredentialResolving: Sendable {
+    /// Resolve the configured value. Throws `.notConfigured` when absent —
+    /// `resolve` never returns an empty value.
+    func resolve(_ reference: CredentialReference) throws -> ResolvedCredential
+}
+
+/// The full host-side service surface. Production conformers are the
+/// Keychain-backed service and the in-memory test service.
+public typealias CredentialService = CredentialDescribing & CredentialWriting & CredentialResolving

--- a/Tests/WikiFSAppTests/CredentialSettingsHostedTests.swift
+++ b/Tests/WikiFSAppTests/CredentialSettingsHostedTests.swift
@@ -1,0 +1,97 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+import WikiFSCore
+import WikiFSTypes
+@testable import WikiFS
+
+/// Hosted Settings coverage for the write-only credential authority
+/// (issue #1159 — AC.4): UI-safe APIs have no value-returning method, fields
+/// start blank, configured state is visible, save is write-only, and Remove
+/// is explicit. Mounts the real `ZoteroSettingsView` in an NSWindow against
+/// an `InMemoryCredentialService` — Keychain is never touched.
+///
+/// The identifier/label vocabulary is additionally pinned by the source
+/// contract test below; spoken behavior stays with the VoiceOver smoke script.
+@Suite(.serialized, .timeLimit(.minutes(2)))
+@MainActor
+struct CredentialSettingsHostedTests {
+
+    private static let app: NSApplication = {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        return app
+    }()
+
+    private func mount(_ view: some View) -> NSWindow {
+        _ = Self.app
+        let controller = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: controller)
+        window.setContentSize(NSSize(width: 520, height: 480))
+        window.layoutIfNeeded()
+        controller.view.layoutSubtreeIfNeeded()
+        window.orderFrontRegardless()
+        return window
+    }
+
+    @Test func fieldsStartBlankAndShowConfiguredStateWithoutPreloading() async throws {
+        let credentials = InMemoryCredentialService(seed: [.zoteroAPIKey(): "stored-key"])
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hosted-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let window = mount(ZoteroSettingsView(
+            containerDirectory: directory,
+            credentials: credentials,
+            verifyConnection: { _ in nil }))
+        defer { window.close() }
+        // Give the view's onAppear load a runloop turn.
+        try await Task.sleep(for: .milliseconds(100))
+        // The service still holds the value; the VIEW could not have received
+        // it (write-only authority) — assert the describe surface only.
+        #expect(credentials.describe(.zoteroAPIKey()).isConfigured)
+    }
+
+    @Test func writeOnlySaveAndExplicitRemoveThroughTheService() throws {
+        // The UI seam contract, exercised directly against the same
+        // protocols the view binds: a save writes, a remove deletes, and
+        // whitespace-only input never stores anything.
+        let credentials = InMemoryCredentialService()
+        try credentials.set("sk-new", for: .zoteroAPIKey())
+        #expect(try credentials.resolve(.zoteroAPIKey()).value == "sk-new")
+        try credentials.set("   ", for: .zoteroAPIKey())
+        #expect(credentials.describe(.zoteroAPIKey()).isConfigured == false)
+    }
+
+    /// Source contract: the Settings views may only hold
+    /// `CredentialDescribing & CredentialWriting` handles — a
+    /// value-returning resolve/apiKey call inside a Settings view fails here.
+    @Test func settingsViewsHaveNoValueReturningCredentialCalls() throws {
+        let sources = [
+            "Sources/WikiFS/Settings/ZoteroSettingsView.swift",
+            "Sources/WikiFS/Sources/ExtractionSettingsView.swift",
+            "Sources/WikiFS/Settings/AgentsSettingsView.swift",
+        ]
+        let forbidden = [
+            ".resolve(",
+            ".apiKey()",
+            ".secret(",
+            "apiKey(forProvider",
+        ]
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // Tests/WikiFSAppTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        for relative in sources {
+            let source = try String(
+                contentsOf: root.appendingPathComponent(relative), encoding: .utf8)
+            for needle in forbidden {
+                #expect(
+                    source.contains(needle) == false,
+                    "\(relative) must not contain a value-returning credential call: \(needle)")
+            }
+        }
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -32,11 +32,9 @@ struct ExtractionRouteTableHostedTests {
         return app
     }()
 
-    /// In-memory credential stub — the hosted view must never touch Keychain.
-    private struct StubCredentialStore: ExtractionCredentialStore {
-        func secret(_ secret: ExtractionSecret) -> String? { nil }
-        func setSecret(_ value: String?, _ secret: ExtractionSecret) throws {}
-    }
+    /// In-memory credential stub (#1159) — the hosted view must never touch
+    /// Keychain; `InMemoryCredentialService` backs the write-only UI seam.
+    private static let stubCredentials = InMemoryCredentialService()
 
     private func tempDirectory(_ name: String) throws -> URL {
         let dir = FileManager.default.temporaryDirectory
@@ -68,7 +66,7 @@ struct ExtractionRouteTableHostedTests {
         ExtractionSettingsView(
             containerDirectory: directory,
             launcher: AgentLauncher(),
-            credentialStore: StubCredentialStore(),
+            credentials: Self.stubCredentials,
             packageSnapshot: { snapshot })
     }
 

--- a/Tests/WikiFSTests/AgentProviderCredentialMigrationTests.swift
+++ b/Tests/WikiFSTests/AgentProviderCredentialMigrationTests.swift
@@ -1,0 +1,282 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+import WikiFSTypes
+
+/// The one-shot provider sidecar → Keychain migration (issue #1159 — AC.5,
+/// plan step 17 / Risk 13). Covers known-key classification, provider-scoped
+/// references, successful migration, equal-value duplicate removal, conflict
+/// preservation, failed-write preservation, idempotence, concurrent sidecar
+/// mutation, and removal of plaintext after success.
+///
+/// Uses `InMemoryCredentialService` as the credential backend — the
+/// migration's CONTRACT is backend-independent (it speaks the service
+/// protocols); the real-Keychain backend is covered by the opt-in
+/// multiprocess fixture.
+@Suite(.serialized)
+struct AgentProviderCredentialMigrationTests {
+
+    /// Unwrapping helper: these provider ids are grammar-valid literals, so a
+    /// nil factory result is a test bug.
+    private func ref(
+        _ provider: String, _ variable: ProviderSecretEnvironmentVariable
+    ) -> CredentialReference {
+        guard let reference = CredentialReference.providerSecret(
+            providerID: ProviderID(rawValue: provider), variable: variable)
+        else { preconditionFailure("test provider id must satisfy the grammar") }
+        return reference
+    }
+
+    // MARK: Fixtures
+
+    /// Writes RAW sidecar JSON with legacy plaintext secrets still present.
+    /// Deliberately NOT `AgentProvidersConfig.writeAtomically` — the #1159
+    /// write boundary would strip the secrets, and the migration's input is
+    /// precisely a legacy file that predates that boundary.
+    private func seedRawSidecar(
+        directory: URL,
+        providerID: String = "claude-acp",
+        env: [String: String]
+    ) throws {
+        let envJSON = String(decoding: try JSONSerialization.data(withJSONObject: env), as: UTF8.self)
+        let json = """
+        {"providers":[{"id":"\(providerID)","label":"Seeded","command":["claude","--acp"],"env":\(envJSON),"enabled":true,"isDefault":true}],"generation":0}
+        """
+        try Data(json.utf8).write(
+            to: directory.appendingPathComponent(AgentProvidersConfig.fileName))
+    }
+
+    private func makeStore(_ directory: URL) -> AgentProvidersConfigStore {
+        AgentProvidersConfigStore(directory: directory)
+    }
+
+    private func makeDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("migration-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    // MARK: Classification + references
+
+    @Test func knownSecretVariablesClassifyExactly() {
+        #expect(ProviderSecretEnvironmentVariable.isKnownSecret("ANTHROPIC_API_KEY"))
+        #expect(ProviderSecretEnvironmentVariable.isKnownSecret("GEMINI_API_KEY"))
+        #expect(ProviderSecretEnvironmentVariable.isKnownSecret("OPENAI_API_KEY"))
+        #expect(!ProviderSecretEnvironmentVariable.isKnownSecret("CLAUDE_CODE_EXECUTABLE"))
+        #expect(!ProviderSecretEnvironmentVariable.isKnownSecret("anthropic_api_key"))
+        #expect(!ProviderSecretEnvironmentVariable.isKnownSecret(""))
+        #expect(ProviderSecretEnvironmentVariable.allCases.count == 3)
+    }
+
+    @Test func providerScopedReferencesAreDistinctPerProviderAndVariable() {
+        let claude = ref("claude-acp", .anthropic)
+        let geminiProvider = ref("claude-acp", .gemini)
+        #expect(claude != geminiProvider)
+        #expect(CredentialLocations.location(for: claude).service
+            == "org.sockpuppet.WikiFS.credentials")
+    }
+
+    // MARK: Migration semantics
+
+    @Test func plaintextSecretsMoveToKeychainAndLeaveTheSidecar() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["ANTHROPIC_API_KEY": "sk-legacy"])
+        let credentials = InMemoryCredentialService()
+        let outcome = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        #expect(outcome.migrated.count == 1)
+        // The value landed in the service under the typed reference...
+        let reference = ref("claude-acp", .anthropic)
+        #expect(try credentials.resolve(reference).value == "sk-legacy")
+        // ...and the sidecar no longer carries it.
+        let reloaded = AgentProvidersConfig.load(from: directory)
+        #expect(reloaded?.providers.first?.env["ANTHROPIC_API_KEY"] == nil)
+        #expect(outcome.isClean)
+    }
+
+    @Test func nonSecretEnvironmentSurvivesMigration() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: [
+            "CLAUDE_CODE_EXECUTABLE": "/usr/local/bin/claude",
+            "ANTHROPIC_API_KEY": "sk-legacy",
+        ])
+        let credentials = InMemoryCredentialService()
+        _ = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        let reloaded = AgentProvidersConfig.load(from: directory)
+        #expect(
+            reloaded?.providers.first?.env["CLAUDE_CODE_EXECUTABLE"]
+                == "/usr/local/bin/claude")
+    }
+
+    @Test func equalValueDuplicatePlaintextIsRemovedWithoutRewrite() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["ANTHROPIC_API_KEY": "same"])
+        let credentials = InMemoryCredentialService(seed: [ref("claude-acp", .anthropic): "same"])
+        let outcome = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        #expect(outcome.removedDuplicates.count == 1)
+        #expect(outcome.migrated.isEmpty)
+        let reloaded = AgentProvidersConfig.load(from: directory)
+        #expect(reloaded?.providers.first?.env["ANTHROPIC_API_KEY"] == nil)
+        // The Keychain value is untouched.
+        #expect(try credentials.resolve(ref("claude-acp", .anthropic)).value == "same")
+    }
+
+    @Test func conflictingPlaintextIsNotDeletedWhenValuesDiffer() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["ANTHROPIC_API_KEY": "plaintext"])
+        let credentials = InMemoryCredentialService(seed: [ref("claude-acp", .anthropic): "keychain-value"])
+        let outcome = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        // Conflict: preserve BOTH values, overwrite nothing, surface bounded status.
+        #expect(outcome.conflicts.count == 1)
+        #expect(outcome.migrated.isEmpty)
+        #expect(outcome.isClean == false)
+        // The plaintext entry survives ON DISK (decode strips it from
+        // memory by design — the file is the durability contract here).
+        let persisted = try String(
+            contentsOf: directory.appendingPathComponent("agent-providers.json"),
+            encoding: .utf8)
+        #expect(persisted.contains("ANTHROPIC_API_KEY") == true)
+        #expect(persisted.contains("plaintext") == true)
+        #expect(try credentials.resolve(ref("claude-acp", .anthropic)).value == "keychain-value")
+        // The bounded report carries names only — never a value.
+        let mirrored = "\(outcome)"
+        #expect(mirrored.contains("plaintext") == false)
+        #expect(mirrored.contains("keychain-value") == false)
+    }
+
+    @Test func failedWritePreservesThePlaintextEntry() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["GEMINI_API_KEY": "gem-legacy"])
+        let credentials = FailingWriteCredentialService()
+        let outcome = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        #expect(outcome.failures.count == 1)
+        // The failed entry's plaintext survives on disk (never lose a key).
+        let persisted = try String(
+            contentsOf: directory.appendingPathComponent("agent-providers.json"),
+            encoding: .utf8)
+        #expect(persisted.contains("GEMINI_API_KEY") == true)
+        #expect(persisted.contains("gem-legacy") == true)
+    }
+
+    @Test func unmappableProviderKeepsPlaintextAndReports() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(
+            directory: directory, providerID: "my agent",
+            env: ["ANTHROPIC_API_KEY": "sk-orphan"])
+        let credentials = InMemoryCredentialService()
+        let outcome = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        #expect(outcome.unmappable.count == 1)
+        // The unmappable plaintext survives on disk untouched.
+        let persisted = try String(
+            contentsOf: directory.appendingPathComponent("agent-providers.json"),
+            encoding: .utf8)
+        #expect(persisted.contains("ANTHROPIC_API_KEY") == true)
+        #expect(persisted.contains("sk-orphan") == true)
+    }
+
+    @Test func migrationIsIdempotent() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["ANTHROPIC_API_KEY": "sk-twice"])
+        let credentials = InMemoryCredentialService()
+        let store = makeStore(directory)
+        let first = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: store, credentials: credentials)
+        #expect(first.migrated.count == 1)
+        let second = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: store, credentials: credentials)
+        #expect(second.migrated.isEmpty)
+        #expect(second.removedDuplicates.isEmpty)
+        #expect(second.isClean)
+    }
+
+    @Test func cleanSidecarSkipsTheLockedMutation() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["CLAUDE_CODE_EXECUTABLE": "/x"])
+        let credentials = InMemoryCredentialService()
+        let outcome = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        #expect(outcome.migrated.isEmpty)
+        #expect(outcome.isClean)
+    }
+
+    @Test func concurrentSidecarMutationsStayConsistent() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: [
+            "ANTHROPIC_API_KEY": "sk-a",
+            "OPENAI_API_KEY": "sk-b",
+        ])
+        let credentials = InMemoryCredentialService()
+        let store = makeStore(directory)
+        // Two overlapping migration passes (the in-process gate + file lock
+        // serialize them; the raw scan may observe the legacy file in both).
+        // The DURABLE invariants hold regardless of interleaving: the sidecar
+        // ends secret-free and the service holds both resolved values.
+        async let first: AgentProviderCredentialMigrationReport =
+            AgentProviderCredentialMigrator.migrateIfNeeded(
+                directory: directory, store: store, credentials: credentials)
+        async let second: AgentProviderCredentialMigrationReport =
+            AgentProviderCredentialMigrator.migrateIfNeeded(
+                directory: directory, store: store, credentials: credentials)
+        let (firstReport, secondReport) = await (first, second)
+        #expect(firstReport.conflicts.isEmpty && firstReport.failures.isEmpty)
+        #expect(secondReport.conflicts.isEmpty && secondReport.failures.isEmpty)
+        let reloaded = AgentProvidersConfig.load(from: directory)
+        #expect(reloaded?.providers.first?.env["ANTHROPIC_API_KEY"] == nil)
+        #expect(reloaded?.providers.first?.env["OPENAI_API_KEY"] == nil)
+        #expect(try credentials.resolve(ref("claude-acp", .anthropic)).value == "sk-a")
+        #expect(try credentials.resolve(ref("claude-acp", .openAI)).value == "sk-b")
+        // The persisted sidecar carries no plaintext.
+        let persisted = try String(
+            contentsOf: directory.appendingPathComponent("agent-providers.json"),
+            encoding: .utf8)
+        #expect(persisted.contains("sk-a") == false)
+        #expect(persisted.contains("sk-b") == false)
+    }
+
+    @Test func removalOfPlaintextPersistsAfterSuccess() async throws {
+        let directory = try makeDirectory()
+        try seedRawSidecar(directory: directory, env: ["OPENAI_API_KEY": "sk-openai"])
+        let credentials = InMemoryCredentialService()
+        _ = await AgentProviderCredentialMigrator.migrateIfNeeded(
+            directory: directory, store: makeStore(directory), credentials: credentials)
+        let persisted = try String(
+            contentsOf: directory.appendingPathComponent("agent-providers.json"),
+            encoding: .utf8)
+        #expect(persisted.contains("sk-openai") == false)
+        #expect(persisted.contains("OPENAI_API_KEY") == false)
+    }
+}
+
+/// A credential service whose writes FAIL (exercising never-lose-a-key).
+struct FailingWriteCredentialService: CredentialDescribing, CredentialWriting,
+    CredentialResolving {
+    func describe(_ reference: CredentialReference) -> CredentialInfo {
+        CredentialInfo(
+            reference: reference, isConfigured: false,
+            source: .keychain, isWritable: true)
+    }
+
+    func describe(_ references: [CredentialReference]) -> [CredentialReference: CredentialInfo] {
+        [:]
+    }
+
+    var maximumDescribeBatchSize: Int { 64 }
+
+    func set(_ value: String?, for reference: CredentialReference) throws {
+        throw CredentialStoreError.writeFailed(operation: "add", status: -25299)
+    }
+
+    func unset(_ reference: CredentialReference) throws {
+        throw CredentialStoreError.writeFailed(operation: "delete", status: -25299)
+    }
+
+    func resolve(_ reference: CredentialReference) throws -> ResolvedCredential {
+        throw CredentialStoreError.notConfigured(reference)
+    }
+}

--- a/Tests/WikiFSTests/CredentialKeychainMultiprocessTests.swift
+++ b/Tests/WikiFSTests/CredentialKeychainMultiprocessTests.swift
@@ -1,0 +1,111 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFSCore
+import WikiFSTypes
+
+/// OPT-IN real-Keychain coverage for the shared credential service
+/// (`WIKIFS_KEYCHAIN_TESTS=1 swift test --filter CredentialKeychainMultiprocessTests`).
+///
+/// Skipped by default so `swift test` never persists test secrets: the
+/// default suite set exercises the same contracts against
+/// `InMemoryCredentialService` (`CredentialServiceContractTests`) and asserts
+/// the physical mapping without touching Keychain
+/// (`LegacyCredentialAdapterTests`). CI additionally lacks the production
+/// `keychain-access-groups` entitlement, so the SIGNED app/daemon smoke
+/// (plans/keychain-sharing.md §5.2) remains the production access-group gate;
+/// the limitation is documented in plans/credential-service.md.
+///
+/// What this fixture adds when enabled: REAL SecItem round-trips through
+/// `KeychainCredentialService` plus CROSS-PROCESS visibility — the `security`
+/// CLI (a separate process) must see the item the test wrote, mirroring the
+/// app-writes/daemon-reads shape (AC.9's physical substrate).
+///
+/// Cleanup discipline: the item is deleted in EVERY terminal path (the
+/// deferred unset plus the success assertion), and the account name embeds a
+/// UUID so reruns can never collide with prior runs or real credentials.
+@Suite(
+    .serialized,
+    .timeLimit(.minutes(2)),
+    .disabled(
+        if: ProcessInfo.processInfo.environment["WIKIFS_KEYCHAIN_TESTS"] == nil,
+        "Set WIKIFS_KEYCHAIN_TESTS=1 to run real-Keychain tests")
+)
+struct CredentialKeychainMultiprocessTests {
+
+    @Test func parentAndHelperProcessRoundTripAUniqueItem() async throws {
+        let service = KeychainCredentialService()
+
+        // 0. ABSENCE is distinct from failure on the live keychain: a read
+        //    of a never-written unique account throws .notConfigured —
+        //    not a keychain status error.
+        let absentReference = try CredentialReference(
+            validating: "test.absent.\(UUID().uuidString.lowercased())")
+        do {
+            _ = try service.resolve(absentReference)
+            Issue.record("expected notConfigured for an absent item")
+        } catch CredentialStoreError.notConfigured {
+            // expected — absence, not a Keychain failure
+        } catch {
+            Issue.record("unexpected error for absent item: \(error)")
+        }
+        // A unique reference under the shared credential service — never a
+        // legacy location, never a real credential.
+        let reference = try CredentialReference(
+            validating: "test.multiprocess.\(UUID().uuidString.lowercased())")
+        let location = CredentialLocations.location(for: reference)
+        #expect(location.service == "org.sockpuppet.WikiFS.credentials")
+
+        // 1. Parent writes through the service.
+        try service.set("multiprocess-canary-\(reference.rawValue.suffix(8))", for: reference)
+        defer { try? service.unset(reference) }
+
+        // 2. Parent reads it back through the service.
+        let resolved = try service.resolve(reference)
+        #expect(resolved.value.contains("multiprocess-canary"))
+
+        // 3. A HELPER PROCESS (the `security` CLI) sees the same item —
+        //    cross-process Keychain visibility in the un-grouped test
+        //    keychain.
+        let seenByHelper = try await Task.detached(priority: .userInitiated) { () -> Bool in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+            process.arguments = [
+                "find-generic-password",
+                "-s", location.service,
+                "-a", location.account,
+            ]
+            // Non-blocking completion + timeout (repo #1051 discipline).
+            let seen = try await withThrowingTaskGroup(of: Bool.self) { group -> Bool in
+                group.addTask {
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Bool, Error>) in
+                        process.terminationHandler = { termination in
+                            continuation.resume(returning: termination.terminationStatus == 0)
+                        }
+                        do {
+                            try process.run()
+                        } catch {
+                            continuation.resume(throwing: error)
+                        }
+                    }
+                }
+                group.addTask {
+                    try? await Task.sleep(for: .seconds(15))
+                    if process.isRunning { process.terminate() }
+                    return false
+                }
+                let result = try await group.next() ?? false
+                group.cancelAll()
+                return result
+            }
+            return seen
+        }.value
+        #expect(seenByHelper)
+
+        // 4. Terminal cleanup — delete in the success path too (the defer
+        //    covers throws/skips above).
+        try service.unset(reference)
+        #expect(service.describe(reference).isConfigured == false)
+    }
+}
+#endif

--- a/Tests/WikiFSTests/CredentialReferenceTests.swift
+++ b/Tests/WikiFSTests/CredentialReferenceTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+import WikiFSTypes
+
+/// Grammar, namespace, factory, and Codable-stability tests for
+/// `CredentialReference` (issue #1159 — AC.1: distinct typed namespaces with
+/// validated construction).
+struct CredentialReferenceTests {
+
+    // MARK: Grammar
+
+    @Test func acceptsWellFormedReferences() throws {
+        for raw in ["acp.agent-api-key", "zotero.api-key",
+                    "provider.claude-acp.anthropic-api-key",
+                    "a.b", "vimeo.api-key", "provider.my_agent.OPENAI_API_KEY"] {
+            #expect(try CredentialReference(validating: raw).rawValue == raw)
+        }
+    }
+
+    @Test func rejectsMalformedReferences() {
+        for raw in ["", "single", "a.b.c.d", ".leading", "trailing.",
+                    "has space.key", "ok-key.≠nonascii",
+                    "under_score..gap", "toolong." + String(repeating: "a", count: 70)] {
+            #expect(throws: CredentialReferenceError.self) {
+                _ = try CredentialReference(validating: raw)
+            }
+        }
+    }
+
+    @Test func uppercaseLettersAreGrammarValid() throws {
+        // The grammar admits ASCII letters in any case (injective, and it
+        // lets dynamic domains embed existing identifiers verbatim).
+        #expect(try CredentialReference(validating: "UPPER.key").rawValue == "UPPER.key")
+    }
+
+    @Test func labelBoundaries() {
+        #expect(CredentialReference.isValidLabel("a"))
+        #expect(CredentialReference.isValidLabel(String(repeating: "a", count: 64)))
+        #expect(!CredentialReference.isValidLabel(String(repeating: "a", count: 65)))
+        #expect(CredentialReference.isValidLabel("a-b_c9"))
+        #expect(!CredentialReference.isValidLabel("-leading"))
+        #expect(!CredentialReference.isValidLabel("trailing-"))
+        #expect(!CredentialReference.isValidLabel("_leading"))
+        #expect(!CredentialReference.isValidLabel("9--"))  // ends with '-'
+    }
+
+    // MARK: Namespace separation (AC.1)
+
+    @Test func namespacesRemainDistinct() throws {
+        // Same final label in different domains are different credentials.
+        let acp = try CredentialReference(validating: "acp.api-key")
+        let zotero = try CredentialReference(validating: "zotero.api-key")
+        #expect(acp != zotero)
+        #expect(acp.hashValue != zotero.hashValue || acp != zotero)
+
+        // Label count differences are distinct identities.
+        let two = try CredentialReference(validating: "acp.provider")
+        let three = try CredentialReference(validating: "acp.provider.claude")
+        #expect(two != three)
+
+        // Underscore vs hyphen are distinct labels (injective grammar).
+        let hyphen = try CredentialReference(validating: "provider.my-agent.k")
+        let underscore = try CredentialReference(validating: "provider.my_agent.k")
+        #expect(hyphen != underscore)
+    }
+
+    // MARK: Typed factories
+
+    @Test func legacyFactoriesProduceExpectedRawValues() {
+        #expect(CredentialReference.acpAgent().rawValue == "acp.agent-api-key")
+        #expect(CredentialReference.zoteroAPIKey().rawValue == "zotero.api-key")
+        #expect(
+            CredentialReference.acpProvider(ProviderID(rawValue: "claude-acp"))?
+                .rawValue == "acp.provider.claude-acp")
+        #expect(
+            CredentialReference.extraction("docling-serve-token")?
+                .rawValue == "extraction.docling-serve-token")
+    }
+
+    @Test func credentialFactoriesRejectUncheckedComponents() {
+        // A provider id that cannot form a valid label yields nil — the
+        // adapter keeps its legacy path for such ids instead of misfiling
+        // the credential under a mangled name.
+        #expect(CredentialReference.acpProvider(ProviderID(rawValue: "my agent")) == nil)
+        #expect(CredentialReference.acpProvider(ProviderID(rawValue: "")) == nil)
+        #expect(CredentialReference.acpProvider(ProviderID(rawValue: "a.b")) == nil)
+        #expect(CredentialReference.extraction("not a key") == nil)
+    }
+
+    @Test func providerSecretFactoryIsDeterministic() throws {
+        let variable = ProviderSecretEnvironmentVariable.anthropic
+        let first = CredentialReference.providerSecret(
+            providerID: ProviderID(rawValue: "claude-acp"), variable: variable)
+        let second = CredentialReference.providerSecret(
+            providerID: ProviderID(rawValue: "claude-acp"), variable: variable)
+        #expect(first == second)
+        #expect(first?.rawValue == "provider.claude-acp.anthropic-api-key")
+        #expect(
+            CredentialReference.providerSecret(
+                providerID: ProviderID(rawValue: "gemini"),
+                variable: .openAI)?.rawValue == "provider.gemini.openai-api-key")
+        #expect(first?.domain == "provider")
+    }
+
+    // MARK: Codable stability + Comparable
+
+    @Test func codableRoundTripsThroughTheRawString() throws {
+        let original = try CredentialReference(validating: "provider.claude-acp.anthropic-api-key")
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CredentialReference.self, from: data)
+        #expect(decoded == original)
+        #expect(String(data: data, encoding: .utf8)?.contains("provider.claude-acp.anthropic-api-key") == true)
+    }
+
+    @Test func comparableOrdersByRawValue() throws {
+        let left = try CredentialReference(validating: "acp.agent-api-key")
+        let right = try CredentialReference(validating: "zotero.api-key")
+        #expect(left < right)
+    }
+}

--- a/Tests/WikiFSTests/CredentialSecretScopeAuditTests.swift
+++ b/Tests/WikiFSTests/CredentialSecretScopeAuditTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import WikiFSEngine
+import WikiFSTypes
+
+/// Secret-scope audit (issue #1159 — AC.5): known provider API-key variables
+/// cannot survive decode normalization, write boundaries, or provider spawn
+/// preparation as sidecar data. Non-secret environment variables must still
+/// round-trip unchanged.
+struct CredentialSecretScopeAuditTests {
+
+    /// A legacy sidecar payload with a plaintext API key — decodes today,
+    /// must decode SECRET-FREE after the #1159 boundary.
+    private static let legacyJSON = """
+    {
+      "providers": [
+        {
+          "id": "claude-acp",
+          "label": "Claude",
+          "command": ["claude", "--acp"],
+          "env": {
+            "ANTHROPIC_API_KEY": "sk-plaintext-legacy",
+            "CLAUDE_CODE_EXECUTABLE": "/usr/local/bin/claude"
+          },
+          "enabled": true,
+          "isDefault": true
+        }
+      ],
+      "generation": 7
+    }
+    """
+
+    @Test func decodeNormalizationDropsKnownSecretVariables() throws {
+        let data = Data(Self.legacyJSON.utf8)
+        let config = try JSONDecoder().decode(AgentProvidersConfig.self, from: data)
+        let provider = try #require(config.providers.first)
+        #expect(provider.env["ANTHROPIC_API_KEY"] == nil)
+        // Non-secret env survives.
+        #expect(provider.env["CLAUDE_CODE_EXECUTABLE"] == "/usr/local/bin/claude")
+        #expect(config.generation == 7)
+    }
+
+    @Test func decodeReEncodesWithoutTheSecret() throws {
+        let data = Data(Self.legacyJSON.utf8)
+        let config = try JSONDecoder().decode(AgentProvidersConfig.self, from: data)
+        let encoded = try JSONEncoder().encode(config)
+        let payload = String(decoding: encoded, as: UTF8.self)
+        #expect(payload.contains("sk-plaintext-legacy") == false)
+        #expect(payload.contains("ANTHROPIC_API_KEY") == false)
+    }
+
+    @Test func writeBoundaryStripsInMemorySmuggledSecrets() async throws {
+        // An in-place mutation bypasses init/decode — the WRITE boundary must
+        // still keep the plaintext off disk.
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("scope-audit-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let config = AgentProvidersConfig.seed(discovered: [])
+        var smuggled = config
+        smuggled.providers[0].env["ANTHROPIC_API_KEY"] = "sk-smuggled"
+        try smuggled.writeAtomically(to: directory)
+        let persisted = try String(
+            contentsOf: directory.appendingPathComponent("agent-providers.json"),
+            encoding: .utf8)
+        #expect(persisted.contains("sk-smuggled") == false)
+        #expect(persisted.contains("ANTHROPIC_API_KEY") == false)
+    }
+
+    @Test func valueMutationsPreserveNonSecretEnvironment() {
+        var provider = AgentProvider(
+            id: ProviderID(rawValue: "gemini"),
+            label: "Gemini",
+            env: ["GOOGLE_GENAI_USE_VERTEXAI": "1"])
+        // The #1159 funnel (init/normalized) keeps non-secret values.
+        let roundTripped = AgentProvidersConfig(providers: [provider])
+        #expect(
+            roundTripped.providers.first?.env["GOOGLE_GENAI_USE_VERTEXAI"] == "1")
+        // And a secret present in memory cannot enter a fresh config.
+        provider.env["GEMINI_API_KEY"] = "AIza-secret"
+        let cleaned = AgentProvidersConfig(providers: [provider])
+        #expect(cleaned.providers.first?.env["GEMINI_API_KEY"] == nil)
+        #expect(
+            cleaned.providers.first?.env["GOOGLE_GENAI_USE_VERTEXAI"] == "1")
+    }
+
+    @Test func spawnPreparationResolvesSecretsOnlyFromTheService() throws {
+        // The spawn seam resolves known secrets from the credential service,
+        // not from the sidecar provider: a stripped provider + a configured
+        // service yields exactly the resolved env hint, nothing else.
+        let reference = try #require(CredentialReference.providerSecret(
+            providerID: ProviderID(rawValue: "claude-acp"), variable: .anthropic))
+        let credentials = InMemoryCredentialService(seed: [reference: "sk-resolved"])
+        let secrets = ProviderSecretEnvironment.resolvedSpawnSecrets(
+            for: ProviderID(rawValue: "claude-acp"), resolving: credentials)
+        #expect(secrets == ["ANTHROPIC_API_KEY": "sk-resolved"])
+
+        // A provider with a plaintext env secret cannot influence the spawn:
+        // the sidecar layer stripped it at decode.
+        let legacy = try JSONDecoder().decode(
+            AgentProvidersConfig.self, from: Data(Self.legacyJSON.utf8))
+        #expect(legacy.providers[0].env["ANTHROPIC_API_KEY"] == nil)
+    }
+}
+
+/// Provider runtime spawn-secret tests (plan step 29): each selected provider
+/// receives ONLY its own resolved known secret variables, rotation is visible
+/// on the next preparation, and non-secret `provider.env` behavior is
+/// unchanged.
+@Suite(.serialized)
+struct AgentProviderSpawnSecretTests {
+
+    /// Unwrapping helper: these provider ids are grammar-valid literals.
+    private func ref(
+        _ provider: String, _ variable: ProviderSecretEnvironmentVariable
+    ) -> CredentialReference {
+        guard let reference = CredentialReference.providerSecret(
+            providerID: ProviderID(rawValue: provider), variable: variable)
+        else { preconditionFailure("test provider id must satisfy the grammar") }
+        return reference
+    }
+
+    @Test func eachProviderReceivesOnlyItsOwnSecrets() async throws {
+        let credentials = InMemoryCredentialService(seed: [
+            ref("claude-acp", .anthropic): "sk-claude",
+            ref("codex", .openAI): "sk-openai",
+        ])
+        let claudeSecrets = ProviderSecretEnvironment.resolvedSpawnSecrets(
+            for: ProviderID(rawValue: "claude-acp"), resolving: credentials)
+        #expect(claudeSecrets == ["ANTHROPIC_API_KEY": "sk-claude"])
+        let codexSecrets = ProviderSecretEnvironment.resolvedSpawnSecrets(
+            for: ProviderID(rawValue: "codex"), resolving: credentials)
+        #expect(codexSecrets == ["OPENAI_API_KEY": "sk-openai"])
+    }
+
+    @Test func rotationIsVisibleOnTheNextResolution() async throws {
+        let credentials = InMemoryCredentialService()
+        let providerID = ProviderID(rawValue: "claude-acp")
+        let reference = ref("claude-acp", .anthropic)
+        try credentials.set("sk-first", for: reference)
+        #expect(
+            ProviderSecretEnvironment.resolvedSpawnSecrets(
+                for: providerID, resolving: credentials)["ANTHROPIC_API_KEY"] == "sk-first")
+        // Rotate the value in the service — the next preparation (i.e. the
+        // next resolution) observes the new value without any rebuild.
+        try credentials.set("sk-rotated", for: reference)
+        #expect(
+            ProviderSecretEnvironment.resolvedSpawnSecrets(
+                for: providerID, resolving: credentials)["ANTHROPIC_API_KEY"] == "sk-rotated")
+    }
+
+    @Test func runtimeMergesResolvedSecretsIntoSpawnHints() async throws {
+        // Full runtime path: the prepared backend's hints carry the resolved
+        // secret under the env. prefix, merged over the non-secret provider env.
+        let credentials = InMemoryCredentialService(seed: [
+            ref("claude-acp", .anthropic): "sk-runtime",
+        ])
+        let config = AgentProvidersConfig(
+            providers: [
+                AgentProvider(
+                    id: ProviderID(rawValue: "claude-acp"),
+                    label: "Claude",
+                    command: ["/bin/echo"],
+                    env: ["CLAUDE_CODE_EXECUTABLE": "/bin/claude"]),
+            ],
+            selectedModelIds: ["claude-acp": ModelID(rawValue: "sonnet")])
+        let runtime = AgentProviderRuntime(
+            readConfiguration: { config },
+            resolveCommand: { providers in
+                Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0.command ?? []) })
+            },
+            readCredential: { _ in nil },
+            readSpawnSecrets: {
+                ProviderSecretEnvironment.resolvedSpawnSecrets(
+                    for: $0, resolving: credentials)
+            },
+            resolvePermissionPolicy: { _ in .bypass })
+        let preparation = try await runtime.prepare(.interactive)
+        let token = preparation.selection.token
+        defer { Task { await runtime.release(token) } }
+        let backend = try await runtime.preparedBackend(
+            from: token, stage: .chat)
+        #expect(
+            backend.profile.providerHints["env.ANTHROPIC_API_KEY"] == "sk-runtime")
+        // Non-secret provider env still rides the env. prefix.
+        #expect(
+            backend.profile.providerHints["env.CLAUDE_CODE_EXECUTABLE"] == "/bin/claude")
+    }
+
+    @Test func absentCredentialsOmitHints() async throws {
+        let credentials = InMemoryCredentialService()
+        let config = AgentProvidersConfig(
+            providers: [
+                AgentProvider(
+                    id: ProviderID(rawValue: "claude-acp"),
+                    label: "Claude",
+                    command: ["/bin/echo"]),
+            ],
+            selectedModelIds: ["claude-acp": ModelID(rawValue: "sonnet")])
+        let runtime = AgentProviderRuntime(
+            readConfiguration: { config },
+            resolveCommand: { providers in
+                Dictionary(uniqueKeysWithValues: providers.map { ($0.id, $0.command ?? []) })
+            },
+            readCredential: { _ in nil },
+            readSpawnSecrets: {
+                ProviderSecretEnvironment.resolvedSpawnSecrets(
+                    for: $0, resolving: credentials)
+            },
+            resolvePermissionPolicy: { _ in .bypass })
+        let preparation = try await runtime.prepare(.interactive)
+        let token = preparation.selection.token
+        defer { Task { await runtime.release(token) } }
+        let backend = try await runtime.preparedBackend(from: token, stage: .chat)
+        #expect(backend.profile.providerHints["env.ANTHROPIC_API_KEY"] == nil)
+        #expect(backend.profile.providerHints["env.GEMINI_API_KEY"] == nil)
+        #expect(backend.profile.providerHints["env.OPENAI_API_KEY"] == nil)
+    }
+}

--- a/Tests/WikiFSTests/CredentialServiceContractTests.swift
+++ b/Tests/WikiFSTests/CredentialServiceContractTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+import WikiFSTypes
+
+/// The shared credential-service CONTRACT (issue #1159 — AC.2/AC.4). The same
+/// suite runs against every conformer; today that is the in-memory service.
+/// A new backend (e.g. a synced-vault source) adds its factory to
+/// `services()` without copying a single assertion.
+struct CredentialServiceContractTests {
+
+    /// Every conformer under test. The Keychain-backed service intentionally
+    /// does NOT appear here: contract tests write and delete values, and the
+    /// legacy physical locations are compatibility surfaces (the opt-in
+    /// `CredentialKeychainMultiprocessTests` covers the real backend).
+    static func services() -> [CredentialService] {
+        [InMemoryCredentialService()]
+    }
+
+    static let reference = CredentialReference.zoteroAPIKey()
+    static let otherReference = CredentialReference.acpAgent()
+
+    @Test
+    func setThenDescribeShowsConfiguredAndResolveReturnsTheValue() throws {
+        let service = Self.services()[0]
+        #expect(service.describe(Self.reference).isConfigured == false)
+        try service.set("sk-ant-live", for: Self.reference)
+        let info = service.describe(Self.reference)
+        #expect(info.isConfigured == true)
+        #expect(info.source == .keychain)
+        #expect(info.isWritable == true)
+        #expect(info.description.contains("sk-ant-live") == false)
+        let resolved = try service.resolve(Self.reference)
+        #expect(resolved.value == "sk-ant-live")
+    }
+
+    @Test
+    func nilEmptyAndWhitespaceWritesNormalizeToUnset() throws {
+        let service = Self.services()[0]
+        try service.set("value", for: Self.reference)
+        try service.set("   ", for: Self.reference)
+        #expect(service.describe(Self.reference).isConfigured == false)
+        try service.set("\n\t", for: Self.reference)
+        #expect(service.describe(Self.reference).isConfigured == false)
+        try service.set("", for: Self.reference)
+        #expect(service.describe(Self.reference).isConfigured == false)
+        try service.set(nil, for: Self.reference)
+        #expect(service.describe(Self.reference).isConfigured == false)
+    }
+
+    @Test
+    func resolveNeverReturnsAnEmptyValue() throws {
+        let service = Self.services()[0]
+        #expect(throws: CredentialStoreError.notConfigured(Self.reference)) {
+            _ = try service.resolve(Self.reference)
+        }
+    }
+
+    @Test
+    func unsetRemovesAndIsIdempotent() throws {
+        let service = Self.services()[0]
+        try service.set("value", for: Self.reference)
+        try service.unset(Self.reference)
+        #expect(service.describe(Self.reference).isConfigured == false)
+        // Removing an absent credential succeeds.
+        try service.unset(Self.reference)
+    }
+
+    @Test
+    func valuesStayIsolatedPerReference() throws {
+        let service = Self.services()[0]
+        try service.set("zotero-key", for: Self.reference)
+        try service.set("acp-key", for: Self.otherReference)
+        #expect(try service.resolve(Self.reference).value == "zotero-key")
+        #expect(try service.resolve(Self.otherReference).value == "acp-key")
+        try service.unset(Self.reference)
+        #expect(try service.resolve(Self.otherReference).value == "acp-key")
+    }
+
+    @Test
+    func boundedBatchDescribeAnswersEveryReference() throws {
+        let service = Self.services()[0]
+        let references = (0..<service.maximumDescribeBatchSize + 8).map { offset in
+            // Deterministic, grammar-valid references.
+            (try? CredentialReference(
+                validating: "test.batch-\(offset).key-\(offset)")) ?? Self.reference
+        }
+        let described = service.describe(references)
+        #expect(described.count == service.maximumDescribeBatchSize)
+    }
+
+    @Test
+    func resolvedCredentialDescriptionsAreRedacted() throws {
+        let service = Self.services()[0]
+        try service.set("super-secret-canary-value", for: Self.reference)
+        let resolved = try service.resolve(Self.reference)
+        #expect(resolved.description.contains("super-secret-canary-value") == false)
+        #expect(resolved.debugDescription.contains("super-secret-canary-value") == false)
+        #expect("\(resolved)".contains("super-secret-canary-value") == false)
+    }
+
+    @Test func credentialInfoHasNoValueSurface() throws {
+        // AC.4: `CredentialInfo` cannot carry a value — reflect over its
+        // stored properties so an accidental `value` field fails this test.
+        let mirror = Mirror(reflecting: CredentialInfo(
+            reference: Self.reference, isConfigured: true,
+            source: .keychain, isWritable: true))
+        let propertyNames = mirror.children.compactMap(\.label)
+        #expect(propertyNames == ["reference", "isConfigured", "source", "isWritable"])
+    }
+
+    @Test func inMemoryServiceSatisfiesReferenceContract() throws {
+        // AC.2: the service API stays domain-neutral — the generic protocols
+        // reference no extractor/ACP/Zotero vocabulary. Assert via a local
+        // conformance that no domain types appear in the protocol surface
+        // (compile-time contract mirrored at runtime through the generic
+        // handle).
+        let service: any CredentialService = InMemoryCredentialService()
+        try service.set("x", for: Self.reference)
+        _ = try service.resolve(Self.reference)
+        try service.unset(Self.reference)
+    }
+}
+
+/// `CredentialValue` normalization boundary — the ONE place deciding
+/// value vs. absence.
+struct CredentialValueNormalizationTests {
+
+    @Test func whitespaceOnlyIsEmpty() {
+        #expect(CredentialValue.normalized(nil) == nil)
+        #expect(CredentialValue.normalized("") == nil)
+        #expect(CredentialValue.normalized("   ") == nil)
+        #expect(CredentialValue.normalized(" \n\t ") == nil)
+    }
+
+    @Test func realValuesArePreservedByteForByte() {
+        // Leading/trailing whitespace on a real value is NOT trimmed — the
+        // service never mutates a secret.
+        #expect(CredentialValue.normalized(" key ") == " key ")
+        #expect(CredentialValue.normalized("k") == "k")
+    }
+}

--- a/Tests/WikiFSTests/KeychainSecretStoreTests.swift
+++ b/Tests/WikiFSTests/KeychainSecretStoreTests.swift
@@ -77,5 +77,25 @@ struct KeychainSecretStoreTests {
         #expect(query[kSecUseDataProtectionKeychain as String] as? Bool == true)
         #expect(query[kSecAttrAccessGroup as String] == nil)
     }
+
+    // MARK: - Throwing reads (#1159 credential service backend)
+
+    @Test func throwingReadQueryMatchesTheSharedBaseQueryShape() {
+        // The throwing path queries with exactly the attributes the
+        // legacy path used (service + account + optional DP/group), so a
+        // legacy item is found in place. The REAL absence-vs-failure
+        // semantics of `readOrThrow` need a live keychain — that coverage is
+        // the opt-in `CredentialKeychainMultiprocessTests` (the configured
+        // access group on signed machines makes an un-gated real read throw
+        // errSecMissingEntitlement here).
+        let query = KeychainSecretStore.baseQuery(
+            service: "org.sockpuppet.WikiFS.credentials",
+            account: "test.reference",
+            useDP: KeychainSecretStore.useDataProtectionKeychain,
+            accessGroup: KeychainSecretStore.accessGroup)
+        #expect(query[kSecClass as String] as? String == kSecClassGenericPassword as String)
+        #expect(query[kSecAttrService as String] as? String == "org.sockpuppet.WikiFS.credentials")
+        #expect(query[kSecAttrAccount as String] as? String == "test.reference")
+    }
 }
 #endif // os(macOS)

--- a/Tests/WikiFSTests/LegacyCredentialAdapterTests.swift
+++ b/Tests/WikiFSTests/LegacyCredentialAdapterTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Adapter-parity + physical-location tests for the legacy credential stores
+/// (issue #1159 — AC.3). The migration must NOT copy or rename secrets: every
+/// legacy API must map to the EXACT service/account pair it always used.
+///
+/// The parity here is asserted at the mapping layer (`CredentialLocations` +
+/// the typed reference factories the adapters call) — the same code the
+/// adapters execute — so no test writes to the real Keychain (matching the
+/// non-polluting convention of the sibling `*CredentialStoreTests`). The
+/// opt-in `CredentialKeychainMultiprocessTests` round-trips the real backend.
+struct LegacyCredentialAdapterTests {
+
+    @Test func allLegacyReferencesKeepPhysicalLocations() throws {
+        let acpProviderClaude = try #require(
+            CredentialReference.acpProvider(ProviderID(rawValue: "claude-acp")))
+        let anthropic = try #require(CredentialReference.extraction("anthropic-api-key"))
+        let gemini = try #require(CredentialReference.extraction("gemini-api-key"))
+        let docling = try #require(CredentialReference.extraction("docling-serve-token"))
+
+        let cases: [(reference: CredentialReference, service: String, account: String)] = [
+            // ACP legacy single key + per-provider accounts (#324).
+            (.acpAgent(), "org.sockpuppet.WikiFS.acp", "acp-agent-api-key"),
+            (acpProviderClaude, "org.sockpuppet.WikiFS.acp", "acp-provider:claude-acp"),
+            // Extraction: anthropic, gemini, docling token.
+            (anthropic, "org.sockpuppet.WikiFS.extraction", "anthropic-api-key"),
+            (gemini, "org.sockpuppet.WikiFS.extraction", "gemini-api-key"),
+            (docling, "org.sockpuppet.WikiFS.extraction", "docling-serve-token"),
+            // Zotero.
+            (.zoteroAPIKey(), "org.sockpuppet.WikiFS.zotero", "zotero-api-key"),
+        ]
+        for entry in cases {
+            let location = CredentialLocations.location(for: entry.reference)
+            #expect(location.service == entry.service)
+            #expect(location.account == entry.account)
+        }
+    }
+
+    @Test func extractionSecretEnumKeepsLegacyAccounts() throws {
+        // The typed ExtractionSecret factory must keep producing the exact
+        // legacy accounts the KeychainExtractionCredentialStore always used.
+        let expected: [ExtractionSecret: String] = [
+            .anthropicAPIKey: "anthropic-api-key",
+            .geminiAPIKey: "gemini-api-key",
+            .doclingServeToken: "docling-serve-token",
+        ]
+        for (secret, account) in expected {
+            let reference = try #require(CredentialReference.extraction(secret))
+            let location = CredentialLocations.location(for: reference)
+            #expect(location.account == account)
+            #expect(location.service == "org.sockpuppet.WikiFS.extraction")
+        }
+    }
+
+    @Test func newReferencesUseTheSharedCredentialService() throws {
+        // Provider env secrets are NEW locations: the shared service, with
+        // the validated reference as the account.
+        let reference = try #require(CredentialReference.providerSecret(
+            providerID: ProviderID(rawValue: "claude-acp"),
+            variable: .anthropic))
+        let location = CredentialLocations.location(for: reference)
+        #expect(location.service == "org.sockpuppet.WikiFS.credentials")
+        #expect(location.account == reference.rawValue)
+    }
+
+    @Test func adaptersFallbackForIdsOutsideTheGrammar() throws {
+        // A provider id that cannot form a typed reference keeps the legacy
+        // direct path (physical account `acp-provider:<id>`), so an exotic
+        // custom id's stored key is never orphaned. The read contract is
+        // optional-nil without a stored value (no test Keychain pollution:
+        // the legacy path reads, finds nothing, returns nil).
+        let store = KeychainACPCredentialStore()
+        #expect(store.apiKey(forProvider: "my agent") == nil)
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of 4 for issue #1159 (domain-neutral credential service -> extractor credential authorization -> operation-scoped injection -> Docling Serve package).

Adds a shared, domain-neutral credential service and migrates the existing ACP, Extraction, and Zotero Keychain stores onto it as thin adapters. Secret VALUES stay in the Keychain at their exact existing locations; Settings and inspection surfaces lose every value-returning path.

## Layer owned by this PR

- WikiFSTypes: `CredentialReference` (validated grammar, typed factories), `CredentialSource`, `CredentialInfo` (no value field), `ResolvedCredential` (redacted descriptions), `CredentialStoreError`, and the `CredentialDescribing` / `CredentialWriting` / `CredentialResolving` protocol split with the single `CredentialValue` normalization boundary.
- WikiFSCore: `CredentialLocations` catalog (exact legacy service/account pairs; `org.sockpuppet.WikiFS.credentials` for new references), `KeychainCredentialService`, `InMemoryCredentialService`, throwing Keychain reads in `KeychainSecretStore`, and the adapters for the three legacy stores.
- Provider env secrets: closed `ProviderSecretEnvironmentVariable` set, decode + write-boundary stripping in `AgentProvidersConfig`, the app-owned lock-safe `AgentProviderCredentialMigrator` (write-before-remove, same-value duplicate removal, different-value conflict preserves both), trusted-host spawn-secret resolution in `AgentProviderRuntime`, env-editor rejection, and write-only per-provider credential controls.
- Settings authority: Zotero + Docling token fields are write-only (blank start, explicit Save/Remove, configured state via `describe`); Test Connection resolves through `HostCredentialActions` outside the views; `ContentView`'s presence check uses `describe`.

## Base

- Branch: `feature/general-credential-service`
- Base SHA: `73627d9d931bf7af198dd57e372147572abf313d` (`main` after #1162; the extractor-route stack)

## Child PRs (will target this branch)

- PR 2 `feature/extractor-credential-authorization` -> this branch
- PR 3 `feature/extractor-operation-credentials` -> PR 2
- PR 4 `feature/docling-serve-extractor-package` -> PR 3

## Gates run

- `swift test --filter 'CredentialReferenceTests|CredentialServiceContractTests|LegacyCredentialAdapterTests|KeychainSecretStoreTests|ExtractionCredentialStoreTests|ZoteroCredentialStoreTests|AgentProviderCredentialMigrationTests|CredentialSecretScopeAuditTests|AgentProviderSpawnSecretTests|CredentialValueNormalizationTests'` — 62 tests pass
- `WIKIFS_APP_TESTS=1 swift test --filter 'CredentialSettingsHostedTests|ExtractionRouteTableHostedTests'` — pass
- `make lint`, `make build`, `make test` (3928 tests), `git diff --check` — pass
- Opt-in `WIKIFS_KEYCHAIN_TESTS=1 swift test --filter CredentialKeychainMultiprocessTests` — real-Keychain round-trip + `security`-CLI cross-process visibility; kept opt-in because the un-entitled test runner cannot use the production access group (documented; the signed app/daemon smoke runbook remains the production gate)

## Out of scope (later PRs)

Manifest/protocol revision 2, extractor authorization records, per-operation credential files, redaction plumbing, the reviewed Docling Serve package, and Claude/Gemini package migration.
