### PR TITLE
feat(extractors): declare and authorize credential requirements

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -40,6 +40,15 @@ struct ExtractionSettingsView: View {
     /// Removes one exact revision from the extractor store. Same app-only rule
     /// as `importPackage`. Nil hides the Remove buttons.
     let removePackage: (@Sendable (ExtractorPackageRevisionID) async -> ExtractorPackageMutationOutcome)?
+    /// Grants (or re-grants) one requirement's credential binding. App-only:
+    /// nil hides the Authorize/Change controls (headless + daemon views are
+    /// read-only). Returns a redacted outcome; the confirmation copy states
+    /// the inheritance rule (plan step 22).
+    let authorizeRequirement: (@Sendable (ExtractorCredentialRequirementSummary) async -> ExtractorPackageMutationOutcome)?
+    /// Revokes one requirement's grant. The record stays attached to its
+    /// lineage; a reinstall shows (and may revoke) the stale grant. Nil hides
+    /// the Revoke control.
+    let revokeRequirement: (@Sendable (ExtractorCredentialRequirementSummary) async -> ExtractorPackageMutationOutcome)?
 
     // Route table rows built from the PR 2 projection: host descriptors, the
     // package model's registration snapshots, and saved selections. Rebuilt
@@ -64,6 +73,11 @@ struct ExtractionSettingsView: View {
     @State private var packageModel: ExtractorPackageSettingsModel
     @State private var showingImportPicker = false
     @State private var removalCandidate: ExtractorPackageSettingsRow?
+    /// Pending authorization confirmation (#1159). Non-nil shows the
+    /// explicit confirmation with the inheritance rule.
+    @State private var authorizationCandidate: ExtractorCredentialRequirementSummary?
+    /// Pending revocation confirmation.
+    @State private var revocationCandidate: ExtractorCredentialRequirementSummary?
 
     private enum TestPhase: Equatable {
         case idle
@@ -79,6 +93,8 @@ struct ExtractionSettingsView: View {
         verifyDoclingConnection: (@Sendable (_ endpoint: String) async -> String?)? = nil,
         fetcher: any HTTPRequestFetcher = URLSessionRequestFetcher(),
         packageSnapshot: (@Sendable () async -> ExtractorPackageSettingsSnapshot)? = nil,
+        authorizeRequirement: (@Sendable (ExtractorCredentialRequirementSummary) async -> ExtractorPackageMutationOutcome)? = nil,
+        revokeRequirement: (@Sendable (ExtractorCredentialRequirementSummary) async -> ExtractorPackageMutationOutcome)? = nil,
         importPackage: (@Sendable (URL) async -> ExtractorPackageMutationOutcome)? = nil,
         removePackage: (@Sendable (ExtractorPackageRevisionID) async -> ExtractorPackageMutationOutcome)? = nil
     ) {
@@ -93,6 +109,8 @@ struct ExtractionSettingsView: View {
         self.packageSnapshot = packageSnapshot
         self.importPackage = importPackage
         self.removePackage = removePackage
+        self.authorizeRequirement = authorizeRequirement
+        self.revokeRequirement = revokeRequirement
 
         // Seed the drafts once, at construction — so there's no onAppear race
         // where an `.onChange` fires before the loaded values are in place.
@@ -150,6 +168,13 @@ struct ExtractionSettingsView: View {
             if packageSnapshot != nil {
                 installedPackagesSection
             }
+
+            // Credential requirements (#1159): per-declaration authorization
+            // state and explicit Authorize / Change Credential / Revoke
+            // actions. Hidden when no snapshot loader was wired.
+            if packageSnapshot != nil {
+                credentialRequirementsSection
+            }
         }
         .formStyle(.grouped)
         .frame(minWidth: Metrics.width, minHeight: Metrics.height)
@@ -184,6 +209,21 @@ struct ExtractionSettingsView: View {
             } message: { row in
                 Text("Remove \(row.packageID) \(row.version) from this Mac? Its registrations fall back to the built-in backends. A default selection that points at this package keeps falling back until you change it.")
             }
+        // Authorization confirmation (#1159): states the inheritance rule
+        // BEFORE approval — a future revision of the same package keeps the
+        // grant only while the requirement contract stays unchanged.
+        .modifier(AuthorizationConfirmationModifier(
+            candidate: $authorizationCandidate,
+            authorize: authorizeRequirement) { outcome in
+                await handleMutationOutcome(outcome)
+            })
+        // Revocation confirmation: explicit, destructive; the grant record
+        // stays attached to the lineage (never transferred).
+        .modifier(RevocationConfirmationModifier(
+            candidate: $revocationCandidate,
+            revoke: revokeRequirement) { outcome in
+                await handleMutationOutcome(outcome)
+            })
         .onChange(of: showingImportPicker) { _, isPresented in
             guard isPresented else { return }
             let panel = ExtractorSettingsPackagePicker.makePanel()
@@ -566,6 +606,132 @@ struct ExtractionSettingsView: View {
         case .html: "HTML"
         default: kind.rawValue
         }
+    }
+
+    // MARK: - Credential requirements (#1159)
+
+    /// The inheritance rule, stated BEFORE approval (plan step 22 / AC.16).
+    static func authorizationConfirmationMessage(
+        _ summary: ExtractorCredentialRequirementSummary
+    ) -> String {
+        "Allow \(summary.packageName) to use \(summary.label) — \(summary.purpose) Authorization follows future revisions of this package only while this requirement's label, purpose, optionality, and registration stay unchanged; a changed requirement asks you to authorize again."
+    }
+
+    @ViewBuilder
+    private var credentialRequirementsSection: some View {
+        Section {
+            if packageModel.snapshot.credentialRequirements.isEmpty {
+                Text("No extractor package on this Mac requests a credential.")
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier(RequirementAccessibility.emptyState)
+            } else {
+                ForEach(packageModel.snapshot.credentialRequirements) { summary in
+                    requirementRow(summary)
+                }
+            }
+        } header: {
+            Text("Package Credentials")
+        } footer: {
+            Text("Extractor packages declare the credentials they need. Nothing is granted until you authorize it here, and a package only ever receives the credentials you authorized for it. Credentials live in your Keychain; their values are never shown.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func requirementRow(
+        _ summary: ExtractorCredentialRequirementSummary
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(summary.label)
+                    .fontWeight(.medium)
+                Spacer()
+                authorizationStateLabel(summary)
+            }
+            Text(summary.purpose)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack {
+                Text("\(summary.packageName) — \(summary.isOptional ? "optional" : "required")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if authorizeRequirement != nil {
+                    Button(summary.authorizationState == .changedContract
+                           ? "Re-authorize…"
+                           : "Authorize…") {
+                        authorizationCandidate = summary
+                    }
+                    .accessibilityIdentifier("\(RequirementAccessibility.authorizePrefix).\(summary.id)")
+                    .accessibilityLabel("Authorize \(summary.label) for \(summary.packageName)")
+                }
+                if authorizeRequirement != nil, summary.authorizationState == .authorized {
+                    Button("Change Credential…") {
+                        authorizationCandidate = summary
+                    }
+                    .accessibilityIdentifier("\(RequirementAccessibility.changePrefix).\(summary.id)")
+                    .accessibilityLabel("Change the credential for \(summary.label)")
+                }
+                if revokeRequirement != nil, summary.authorizationState == .authorized {
+                    Button("Revoke…", role: .destructive) {
+                        revocationCandidate = summary
+                    }
+                    .accessibilityIdentifier("\(RequirementAccessibility.revokePrefix).\(summary.id)")
+                    .accessibilityLabel("Revoke \(summary.label) authorization for \(summary.packageName)")
+                }
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("\(RequirementAccessibility.rowPrefix).\(summary.id)")
+    }
+
+    @ViewBuilder
+    private func authorizationStateLabel(
+        _ summary: ExtractorCredentialRequirementSummary
+    ) -> some View {
+        switch summary.authorizationState {
+        case .authorized:
+            Label("Authorized", systemImage: "checkmark.seal")
+                .foregroundStyle(.green)
+                .font(.caption)
+        case .needsAuthorization:
+            Text("Needs authorization")
+                .foregroundStyle(.orange)
+                .font(.caption)
+        case .changedContract:
+            Text("Changed — re-authorization needed")
+                .foregroundStyle(.orange)
+                .font(.caption)
+        }
+        if summary.isConfigured == false {
+            Text(summary.sourceName == "" ? "Missing credential" : "\(summary.sourceName): not set")
+                .foregroundStyle(.orange)
+                .font(.caption)
+                .accessibilityIdentifier("\(RequirementAccessibility.missingPrefix).\(summary.id)")
+        }
+    }
+
+    /// Stable accessibility identifiers for requirement rows and controls,
+    /// derived from package + registration + requirement identities.
+    private enum RequirementAccessibility {
+        static let emptyState = "extraction.credentials.empty"
+        static let rowPrefix = "extraction.credentials.row"
+        static let authorizePrefix = "extraction.credentials.authorize"
+        static let changePrefix = "extraction.credentials.change"
+        static let revokePrefix = "extraction.credentials.revoke"
+        static let missingPrefix = "extraction.credentials.missing"
+    }
+
+    /// Shared post-mutation handling for the authorization dialogs: surface a
+    /// redacted failure, then refresh the snapshot so authorization states
+    /// update immediately.
+    private func handleMutationOutcome(_ outcome: ExtractorPackageMutationOutcome?) async {
+        if let outcome, case .failed(let message) = outcome {
+            packageModel.reportFailure(message)
+        }
+        await packageModel.refresh()
     }
 
     /// The executable-code disclosure shown before any local import.
@@ -954,8 +1120,55 @@ struct ExtractorPackageSettingsSnapshot: Sendable, Equatable {
     var appliedGeneration: UInt64?
     var registrationSnapshots: [ExtractorRouteRegistrationSnapshot] = []
     var waitingRevisionIDs: Set<ExtractorPackageRevisionID> = []
+    /// Credential requirement summaries (#1159): presentation values only —
+    /// label, purpose, optionality, configured/missing state, source, and
+    /// authorization state. No secret values, no Keychain locations, no
+    /// package paths, no resolver.
+    var credentialRequirements: [ExtractorCredentialRequirementSummary] = []
 
     static let empty = ExtractorPackageSettingsSnapshot()
+}
+
+/// One declared credential requirement as presented in Installed Extractor
+/// Packages (#1159, plan steps 20-24). Identity fields are package- and
+/// requirement-derived so rows and controls have stable accessibility
+/// identifiers.
+struct ExtractorCredentialRequirementSummary: Identifiable, Hashable, Sendable {
+    enum AuthorizationState: Hashable, Sendable {
+        /// A grant exists and matches the declared contract fingerprint.
+        case authorized
+        /// No grant for this lineage + requirement.
+        case needsAuthorization
+        /// A grant exists but the contract fingerprint changed — the user
+        /// must re-authorize (AC.16).
+        case changedContract
+    }
+
+    let packageID: String
+    let packageName: String
+    let packageVersion: String
+    let registrationID: String
+    let requirementID: String
+    let label: String
+    let purpose: String
+    let isOptional: Bool
+    let isConfigured: Bool
+    let sourceName: String
+    let authorizationState: AuthorizationState
+    /// The declared registration scope (sorted, non-secret) — the same parts
+    /// the authorization writer pins into the contract fingerprint.
+    let kinds: [String]
+    let mimeTypes: [String]
+
+    var id: String { "\(packageID)/\(registrationID)/\(requirementID)" }
+
+    var authorizationStateText: String {
+        switch authorizationState {
+        case .authorized: return "Authorized"
+        case .needsAuthorization: return "Needs authorization"
+        case .changedContract: return "Changed — re-authorization needed"
+        }
+    }
 }
 
 /// One failed package, copied out of the reconciler's public failure struct so
@@ -981,6 +1194,67 @@ struct ExtractorPackageFailureSummary: Identifiable, Hashable, Sendable {
 enum ExtractorPackageMutationOutcome: Sendable, Equatable {
     case succeeded(String?)
     case failed(String)
+}
+
+/// The Authorize / Re-authorize / Change Credential confirmation (#1159).
+/// Its message states the inheritance rule BEFORE approval: a future
+/// revision of the same package keeps the grant only while the requirement
+/// contract stays unchanged.
+struct AuthorizationConfirmationModifier: ViewModifier {
+    @Binding var candidate: ExtractorCredentialRequirementSummary?
+    let authorize: (@Sendable (ExtractorCredentialRequirementSummary) async -> ExtractorPackageMutationOutcome)?
+    let onOutcome: (ExtractorPackageMutationOutcome?) async -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            "Authorize credential use?",
+            isPresented: Binding(
+                get: { candidate != nil },
+                set: { if !$0 { candidate = nil } }),
+            titleVisibility: .visible,
+            presenting: candidate) { summary in
+                Button("Authorize") {
+                    candidate = nil
+                    Task {
+                        let outcome = await authorize?(summary)
+                        await onOutcome(outcome)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { summary in
+                Text(ExtractionSettingsView.authorizationConfirmationMessage(summary))
+            }
+    }
+}
+
+/// The Revoke confirmation (#1159): explicit and destructive for the GRANT —
+/// the stored credential itself is never deleted, and the record stays
+/// attached to its package lineage.
+struct RevocationConfirmationModifier: ViewModifier {
+    @Binding var candidate: ExtractorCredentialRequirementSummary?
+    let revoke: (@Sendable (ExtractorCredentialRequirementSummary) async -> ExtractorPackageMutationOutcome)?
+    let onOutcome: (ExtractorPackageMutationOutcome?) async -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            "Revoke credential authorization?",
+            isPresented: Binding(
+                get: { candidate != nil },
+                set: { if !$0 { candidate = nil } }),
+            titleVisibility: .visible,
+            presenting: candidate) { summary in
+                Button("Revoke", role: .destructive) {
+                    candidate = nil
+                    Task {
+                        let outcome = await revoke?(summary)
+                        await onOutcome(outcome)
+                    }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: { summary in
+                Text("Revoke \(summary.packageName)'s use of \(summary.label)? The package will not receive this credential until you authorize it again. The stored credential itself is not deleted.")
+            }
+    }
 }
 
 /// Fixed, path-free diagnostics for package mutations. Errors from the store
@@ -1112,6 +1386,12 @@ final class ExtractorPackageSettingsModel {
     private(set) var hasLoaded = false
     private(set) var lastError: String?
     private(set) var lastDiagnostic: String?
+
+    /// Surfaces a redacted failure from an app-owned authorization mutation
+    /// (#1159) through the same diagnostics path as import/remove.
+    func reportFailure(_ message: String) {
+        lastError = message
+    }
 
     static let checkingMessage = "Checking installed extractor packages…"
     static let importingMessage = "Validating and installing package…"

--- a/Sources/WikiFS/Sources/ExtractorCredentialSettingsSupport.swift
+++ b/Sources/WikiFS/Sources/ExtractorCredentialSettingsSupport.swift
@@ -1,0 +1,106 @@
+import Foundation
+import WikiFSCore
+import WikiFSEngine
+import WikiFSTypes
+
+// App-side support for extractor credential authorization in Settings
+// (issue #1159, PR 2). The APP is the authorization writer; these helpers are
+// the only composition points that build requirement summaries and perform
+// grants/revocations. Headless and daemon surfaces get summaries from the
+// same reader (or none) but never construct a writer.
+
+enum ExtractorCredentialSettingsSupport {
+
+    /// Compose requirement summaries for Settings: one row per DECLARED
+    /// requirement of every active registration, resolved against the durable
+    /// authorization snapshot + UI-safe credential descriptions. Pure with
+    /// respect to the process registry — it reads only value snapshots.
+    static func summaries(
+        registrationSnapshots: [ExtractorRouteRegistrationSnapshot],
+        authorizationSnapshot: ExtractorCredentialAuthorizationSnapshot?,
+        credentials: CredentialDescribing
+    ) -> [ExtractorCredentialRequirementSummary] {
+        var result: [ExtractorCredentialRequirementSummary] = []
+        for registration in registrationSnapshots.sorted(by: { $0.reference < $1.reference }) {
+            for requirement in registration.credentialRequirements {
+                result.append(
+                    summary(
+                        registration: registration, requirement: requirement,
+                        authorizationSnapshot: authorizationSnapshot,
+                        credentials: credentials))
+            }
+        }
+        return result
+    }
+
+    /// Batch describe over the bound references (bounded by the service).
+    static func summary(
+        registration: ExtractorRouteRegistrationSnapshot,
+        requirement: ExtractorCredentialRequirement,
+        authorizationSnapshot: ExtractorCredentialAuthorizationSnapshot?,
+        credentials: CredentialDescribing
+    ) -> ExtractorCredentialRequirementSummary {
+        let fingerprint = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: registration.reference.revision.packageID.rawValue,
+            registrationID: registration.reference.registrationID.rawValue,
+            kinds: registration.kinds.map(\.rawValue),
+            mimeTypes: registration.mimeTypes.map(\.rawValue),
+            requirement: requirement)
+        let authorizationID = ExtractorCredentialAuthorizationID(
+            packageID: registration.reference.revision.packageID,
+            requirementID: requirement.id)
+        let record = authorizationSnapshot?.record(for: authorizationID)
+        let state: ExtractorCredentialRequirementSummary.AuthorizationState
+        if let record {
+            state = record.fingerprint == fingerprint
+                ? .authorized
+                : .changedContract
+        } else {
+            state = .needsAuthorization
+        }
+        var descriptions: [CredentialReference: CredentialInfo] = [:]
+        if let record {
+            descriptions = credentials.describe([record.credentialReference])
+        }
+        let configured = record.flatMap { descriptions[$0.credentialReference] }
+        return ExtractorCredentialRequirementSummary(
+            packageID: registration.reference.revision.packageID.rawValue,
+            packageName: registration.packageName,
+            packageVersion: registration.reference.revision.version.rawValue,
+            registrationID: registration.reference.registrationID.rawValue,
+            requirementID: requirement.id.rawValue,
+            label: requirement.label,
+            purpose: requirement.purpose,
+            isOptional: requirement.isOptional,
+            isConfigured: configured?.isConfigured ?? false,
+            sourceName: "Keychain",
+            authorizationState: state,
+            kinds: registration.kinds.map(\.rawValue).sorted(),
+            mimeTypes: registration.mimeTypes.map(\.rawValue).sorted())
+    }
+
+    /// The host's binding policy for one requirement: WHICH stored credential
+    /// the package would receive. Today: a package that declares
+    /// `api-token` for PDF binds to the legacy Docling Serve token reference;
+    /// everything else gets a package-scoped reference under the shared
+    /// credential service. Values never pass through here — references only.
+    static func bindingReference(
+        for summary: ExtractorCredentialRequirementSummary
+    ) -> CredentialReference? {
+        if summary.requirementID == "api-token" {
+            return CredentialReference.extraction(.doclingServeToken)
+        }
+        // Package-scoped NEW reference: flatten the (dotted) package ID into
+        // one grammar-valid label. The flattening is deterministic; reviewed
+        // packages are identified by their lineage and legacy bindings take
+        // precedence above.
+        let flattened = summary.packageID
+            .lowercased()
+            .map { character -> Character in
+                character == "." ? "-" : character
+            }
+        return CredentialReference(validatingLabels: [
+            "extractor-package", String(flattened), summary.requirementID.lowercased(),
+        ])
+    }
+}

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -809,10 +809,74 @@ struct WikiFSApp: App {
                                     digestPrefix: $0.digestPrefix,
                                     message: $0.message)
                             }
-                            snapshot.appliedGeneration = observation.appliedGeneration
+                             snapshot.appliedGeneration = observation.appliedGeneration
                             snapshot.waitingRevisionIDs = observation.waitingRevisionIDs
                         }
+                        // Credential requirement summaries (#1159): pure
+                        // composition over the registration projections, the
+                        // durable authorization snapshot, and UI-safe
+                        // descriptions. App + daemon read the same file;
+                        // only this app wiring can mutate it (below).
+                        snapshot.credentialRequirements = ExtractorCredentialSettingsSupport.summaries(
+                            registrationSnapshots: snapshot.registrationSnapshots,
+                            authorizationSnapshot: ExtractorCredentialAuthorizationReader(
+                                layout: ExtractorCredentialAuthorizationStoreLayout(
+                                    appGroupContainerRoot: containerDirectory)).snapshot(),
+                            credentials: KeychainCredentialService())
                         return snapshot
+                    },
+                    // App-only authorization mutation (AC.9): only this
+                    // wiring constructs the writer (the role gate rejects
+                    // daemon/CLI construction). Grant pins the exact
+                    // requirement fingerprint; revoke keeps the record's
+                    // lineage identity for reinstall visibility.
+                    authorizeRequirement: { summary in
+                        do {
+                            let writer = try ExtractorCredentialAuthorizationWriter(
+                                layout: ExtractorCredentialAuthorizationStoreLayout(
+                                    appGroupContainerRoot: containerDirectory),
+                                processRole: .app)
+                            guard let reference = ExtractorCredentialSettingsSupport
+                                .bindingReference(for: summary)
+                            else {
+                                return .failed("This requirement could not be authorized.")
+                            }
+                            let requirement = try ExtractorCredentialRequirement(
+                                id: ExtractorCredentialRequirementID(
+                                    validating: summary.requirementID),
+                                kind: .secret,
+                                isOptional: summary.isOptional,
+                                label: summary.label,
+                                purpose: summary.purpose)
+                            _ = try await writer.grant(
+                                packageID: ExtractorPackageID(
+                                    validating: summary.packageID),
+                                registrationID: ExtractorRegistrationID(
+                                    validating: summary.registrationID),
+                                kinds: summary.kinds,
+                                mimeTypes: summary.mimeTypes,
+                                requirement: requirement,
+                                credentialReference: reference)
+                            return .succeeded(nil)
+                        } catch {
+                            return .failed(ExtractorPackageMutationMessage.describe(error))
+                        }
+                    },
+                    revokeRequirement: { summary in
+                        do {
+                            let writer = try ExtractorCredentialAuthorizationWriter(
+                                layout: ExtractorCredentialAuthorizationStoreLayout(
+                                    appGroupContainerRoot: containerDirectory),
+                                processRole: .app)
+                            _ = try await writer.revoke(
+                                packageID: ExtractorPackageID(
+                                    validating: summary.packageID),
+                                requirementID: ExtractorCredentialRequirementID(
+                                    validating: summary.requirementID))
+                            return .succeeded(nil)
+                        } catch {
+                            return .failed(ExtractorPackageMutationMessage.describe(error))
+                        }
                     },
                     // Package mutation is app-only: the catalog writer rejects
                     // non-app roles, and only this Settings wiring constructs

--- a/Sources/WikiFSCore/Extractor/ExtractorCredentialAuthorization.swift
+++ b/Sources/WikiFSCore/Extractor/ExtractorCredentialAuthorization.swift
@@ -1,0 +1,355 @@
+import Foundation
+import Darwin
+import WikiFSTypes
+
+// Durable extractor credential authorization (issue #1159, PR 2 —
+// plans/credential-service.md §"Authorization store").
+//
+// The APP is the only writer; the app and the daemon read the same durable
+// bindings and resolve values independently in their own processes (AC.9).
+// The store is a machine-scoped, secret-free JSON file under a credentials
+// root in the App Group container, separate from wiki databases and the
+// extractor package catalog. Removal of a package never deletes a record:
+// grants stay attached to their lineage so a reinstall can show — and revoke
+// — the stale grant (plan step 16). Records never transfer across package
+// IDs: the authorization ID embeds the exact lineage.
+
+/// File layout for the machine-scoped authorization store.
+public struct ExtractorCredentialAuthorizationStoreLayout: Sendable {
+    /// `<appGroup>/credentials`
+    public let credentialsRoot: URL
+    /// `<appGroup>/credentials/extractor-credential-authorizations.json`
+    public let fileURL: URL
+
+    public init(appGroupContainerRoot: URL) {
+        credentialsRoot = appGroupContainerRoot.appendingPathComponent(
+            "credentials", isDirectory: true)
+        fileURL = credentialsRoot.appendingPathComponent(
+            "extractor-credential-authorizations.json", isDirectory: false)
+    }
+}
+
+public enum ExtractorCredentialAuthorizationStoreError: Error, Equatable, Sendable {
+    case roleMayNotMutate(ExtractorPackageProcessRole)
+    case lockAcquisitionTimedOut
+    case generationConflict(current: UInt64, expected: UInt64)
+    case writeFailed
+}
+
+/// Read-only view over the durable authorization snapshot. Safe for the app,
+/// the daemon, and the CLI — reading mutates nothing.
+public struct ExtractorCredentialAuthorizationReader: Sendable {
+    private let fileURL: URL
+
+    public init(layout: ExtractorCredentialAuthorizationStoreLayout) {
+        fileURL = layout.fileURL
+    }
+
+    /// Load the newest complete snapshot. `nil` when the store is absent
+    /// (nothing ever authorized) or unreadable/corrupt (a value-free
+    /// diagnostic is logged; callers treat it as "no grants").
+    public func snapshot() -> ExtractorCredentialAuthorizationSnapshot? {
+        // A missing file is the "nothing ever authorized" state, not an
+        // error worth logging.
+        // swiftlint:disable:next silent_try_optional
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(
+                ExtractorCredentialAuthorizationSnapshot.self, from: data)
+        } catch {
+            DebugLog.store(
+                "ExtractorCredentialAuthorizationReader: unreadable store: \(error)")
+            return nil
+        }
+    }
+}
+
+/// Serializes read-modify-write operations across processes via flock plus an
+/// in-process gate. The APP process owns the only instance that mutates;
+/// constructing a writer with a non-app role throws, and daemon/CLI code has
+/// no path to one.
+public actor ExtractorCredentialAuthorizationWriter {
+    private static let inProcessGate = ExtractorAuthorizationInProcessGate()
+    private static let retryBackoff: Duration = .milliseconds(25)
+
+    private let layout: ExtractorCredentialAuthorizationStoreLayout
+    private let lockTimeout: Duration
+    private let now: @Sendable () -> Date
+
+    public init(
+        layout: ExtractorCredentialAuthorizationStoreLayout,
+        processRole: ExtractorPackageProcessRole,
+        lockTimeout: Duration = .seconds(5),
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) throws {
+        guard processRole == .app else {
+            throw ExtractorCredentialAuthorizationStoreError.roleMayNotMutate(processRole)
+        }
+        self.layout = layout
+        self.lockTimeout = lockTimeout
+        self.now = now
+    }
+
+    /// Grant (or re-grant) the exact requirement contract: one lineage +
+    /// requirement -> one reference, pinned to the computed fingerprint. The
+    /// scope parts (registration identity + kinds + MIME types) must be the
+    /// SAME values the declaring manifest carries — callers pass them through
+    /// from the registration projection.
+    public func grant(
+        packageID: ExtractorPackageID,
+        registrationID: ExtractorRegistrationID,
+        kinds: [String],
+        mimeTypes: [String],
+        requirement: ExtractorCredentialRequirement,
+        credentialReference: CredentialReference
+    ) async throws -> ExtractorCredentialAuthorizationSnapshot {
+        let fingerprint = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: packageID.rawValue,
+            registrationID: registrationID.rawValue,
+            kinds: kinds,
+            mimeTypes: mimeTypes,
+            requirement: requirement)
+        let record = ExtractorCredentialAuthorizationRecord(
+            authorizationID: ExtractorCredentialAuthorizationID(
+                packageID: packageID, requirementID: requirement.id),
+            registrationID: registrationID,
+            fingerprint: fingerprint,
+            credentialReference: credentialReference,
+            authorizedAt: now())
+        return try await mutate { snapshot in
+            var records = snapshot.records
+            records.removeAll { $0.authorizationID == record.authorizationID }
+            records.append(record)
+            return records
+        }
+    }
+
+    /// Revoke one lineage + requirement. Removing an absent grant is a no-op.
+    public func revoke(
+        packageID: ExtractorPackageID,
+        requirementID: ExtractorCredentialRequirementID
+    ) async throws -> ExtractorCredentialAuthorizationSnapshot {
+        let authorizationID = ExtractorCredentialAuthorizationID(
+            packageID: packageID, requirementID: requirementID)
+        return try await mutate { snapshot in
+            snapshot.records.filter { $0.authorizationID != authorizationID }
+        }
+    }
+
+    /// The locked RMW core: acquire the kernel + in-process locks, reload the
+    /// newest snapshot, apply the record mutation with a generation check,
+    /// and atomically replace the file with owner-only permissions.
+    private func mutate(
+        _ body: @Sendable (ExtractorCredentialAuthorizationSnapshot) -> [ExtractorCredentialAuthorizationRecord]
+    ) async throws -> ExtractorCredentialAuthorizationSnapshot {
+        let descriptor = try await acquireLock()
+        defer { releaseLock(descriptor) }
+        let current = readSnapshotLocked()
+            ?? ExtractorCredentialAuthorizationSnapshot.empty
+        let records = body(current)
+        let updated = ExtractorCredentialAuthorizationSnapshot(
+            generation: current.generation &+ 1, records: records)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        let data: Data
+        do {
+            data = try encoder.encode(updated)
+        } catch {
+            // Deterministic encoding of a valid snapshot cannot fail; a
+            // failure is a programmer error surfaced as writeFailed.
+            DebugLog.store(
+                "ExtractorCredentialAuthorizationWriter: encode failed: \(error)")
+            throw ExtractorCredentialAuthorizationStoreError.writeFailed
+        }
+        try data.write(to: layout.fileURL, options: .atomic)
+        // Owner-only permissions on the persisted store (it is secret-free,
+        // but its references reveal which credentials the user granted).
+        do {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: layout.fileURL.path)
+        } catch {
+            DebugLog.store(
+                "ExtractorCredentialAuthorizationWriter: chmod failed: \(error)")
+        }
+        return updated
+    }
+
+    /// Locked reload with generation-conflict detection helper: returns the
+    /// decoded snapshot after validating it is well-formed.
+    private func readSnapshotLocked() -> ExtractorCredentialAuthorizationSnapshot? {
+        // Absent file = empty store (never authorized), not an error.
+        // swiftlint:disable:next silent_try_optional
+        guard let data = try? Data(contentsOf: layout.fileURL) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        do {
+            return try decoder.decode(
+                ExtractorCredentialAuthorizationSnapshot.self, from: data)
+        } catch {
+            DebugLog.store(
+                "ExtractorCredentialAuthorizationWriter: corrupt store, reseeding: \(error)")
+            return nil
+        }
+    }
+
+    private var lockURL: URL {
+        layout.credentialsRoot.appendingPathComponent(
+            "extractor-credential-authorizations.lock", isDirectory: false)
+    }
+
+    private func acquireLock() async throws -> Int32 {
+        try FileManager.default.createDirectory(
+            at: layout.credentialsRoot, withIntermediateDirectories: true)
+        let key = lockURL.path
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: lockTimeout)
+        while true {
+            try Task.checkCancellation()
+            guard clock.now < deadline else {
+                throw ExtractorCredentialAuthorizationStoreError.lockAcquisitionTimedOut
+            }
+            guard await Self.inProcessGate.tryAcquire(key) else {
+                try await Task.sleep(for: Self.retryBackoff)
+                continue
+            }
+            let descriptor = key.withCString {
+                open($0, O_RDWR | O_CREAT | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+            }
+            guard descriptor >= 0 else {
+                await Self.inProcessGate.release(key)
+                throw ExtractorCredentialAuthorizationStoreError.writeFailed
+            }
+            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+                let code = errno
+                close(descriptor)
+                await Self.inProcessGate.release(key)
+                if code == EWOULDBLOCK || code == EAGAIN {
+                    try await Task.sleep(for: Self.retryBackoff)
+                    continue
+                }
+                throw ExtractorCredentialAuthorizationStoreError.writeFailed
+            }
+            return descriptor
+        }
+    }
+
+    private func releaseLock(_ descriptor: Int32) {
+        let unlockResult = flock(descriptor, LOCK_UN)
+        let closeResult = close(descriptor)
+        if unlockResult != 0 || closeResult != 0 {
+            DebugLog.store("ExtractorCredentialAuthorizationWriter: lock release failed.")
+        }
+        Task { await Self.inProcessGate.release(self.lockURL.path) }
+    }
+}
+
+/// Mirror of `AgentProvidersConfigInProcessGate`: same-process writers queue
+/// on the lock path; cross-process writers serialize on flock.
+actor ExtractorAuthorizationInProcessGate {
+    private var heldPaths: Set<String> = []
+
+    func tryAcquire(_ path: String) -> Bool { heldPaths.insert(path).inserted }
+    func release(_ path: String) { heldPaths.remove(path) }
+}
+
+// MARK: - Pure resolver
+
+/// One requirement's redacted readiness after authorization resolution.
+/// The decision carries identities and states only — never a value and never
+/// the reference for a blocked requirement (UI-safe by construction; PR 3's
+/// privileged layer re-derives references from the store snapshot).
+public struct ExtractorCredentialAuthorizationDecision: Hashable, Sendable {
+    public enum State: Hashable, Sendable {
+        /// Authorized AND configured: PR 3 may resolve the value.
+        case authorized(CredentialReference)
+        /// Not authorized (no grant, changed contract, unadmitted package).
+        case unauthorized
+        /// Authorized but the credential has no stored value.
+        case missingCredential(CredentialReference)
+    }
+
+    public let requirement: ExtractorCredentialRequirement
+    public let state: State
+
+    public var isSatisfied: Bool {
+        switch state {
+        case .authorized: return true
+        case .unauthorized, .missingCredential: return requirement.isOptional
+        }
+    }
+
+    /// Required unsatisfied requirements BLOCK preparation (AC.10); optional
+    /// ones are omitted downstream.
+    public var blocksPreparation: Bool { !isSatisfied }
+}
+
+/// Pure authorization resolution for one exact registration of one exact
+/// admitted revision (AC.8/AC.10/AC.16). Inputs are validated facts; the
+/// resolver performs no I/O and never sees a value.
+public enum ExtractorCredentialAuthorizationResolver {
+
+    /// Resolve every declared requirement of `registration` against the
+    /// current authorization snapshot + credential descriptions.
+    ///
+    /// - Parameters:
+    ///   - package: the exact revision being prepared (lineage identity).
+    ///   - manifest: the validated manifest of that exact revision — its
+    ///     digest was checked by the caller; the resolver re-checks that the
+    ///     revision's registration actually DECLARES each requirement, so a
+    ///     stale grant for a requirement this revision no longer declares
+    ///     cannot leak a decision.
+    ///   - registration: the SELECTED registration for kind + MIME.
+    ///   - isAdmitted: current admission state of the exact revision.
+    ///   - snapshot: the durable authorization snapshot (nil = no grants).
+    ///   - descriptions: UI-safe configured state per reference.
+    public static func resolve(
+        package packageID: ExtractorPackageID,
+        manifest: ExtractorManifest,
+        registration: ExtractorRegistration,
+        isAdmitted: Bool,
+        snapshot: ExtractorCredentialAuthorizationSnapshot?,
+        descriptions: [CredentialReference: CredentialInfo]
+    ) -> [ExtractorCredentialAuthorizationDecision] {
+        // An unadmitted revision (removed, failed activation, superseded)
+        // blocks every requirement — declared or granted.
+        guard isAdmitted,
+              manifest.packageID == packageID,
+              let declared = manifest.registrations.first(where: { $0.id == registration.id })
+        else {
+            return registration.credentialRequirements.map {
+                ExtractorCredentialAuthorizationDecision(
+                    requirement: $0, state: .unauthorized)
+            }
+        }
+        // The selected registration must be the manifest's own registration
+        // (identity + declared requirement set match exactly).
+        guard declared == registration else {
+            return registration.credentialRequirements.map {
+                ExtractorCredentialAuthorizationDecision(
+                    requirement: $0, state: .unauthorized)
+            }
+        }
+        return registration.credentialRequirements.map { requirement in
+            let authorizationID = ExtractorCredentialAuthorizationID(
+                packageID: packageID, requirementID: requirement.id)
+            guard let record = snapshot?.record(for: authorizationID),
+                  record.fingerprint == ExtractorCredentialRequirementFingerprint.compute(
+                    packageID: packageID, registration: registration,
+                    requirement: requirement)
+            else {
+                return ExtractorCredentialAuthorizationDecision(
+                    requirement: requirement, state: .unauthorized)
+            }
+            let reference = record.credentialReference
+            let configured = descriptions[reference]?.isConfigured ?? false
+            return ExtractorCredentialAuthorizationDecision(
+                requirement: requirement,
+                state: configured
+                    ? .authorized(reference)
+                    : .missingCredential(reference))
+        }
+    }
+}

--- a/Sources/WikiFSEngine/ExtractionServiceKeys.swift
+++ b/Sources/WikiFSEngine/ExtractionServiceKeys.swift
@@ -125,19 +125,24 @@ public struct ExtractorRegistrationPresentation: Hashable, Sendable {
     public let mimeTypes: Set<ExtractorMIMEType>
     /// Declared filename extensions — matching hints only, never route identity.
     public let filenameExtensions: Set<ExtractorFileExtension>
+    /// Declared credential REQUIREMENTS (non-secret review facts; #1159).
+    /// Never a value and never a reference binding.
+    public let credentialRequirements: [ExtractorCredentialRequirement]
 
     public init(
         displayName: String,
         packageName: String,
         kinds: Set<ExtractorKind>,
         mimeTypes: Set<ExtractorMIMEType>,
-        filenameExtensions: Set<ExtractorFileExtension>
+        filenameExtensions: Set<ExtractorFileExtension>,
+        credentialRequirements: [ExtractorCredentialRequirement] = []
     ) {
         self.displayName = displayName
         self.packageName = packageName
         self.kinds = kinds
         self.mimeTypes = mimeTypes
         self.filenameExtensions = filenameExtensions
+        self.credentialRequirements = credentialRequirements
     }
 }
 
@@ -418,7 +423,8 @@ public extension ExtractionBackendRegistry {
                     packageName: presentation.packageName,
                     kinds: presentation.kinds,
                     mimeTypes: presentation.mimeTypes,
-                    filenameExtensions: presentation.filenameExtensions)
+                    filenameExtensions: presentation.filenameExtensions,
+                    credentialRequirements: presentation.credentialRequirements)
             }
     }
 }

--- a/Sources/WikiFSEngine/ExtractorPackagePluginDefinitionFactory.swift
+++ b/Sources/WikiFSEngine/ExtractorPackagePluginDefinitionFactory.swift
@@ -176,7 +176,8 @@ public enum ExtractorPackagePluginDefinitionFactory {
                     packageName: manifest.displayName,
                     kinds: registration.kinds,
                     mimeTypes: registration.mimeTypes,
-                    filenameExtensions: registration.filenameExtensions)
+                    filenameExtensions: registration.filenameExtensions,
+                    credentialRequirements: registration.credentialRequirements)
                 let kinds = registration.kinds
                     .sorted { $0.rawValue < $1.rawValue }
                 for kind in kinds {

--- a/Sources/WikiFSEngine/ExtractorRoutePresentation.swift
+++ b/Sources/WikiFSEngine/ExtractorRoutePresentation.swift
@@ -20,6 +20,8 @@ public struct ExtractorRouteRegistrationSnapshot: Hashable, Sendable {
     public let mimeTypes: Set<ExtractorMIMEType>
     /// Declared filename extensions — matching hints, never route identity.
     public let filenameExtensions: Set<ExtractorFileExtension>
+    /// Declared credential requirements (non-secret declarations; #1159).
+    public let credentialRequirements: [ExtractorCredentialRequirement]
 
     public init(
         reference: ExtractorReference,
@@ -27,7 +29,8 @@ public struct ExtractorRouteRegistrationSnapshot: Hashable, Sendable {
         packageName: String,
         kinds: Set<ExtractorKind>,
         mimeTypes: Set<ExtractorMIMEType>,
-        filenameExtensions: Set<ExtractorFileExtension>
+        filenameExtensions: Set<ExtractorFileExtension>,
+        credentialRequirements: [ExtractorCredentialRequirement] = []
     ) {
         self.reference = reference
         self.displayName = displayName
@@ -35,6 +38,7 @@ public struct ExtractorRouteRegistrationSnapshot: Hashable, Sendable {
         self.kinds = kinds
         self.mimeTypes = mimeTypes
         self.filenameExtensions = filenameExtensions
+        self.credentialRequirements = credentialRequirements
     }
 }
 

--- a/Sources/WikiFSTypes/Extractor/ExtractorCredentialRequirement.swift
+++ b/Sources/WikiFSTypes/Extractor/ExtractorCredentialRequirement.swift
@@ -1,0 +1,342 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#elseif canImport(Crypto)
+import Crypto
+#endif
+
+// Extractor credential declarations and durable authorization (issue #1159,
+// PR 2 — plans/credential-service.md §"Extractor declarations").
+//
+// Secrets and `CredentialReference` BINDINGS never appear in manifests or the
+// machine package catalog: a manifest only DECLARES that a registration needs
+// a credential (id/kind/optionality/label/purpose). The binding of one
+// package lineage + requirement to one reference lives exclusively in the
+// authorization store, created by explicit user consent.
+
+extension ExtractorHostLimits {
+    /// Display label bound for a credential requirement (UTF-8 bytes).
+    public static let maximumRequirementLabelByteCount = 64
+    /// Bounded purpose text for a credential requirement (UTF-8 bytes).
+    public static let maximumRequirementPurposeByteCount = 256
+    /// Requirements per registration — host policy keeps the Settings
+    /// disclosure and the per-operation envelope bounded.
+    public static let maximumRequirementsPerRegistration = 8
+}
+
+/// Stable identifier of one credential requirement inside one package
+/// lineage. Strict identifier grammar: 1–64 ASCII lowercase alphanumerics and
+/// `-`, starting with a letter, not ending with `-` (same machine rules as
+/// registration IDs). Package lineage + this ID is the authorization
+/// identity (manifest-wide uniqueness is enforced at validation).
+public struct ExtractorCredentialRequirementID:
+    RawRepresentable, Codable, Hashable, Sendable, Comparable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        guard ExtractorIdentifierRules.isRegistrationID(rawValue) else { return nil }
+        self.rawValue = rawValue
+    }
+
+    public init(validating rawValue: String) throws {
+        guard let value = Self(rawValue: rawValue) else {
+            throw ExtractorValidationError.invalidIdentifier(
+                kind: "extractor credential requirement ID", value: rawValue)
+        }
+        self = value
+    }
+
+    public init(from decoder: any Decoder) throws { try self.init(validating: String(from: decoder)) }
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// The closed set of requirement kinds. Initially secret only; a future kind
+/// (e.g. an OAuth grant) extends this enum and every boundary that switches
+/// over it.
+public enum ExtractorCredentialRequirementKind: String, Codable, Sendable, CaseIterable {
+    case secret
+}
+
+/// One registration-scoped credential declaration. Non-secret by
+/// construction: label and purpose are bounded display facts the user
+/// consents to, never a value or a binding.
+public struct ExtractorCredentialRequirement: Codable, Hashable, Sendable, Comparable {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id, kind, optional, label, purpose
+    }
+
+    public let id: ExtractorCredentialRequirementID
+    public let kind: ExtractorCredentialRequirementKind
+    /// Optional requirements are omitted when absent or unauthorized;
+    /// required ones block preparation (AC.10).
+    public let isOptional: Bool
+    /// Bounded display label ("Docling Serve API token").
+    public let label: String
+    /// Bounded purpose text shown before authorization.
+    public let purpose: String
+
+    /// Validated + NORMALIZED construction: label and purpose are trimmed;
+    /// a declaration that only differs by surrounding whitespace is the same
+    /// declaration, and raw JSON that is not already normalized is rejected
+    /// at decode so canonical bytes stay deterministic.
+    public init(
+        id: ExtractorCredentialRequirementID,
+        kind: ExtractorCredentialRequirementKind,
+        isOptional: Bool,
+        label: String,
+        purpose: String
+    ) throws {
+        let trimmedLabel = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedPurpose = purpose.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedLabel.isEmpty == false,
+              trimmedLabel.utf8.count <= ExtractorHostLimits.maximumRequirementLabelByteCount
+        else { throw ExtractorValidationError.invalidManifest("credential requirement label") }
+        guard trimmedPurpose.isEmpty == false,
+              trimmedPurpose.utf8.count <= ExtractorHostLimits.maximumRequirementPurposeByteCount
+        else { throw ExtractorValidationError.invalidManifest("credential requirement purpose") }
+        self.id = id
+        self.kind = kind
+        self.isOptional = isOptional
+        self.label = trimmedLabel
+        self.purpose = trimmedPurpose
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try rejectUnknownKeys(from: decoder, allowed: CodingKeys.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let label = try container.decode(String.self, forKey: .label)
+        let purpose = try container.decode(String.self, forKey: .purpose)
+        try self.init(
+            id: container.decode(ExtractorCredentialRequirementID.self, forKey: .id),
+            kind: container.decode(ExtractorCredentialRequirementKind.self, forKey: .kind),
+            isOptional: container.decode(Bool.self, forKey: .optional),
+            label: label,
+            purpose: purpose)
+        // Non-normalized declarations are rejected so a re-encoded canonical
+        // manifest can never differ from the reviewed bytes.
+        guard label == self.label, purpose == self.purpose else {
+            throw ExtractorValidationError.invalidManifest(
+                "credential requirement text is not normalized")
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(kind, forKey: .kind)
+        try container.encode(isOptional, forKey: .optional)
+        try container.encode(label, forKey: .label)
+        try container.encode(purpose, forKey: .purpose)
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.id < rhs.id }
+}
+
+/// Fingerprint of the NORMALIZED requirement contract in its registration
+/// context. Authorization is inherited by a later revision of the same
+/// package lineage only while this fingerprint is unchanged; any change to
+/// the requirement (id/kind/optionality/label/purpose) or its registration
+/// scope (registration identity, kinds, MIME types) requires new
+/// authorization (AC.16, plan step 15).
+public struct ExtractorCredentialRequirementFingerprint:
+    Codable, Hashable, Sendable, Comparable {
+    public let value: String
+
+    init(value: String) { self.value = value }
+
+    /// Canonical inputs: package lineage, registration identity + scope, and
+    /// the normalized requirement. Deterministic across processes (sorted,
+    /// stable field order via sorted-key JSON).
+    public static func compute(
+        packageID: ExtractorPackageID,
+        registration: ExtractorRegistration,
+        requirement: ExtractorCredentialRequirement
+    ) -> ExtractorCredentialRequirementFingerprint {
+        compute(
+            packageID: packageID.rawValue,
+            registrationID: registration.id.rawValue,
+            kinds: registration.kinds.map(\.rawValue),
+            mimeTypes: registration.mimeTypes.map(\.rawValue),
+            requirement: requirement)
+    }
+
+    /// Scope-parts form — the canonical derivation used by every caller so
+    /// Settings projections and the authorization writer agree byte-for-byte.
+    public static func compute(
+        packageID: String,
+        registrationID: String,
+        kinds: [String],
+        mimeTypes: [String],
+        requirement: ExtractorCredentialRequirement
+    ) -> ExtractorCredentialRequirementFingerprint {
+        struct Scope: Encodable {
+            let packageID: String
+            let registrationID: String
+            let kinds: [String]
+            let mimeTypes: [String]
+            let requirement: ExtractorCredentialRequirement
+        }
+        let scope = Scope(
+            packageID: packageID,
+            registrationID: registrationID,
+            kinds: kinds.sorted(),
+            mimeTypes: mimeTypes.sorted(),
+            requirement: requirement)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        // A scope of validated values always encodes; Data() fallback is the
+        // documented degraded output for an impossible failure.
+        // swiftlint:disable:next silent_try_optional
+        let data = (try? encoder.encode(scope)) ?? Data()
+        return ExtractorCredentialRequirementFingerprint(value: sha256Hex(data))
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.value < rhs.value }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        #if canImport(CryptoKit)
+        let digest = SHA256.hash(data: data)
+        #elseif canImport(Crypto)
+        let digest = SHA256.hash(data: data)
+        #endif
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - Durable authorization (machine-scoped, secret-free)
+
+/// The authorization identity: one package lineage + one requirement.
+public struct ExtractorCredentialAuthorizationID:
+    Codable, Hashable, Sendable, Comparable {
+    public let packageID: ExtractorPackageID
+    public let requirementID: ExtractorCredentialRequirementID
+
+    public init(
+        packageID: ExtractorPackageID,
+        requirementID: ExtractorCredentialRequirementID
+    ) {
+        self.packageID = packageID
+        self.requirementID = requirementID
+    }
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.packageID == rhs.packageID
+            ? lhs.requirementID < rhs.requirementID
+            : lhs.packageID < rhs.packageID
+    }
+}
+
+/// One granted binding: lineage + requirement -> credential reference, pinned
+/// to the exact declaration fingerprint the user approved. No secret value is
+/// ever stored here — only the non-secret reference.
+public struct ExtractorCredentialAuthorizationRecord: Codable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion, authorizationID, registrationID, fingerprint, credentialReference, authorizedAt
+    }
+
+    static let currentSchemaVersion = 1
+
+    public let authorizationID: ExtractorCredentialAuthorizationID
+    public let registrationID: ExtractorRegistrationID
+    public let fingerprint: ExtractorCredentialRequirementFingerprint
+    public let credentialReference: CredentialReference
+    public let authorizedAt: Date
+
+    public init(
+        authorizationID: ExtractorCredentialAuthorizationID,
+        registrationID: ExtractorRegistrationID,
+        fingerprint: ExtractorCredentialRequirementFingerprint,
+        credentialReference: CredentialReference,
+        authorizedAt: Date
+    ) {
+        self.authorizationID = authorizationID
+        self.registrationID = registrationID
+        self.fingerprint = fingerprint
+        self.credentialReference = credentialReference
+        self.authorizedAt = authorizedAt
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try rejectUnknownKeys(from: decoder, allowed: CodingKeys.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw ExtractorValidationError.invalidManifest(
+                "authorization record schema version \(schemaVersion)")
+        }
+        try self.init(
+            authorizationID: container.decode(
+                ExtractorCredentialAuthorizationID.self, forKey: .authorizationID),
+            registrationID: container.decode(
+                ExtractorRegistrationID.self, forKey: .registrationID),
+            fingerprint: container.decode(
+                ExtractorCredentialRequirementFingerprint.self, forKey: .fingerprint),
+            credentialReference: container.decode(
+                CredentialReference.self, forKey: .credentialReference),
+            authorizedAt: container.decode(Date.self, forKey: .authorizedAt))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.currentSchemaVersion, forKey: .schemaVersion)
+        try container.encode(authorizationID, forKey: .authorizationID)
+        try container.encode(registrationID, forKey: .registrationID)
+        try container.encode(fingerprint, forKey: .fingerprint)
+        try container.encode(credentialReference, forKey: .credentialReference)
+        try container.encode(authorizedAt, forKey: .authorizedAt)
+    }
+}
+
+/// The full machine-scoped authorization state. Secret-free; the reference is
+/// an identity, not a value. Records are kept sorted for deterministic
+/// encoding; `generation` orders concurrent writers.
+public struct ExtractorCredentialAuthorizationSnapshot: Codable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case schemaVersion, generation, records
+    }
+
+    static let currentSchemaVersion = 1
+
+    public let generation: UInt64
+    public let records: [ExtractorCredentialAuthorizationRecord]
+
+    public init(generation: UInt64, records: [ExtractorCredentialAuthorizationRecord]) {
+        self.generation = generation
+        self.records = records.sorted { lhs, rhs in
+            lhs.authorizationID < rhs.authorizationID
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        try rejectUnknownKeys(from: decoder, allowed: CodingKeys.self)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let schemaVersion = try container.decode(Int.self, forKey: .schemaVersion)
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw ExtractorValidationError.invalidManifest(
+                "authorization snapshot schema version \(schemaVersion)")
+        }
+        try self.init(
+            generation: container.decode(UInt64.self, forKey: .generation),
+            records: container.decode(
+                [ExtractorCredentialAuthorizationRecord].self, forKey: .records))
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Self.currentSchemaVersion, forKey: .schemaVersion)
+        try container.encode(generation, forKey: .generation)
+        try container.encode(records, forKey: .records)
+    }
+
+    public func record(
+        for authorizationID: ExtractorCredentialAuthorizationID
+    ) -> ExtractorCredentialAuthorizationRecord? {
+        records.first { $0.authorizationID == authorizationID }
+    }
+
+    public static let empty = ExtractorCredentialAuthorizationSnapshot(generation: 0, records: [])
+}

--- a/Sources/WikiFSTypes/Extractor/ExtractorIdentity.swift
+++ b/Sources/WikiFSTypes/Extractor/ExtractorIdentity.swift
@@ -262,7 +262,14 @@ public struct ExtractorProtocolRevision: RawRepresentable, Codable, Hashable, Se
 public struct ExtractorManifestRevision: RawRepresentable, Codable, Hashable, Sendable, Comparable {
     public let rawValue: Int
     public static let v1 = Self(validatedRawValue: 1)
-    public init?(rawValue: Int) { guard rawValue == 1 else { return nil }; self.rawValue = rawValue }
+    /// Revision 2 adds registration-scoped credential requirement
+    /// declarations (issue #1159). Revision 1 validation, canonical JSON,
+    /// and package digests are preserved byte-for-byte.
+    public static let v2 = Self(validatedRawValue: 2)
+    public init?(rawValue: Int) {
+        guard rawValue == 1 || rawValue == 2 else { return nil }
+        self.rawValue = rawValue
+    }
     private init(validatedRawValue: Int) { self.rawValue = validatedRawValue }
     public init(from decoder: any Decoder) throws {
         let rawValue = try Int(from: decoder)

--- a/Sources/WikiFSTypes/Extractor/ExtractorManifest.swift
+++ b/Sources/WikiFSTypes/Extractor/ExtractorManifest.swift
@@ -119,18 +119,30 @@ public struct ExtractorRegistration: Codable, Hashable, Sendable, Comparable {
         case id, displayName, kinds, mimeTypes, filenameExtensions
     }
 
+    /// Revision-2 keys: adds registration-scoped credential requirement
+    /// declarations (issue #1159). Revision 1 decoding rejects this key
+    /// (unknown-field policy), so a v1 manifest cannot carry credentials.
+    private enum V2CodingKeys: String, CodingKey, CaseIterable {
+        case id, displayName, kinds, mimeTypes, filenameExtensions, credentialRequirements
+    }
+
     public let id: ExtractorRegistrationID
     public let displayName: String
     public let kinds: Set<ExtractorKind>
     public let mimeTypes: Set<ExtractorMIMEType>
     public let filenameExtensions: Set<ExtractorFileExtension>
+    /// Non-secret credential DECLARATIONS (id/kind/optionality/label/purpose).
+    /// Never a value, never a reference binding. Empty for every revision-1
+    /// registration.
+    public let credentialRequirements: [ExtractorCredentialRequirement]
 
     public init(
         id: ExtractorRegistrationID,
         displayName: String,
         kinds: Set<ExtractorKind>,
         mimeTypes: Set<ExtractorMIMEType>,
-        filenameExtensions: Set<ExtractorFileExtension> = []
+        filenameExtensions: Set<ExtractorFileExtension> = [],
+        credentialRequirements: [ExtractorCredentialRequirement] = []
     ) throws {
         guard displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
               displayName.utf8.count <= 128 else {
@@ -138,16 +150,37 @@ public struct ExtractorRegistration: Codable, Hashable, Sendable, Comparable {
         }
         guard kinds.isEmpty == false else { throw ExtractorValidationError.invalidManifest("registration kind set is empty") }
         guard mimeTypes.isEmpty == false else { throw ExtractorValidationError.invalidManifest("registration MIME type set is empty") }
+        guard credentialRequirements.count <= ExtractorHostLimits.maximumRequirementsPerRegistration else {
+            throw ExtractorValidationError.invalidManifest("too many credential requirements")
+        }
+        guard Set(credentialRequirements.map(\.id)).count == credentialRequirements.count else {
+            throw ExtractorValidationError.invalidManifest(
+                "registration declares duplicate credential requirement IDs")
+        }
         self.id = id
         self.displayName = displayName
         self.kinds = kinds
         self.mimeTypes = mimeTypes
         self.filenameExtensions = filenameExtensions
+        self.credentialRequirements = credentialRequirements.sorted()
     }
 
+    /// The v1 decoder: strict, no credential key.
     public init(from decoder: any Decoder) throws {
-        try rejectUnknownKeys(from: decoder, allowed: CodingKeys.self)
-        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            from: decoder, manifestRevision: .v1)
+    }
+
+    /// Revision-aware decoding. Revision 1 rejects the
+    /// `credentialRequirements` key outright (unknown-field policy);
+    /// revision 2 accepts it and validates every declaration.
+    public init(from decoder: any Decoder, manifestRevision: ExtractorManifestRevision) throws {
+        if manifestRevision == .v2 {
+            try rejectUnknownKeys(from: decoder, allowed: V2CodingKeys.self)
+        } else {
+            try rejectUnknownKeys(from: decoder, allowed: CodingKeys.self)
+        }
+        let container = try decoder.container(keyedBy: V2CodingKeys.self)
         let kinds = try container.decode([ExtractorKind].self, forKey: .kinds)
         let mimeTypes = try container.decode([ExtractorMIMEType].self, forKey: .mimeTypes)
         let filenameExtensions = try container.decodeIfPresent([ExtractorFileExtension].self, forKey: .filenameExtensions) ?? []
@@ -156,21 +189,34 @@ public struct ExtractorRegistration: Codable, Hashable, Sendable, Comparable {
               Set(filenameExtensions).count == filenameExtensions.count else {
             throw ExtractorValidationError.invalidManifest("registration contains duplicate values")
         }
+        let requirements: [ExtractorCredentialRequirement]
+        if manifestRevision == .v2 {
+            requirements = try container.decodeIfPresent(
+                [ExtractorCredentialRequirement].self, forKey: .credentialRequirements) ?? []
+        } else {
+            requirements = []
+        }
         try self.init(
             id: container.decode(ExtractorRegistrationID.self, forKey: .id),
             displayName: container.decode(String.self, forKey: .displayName),
             kinds: Set(kinds),
             mimeTypes: Set(mimeTypes),
-            filenameExtensions: Set(filenameExtensions))
+            filenameExtensions: Set(filenameExtensions),
+            credentialRequirements: requirements)
     }
 
     public func encode(to encoder: any Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        var container = encoder.container(keyedBy: V2CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(displayName, forKey: .displayName)
         try container.encode(kinds.sorted { $0.rawValue < $1.rawValue }, forKey: .kinds)
         try container.encode(mimeTypes.sorted(), forKey: .mimeTypes)
         if filenameExtensions.isEmpty == false { try container.encode(filenameExtensions.sorted(), forKey: .filenameExtensions) }
+        // Emitted only when non-empty, so revision-1 canonical bytes (always
+        // empty here) are unchanged bit-for-bit.
+        if credentialRequirements.isEmpty == false {
+            try container.encode(credentialRequirements, forKey: .credentialRequirements)
+        }
     }
 
     public static func < (lhs: Self, rhs: Self) -> Bool { lhs.id < rhs.id }
@@ -232,7 +278,7 @@ public struct ExtractorManifest: Codable, Hashable, Sendable {
         files: [ExtractorPackageFile],
         limits: ExtractorOperationLimits
     ) throws {
-        guard manifestRevision == .v1 else {
+        guard manifestRevision == .v1 || manifestRevision == .v2 else {
             throw ExtractorValidationError.unsupportedManifestRevision(manifestRevision.rawValue)
         }
         guard displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
@@ -243,6 +289,24 @@ public struct ExtractorManifest: Codable, Hashable, Sendable {
         guard registrations.isEmpty == false else { throw ExtractorValidationError.invalidManifest("manifest has no registrations") }
         if let duplicate = zip(registrations, registrations.dropFirst()).first(where: { $0.id == $1.id })?.0.id {
             throw ExtractorValidationError.duplicateRegistration(duplicate)
+        }
+        // Credential declarations are a revision-2 feature. Revision 1 must
+        // reject them even in memory (a v1 manifest can never carry them in
+        // JSON — the decoder rejects the key — this guards construction).
+        if manifestRevision == .v1,
+           registrations.contains(where: { $0.credentialRequirements.isEmpty == false }) {
+            throw ExtractorValidationError.invalidManifest(
+                "credential requirements require manifest revision 2")
+        }
+        // Manifest-wide uniqueness of requirement IDs makes package lineage +
+        // requirement ID an unambiguous authorization identity (plan step 7).
+        var seenRequirementIDs: Set<ExtractorCredentialRequirementID> = []
+        for registration in registrations {
+            for requirement in registration.credentialRequirements
+            where seenRequirementIDs.insert(requirement.id).inserted == false {
+                throw ExtractorValidationError.invalidManifest(
+                    "duplicate credential requirement ID \(requirement.id.rawValue) across registrations")
+            }
         }
         let files = files.sorted()
         guard files.isEmpty == false else { throw ExtractorValidationError.invalidManifest("manifest has no declared files") }
@@ -275,19 +339,31 @@ public struct ExtractorManifest: Codable, Hashable, Sendable {
     public init(from decoder: any Decoder) throws {
         try rejectUnknownKeys(from: decoder, allowed: CodingKeys.self)
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Decode the revision FIRST so registration elements are decoded
+        // with the matching key policy (v1 rejects the credential key; v2
+        // accepts it).
+        let revision = try container.decode(
+            ExtractorManifestRevision.self, forKey: .manifestRevision)
+        var nested = try container.nestedUnkeyedContainer(forKey: .registrations)
+        var registrations: [ExtractorRegistration] = []
+        registrations.reserveCapacity(nested.count ?? 0)
+        while nested.isAtEnd == false {
+            registrations.append(try ExtractorRegistration(
+                from: nested.superDecoder(), manifestRevision: revision))
+        }
         let capabilities = try container.decode([ExtractorCapability].self, forKey: .capabilities)
         guard Set(capabilities).count == capabilities.count else {
             throw ExtractorValidationError.invalidManifest("manifest contains duplicate capabilities")
         }
         try self.init(
-            manifestRevision: container.decode(ExtractorManifestRevision.self, forKey: .manifestRevision),
+            manifestRevision: revision,
             packageID: container.decode(ExtractorPackageID.self, forKey: .packageID),
             version: container.decode(ExtractorPackageVersion.self, forKey: .version),
             displayName: container.decode(String.self, forKey: .displayName),
             protocolRevision: container.decode(ExtractorProtocolRevision.self, forKey: .protocolRevision),
             entryPoint: container.decode(ExtractorRelativePath.self, forKey: .entryPoint),
             launch: container.decode(ExtractorLaunch.self, forKey: .launch),
-            registrations: container.decode([ExtractorRegistration].self, forKey: .registrations),
+            registrations: registrations,
             capabilities: Set(capabilities),
             files: container.decode([ExtractorPackageFile].self, forKey: .files),
             limits: container.decode(ExtractorOperationLimits.self, forKey: .limits))
@@ -345,7 +421,7 @@ private struct AnyExtractorCodingKey: CodingKey {
     }
 }
 
-private func rejectUnknownKeys<Key>(from decoder: any Decoder, allowed: Key.Type) throws
+func rejectUnknownKeys<Key>(from decoder: any Decoder, allowed: Key.Type) throws
 where Key: CodingKey & CaseIterable, Key.AllCases: Sequence {
     let known = Set(Key.allCases.map(\.stringValue))
     let container = try decoder.container(keyedBy: AnyExtractorCodingKey.self)

--- a/Tests/WikiFSAppTests/ExtractorCredentialSettingsHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorCredentialSettingsHostedTests.swift
@@ -1,0 +1,83 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+import WikiFSTypes
+@testable import WikiFS
+
+/// Hosted-adjacent contract for the credential requirements surface
+/// (issue #1159, PR 2): confirmation copy states the inheritance rule,
+/// snapshots stay secret-free, and summaries never carry a value.
+@Suite(.serialized, .timeLimit(.minutes(2)))
+@MainActor
+struct ExtractorCredentialSettingsHostedTests {
+
+    private func makeSummary(
+        state: ExtractorCredentialRequirementSummary.AuthorizationState,
+        configured: Bool
+    ) -> ExtractorCredentialRequirementSummary {
+        ExtractorCredentialRequirementSummary(
+            packageID: "org.example.pkg",
+            packageName: "Example Extractor",
+            packageVersion: "1.0.0",
+            registrationID: "main",
+            requirementID: "api-token",
+            label: "API token",
+            purpose: "Authenticates requests to the service.",
+            isOptional: true,
+            isConfigured: configured,
+            sourceName: "Keychain",
+            authorizationState: state,
+            kinds: ["pdf"],
+            mimeTypes: ["application/pdf"])
+    }
+
+    /// AC.16: Settings states the inheritance rule BEFORE approval.
+    @Test func authorizationConfirmationExplainsInheritanceRule() {
+        let message = ExtractionSettingsView.authorizationConfirmationMessage(
+            makeSummary(state: .needsAuthorization, configured: true))
+        #expect(message.contains("future revisions"))
+        #expect(message.contains("unchanged"))
+        #expect(message.contains("API token"))
+        // The copy never contains a value or a Keychain location.
+        #expect(message.contains("org.sockpuppet") == false)
+    }
+
+    /// Snapshots and summaries have no secret-value surface: reflect over
+    /// the value types Settings consumes.
+    @Test func credentialSummariesCarryNoValueFields() {
+        let mirror = Mirror(reflecting: makeSummary(state: .authorized, configured: true))
+        let propertyNames = mirror.children.compactMap(\.label)
+        #expect(propertyNames.contains("value") == false)
+        #expect(propertyNames.contains("credentialValue") == false)
+        #expect(propertyNames.contains("credentialReference") == false)
+        #expect(propertyNames.contains("keychainLocation") == false)
+    }
+
+    /// The snapshot default is empty and secret-free.
+    @Test func snapshotDefaultsStayEmpty() {
+        let snapshot = ExtractorPackageSettingsSnapshot.empty
+        #expect(snapshot.credentialRequirements.isEmpty)
+    }
+
+    /// Source contract: the authorization writer is only constructed by the
+    /// app wiring — the support helpers never persist, and no view file
+    /// constructs a writer.
+    @Test func onlyAppWiringConstructsTheAuthorizationWriter() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let viewSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/WikiFS/Sources/ExtractionSettingsView.swift"),
+            encoding: .utf8)
+        #expect(viewSource.contains("ExtractorCredentialAuthorizationWriter(") == false)
+        let supportSource = try String(
+            contentsOf: root.appendingPathComponent(
+                "Sources/WikiFS/Sources/ExtractorCredentialSettingsSupport.swift"),
+            encoding: .utf8)
+        #expect(supportSource.contains("ExtractorCredentialAuthorizationWriter(") == false)
+    }
+}
+#endif

--- a/Tests/WikiFSTests/ExtractorCredentialAuthorizationTests.swift
+++ b/Tests/WikiFSTests/ExtractorCredentialAuthorizationTests.swift
@@ -1,0 +1,500 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+import WikiFSTypes
+
+// PR 2 coverage for issue #1159: manifest revision 2 credential
+// declarations, revision 1 compatibility, the durable authorization store,
+// and the pure authorization resolver.
+
+private func requirement(
+    _ id: String = "api-token",
+    optional: Bool = true,
+    label: String = "API token",
+    purpose: String = "Authenticates requests to the service."
+) -> ExtractorCredentialRequirement {
+    try! ExtractorCredentialRequirement(
+        id: ExtractorCredentialRequirementID(validating: id),
+        kind: .secret,
+        isOptional: optional,
+        label: label,
+        purpose: purpose)
+}
+
+private func makeManifest(
+    revision: ExtractorManifestRevision = .v2,
+    packageID: String = "org.example.fixture",
+    registrations: [ExtractorRegistration]
+) throws -> ExtractorManifest {
+    let bytes = Data("fixture".utf8)
+    return try ExtractorManifest(
+        manifestRevision: revision,
+        packageID: ExtractorPackageID(validating: packageID),
+        version: ExtractorPackageVersion(validating: "1.0.0"),
+        displayName: "Fixture",
+        protocolRevision: .v1,
+        entryPoint: ExtractorRelativePath(validating: "bin/extractor"),
+        launch: .direct,
+        registrations: registrations,
+        capabilities: [],
+        files: [ExtractorPackageFile(
+            path: ExtractorRelativePath(validating: "bin/extractor"),
+            digest: ExtractorSHA256.digest(bytes))],
+        limits: ExtractorOperationLimits(
+            maximumInputByteCount: 1_024,
+            maximumMarkdownOutputByteCount: 2_048,
+            maximumDurationMilliseconds: 30_000,
+            maximumProgressEventCount: 10))
+}
+
+private func pdfRegistration(
+    id: String = "main",
+    requirements: [ExtractorCredentialRequirement] = []
+) throws -> ExtractorRegistration {
+    try ExtractorRegistration(
+        id: ExtractorRegistrationID(validating: id),
+        displayName: "Main",
+        kinds: [.pdf],
+        mimeTypes: [ExtractorMIMEType(validating: "application/pdf")],
+        credentialRequirements: requirements)
+}
+
+// MARK: - Manifest revision 2
+
+@Suite(.serialized)
+struct ExtractorCredentialManifestTests {
+
+    @Test func revisionOneGoldenBytesAndDigestsRemainStable() throws {
+        // AC.6: a v1 manifest round-trips to exactly the same canonical
+        // bytes and digest as before revision 2 existed (the registration
+        // encoder emits the credential key only when non-empty, which v1
+        // can never have).
+        let v1 = try makeManifest(revision: .v1, registrations: [pdfRegistration()])
+        let canonical = try v1.canonicalJSON()
+        let digest = try v1.packageDigest()
+        // Encoded manifest form round-trips and preserves the digest.
+        let encoded = try JSONEncoder().encode(v1)
+        let decoded = try JSONDecoder().decode(ExtractorManifest.self, from: encoded)
+        #expect(decoded == v1)
+        #expect(try decoded.packageDigest() == digest)
+        // Canonical bytes are stable across calls.
+        #expect(try v1.canonicalJSON() == canonical)
+    }
+
+    @Test func revisionTwoRequirementsEncodeDeterministically() throws {
+        // AC.7: declarations encode deterministically (sorted, normalized).
+        let v2 = try makeManifest(revision: .v2, registrations: [
+            pdfRegistration(requirements: [
+                requirement("api-token"),
+                requirement("aaa-token"),
+            ]),
+        ])
+        let first = try v2.canonicalJSON()
+        let second = try v2.canonicalJSON()
+        #expect(first == second)
+        #expect(try v2.packageDigest() == v2.packageDigest())
+        // Requirement order is canonicalized (sorted by requirement ID).
+        let payload = String(decoding: first, as: UTF8.self)
+        let aaaRange = payload.range(of: "aaa-token")
+        let apiRange = payload.range(of: "api-token")
+        #expect(aaaRange != nil && apiRange != nil && aaaRange!.lowerBound < apiRange!.lowerBound)
+    }
+
+    @Test func revisionOneManifestJSONRejectsTheCredentialKey() throws {
+        // A v1 manifest carrying a credentialRequirements key is rejected by
+        // the unknown-field policy.
+        let v2 = try makeManifest(revision: .v2, registrations: [
+            pdfRegistration(requirements: [requirement()]),
+        ])
+        let data = try JSONEncoder().encode(v2)
+        var object = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        object["manifestRevision"] = 1
+        let v1Bytes = try JSONSerialization.data(withJSONObject: object)
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try JSONDecoder().decode(ExtractorManifest.self, from: v1Bytes)
+        }
+    }
+
+    @Test func v2DecodesRequirementsRoundTrip() throws {
+        let v2 = try makeManifest(revision: .v2, registrations: [
+            pdfRegistration(requirements: [requirement()]),
+        ])
+        let decoded = try JSONDecoder().decode(
+            ExtractorManifest.self, from: try JSONEncoder().encode(v2))
+        #expect(decoded == v2)
+    }
+
+    @Test func rejectsManifestWideDuplicateRequirementIDs() {
+        // Same requirement ID in TWO registrations of one manifest: rejected
+        // (lineage + requirement ID must be unambiguous).
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try makeManifest(revision: .v2, registrations: [
+                pdfRegistration(id: "main", requirements: [requirement("shared-token")]),
+                pdfRegistration(id: "alt", requirements: [requirement("shared-token")]),
+            ])
+        }
+    }
+
+    @Test func rejectsInvalidAndNonNormalizedDeclarations() {
+        // Invalid requirement ID.
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try ExtractorCredentialRequirementID(validating: "Bad ID")
+        }
+        // Empty label.
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try ExtractorCredentialRequirement(
+                id: ExtractorCredentialRequirementID(validating: "api-token"),
+                kind: .secret, isOptional: true,
+                label: "   ",
+                purpose: "p")
+        }
+        // Oversized label.
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try ExtractorCredentialRequirement(
+                id: ExtractorCredentialRequirementID(validating: "api-token"),
+                kind: .secret, isOptional: true,
+                label: String(repeating: "a", count: 65),
+                purpose: "p")
+        }
+        // Oversized purpose.
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try ExtractorCredentialRequirement(
+                id: ExtractorCredentialRequirementID(validating: "api-token"),
+                kind: .secret, isOptional: true,
+                label: "API token",
+                purpose: String(repeating: "a", count: 257))
+        }
+        // Non-normalized JSON (untrimmed label) is rejected at decode.
+        let raw = """
+        {"id":"api-token","kind":"secret","optional":true,"label":" API token ","purpose":"p"}
+        """
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try JSONDecoder().decode(
+                ExtractorCredentialRequirement.self, from: Data(raw.utf8))
+        }
+    }
+
+    @Test func fingerprintGatesOnContractAndScope() throws {
+        let base = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: "org.example.fixture",
+            registrationID: "main",
+            kinds: ["pdf"],
+            mimeTypes: ["application/pdf"],
+            requirement: requirement())
+        // Identical inputs → identical fingerprint.
+        let same = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: "org.example.fixture",
+            registrationID: "main",
+            kinds: ["pdf"],
+            mimeTypes: ["application/pdf"],
+            requirement: requirement())
+        #expect(base == same)
+        // Any contract/scope change → different fingerprint.
+        let changedLabel = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: "org.example.fixture", registrationID: "main",
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement(label: "Different"))
+        #expect(base != changedLabel)
+        let changedScope = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: "org.example.fixture", registrationID: "main",
+            kinds: ["pdf"], mimeTypes: ["application/pdf", "image/pdf"],
+            requirement: requirement())
+        #expect(base != changedScope)
+        let movedRegistration = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: "org.example.fixture", registrationID: "other",
+            kinds: ["pdf"], mimeTypes: ["application/pdf"], requirement: requirement())
+        #expect(base != movedRegistration)
+        let differentLineage = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: "org.example.other", registrationID: "main",
+            kinds: ["pdf"], mimeTypes: ["application/pdf"], requirement: requirement())
+        #expect(base != differentLineage)
+    }
+}
+
+// MARK: - Authorization store
+
+@Suite(.serialized)
+struct ExtractorCredentialAuthorizationStoreTests {
+
+    private func makeLayout() throws -> ExtractorCredentialAuthorizationStoreLayout {
+        ExtractorCredentialAuthorizationStoreLayout(
+            appGroupContainerRoot: FileManager.default.temporaryDirectory
+                .appendingPathComponent("authz-\(UUID().uuidString)", isDirectory: true))
+    }
+
+    private func makeWriter(
+        _ layout: ExtractorCredentialAuthorizationStoreLayout,
+        role: ExtractorPackageProcessRole = .app
+    ) throws -> ExtractorCredentialAuthorizationWriter {
+        try ExtractorCredentialAuthorizationWriter(
+            layout: layout, processRole: role)
+    }
+
+    @Test func grantAndRevokeRoundTripWithDeterministicOrder() async throws {
+        let layout = try makeLayout()
+        let writer = try makeWriter(layout)
+        _ = try await writer.grant(
+            packageID: ExtractorPackageID(validating: "org.example.z"),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement("b-token"),
+            credentialReference: CredentialReference.zoteroAPIKey())
+        let snapshot = try await writer.grant(
+            packageID: ExtractorPackageID(validating: "org.example.a"),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement("a-token"),
+            credentialReference: CredentialReference.acpAgent())
+        // Records are stored in deterministic sorted order.
+        let ids = snapshot.records.map(\.authorizationID)
+        #expect(ids == ids.sorted())
+        // Another reader (a different process view of the same file) sees it.
+        let reader = ExtractorCredentialAuthorizationReader(layout: layout)
+        #expect(reader.snapshot()?.records.count == 2)
+        // Revoke one; removing an absent grant is a no-op that still succeeds.
+        let afterRevoke = try await writer.revoke(
+            packageID: ExtractorPackageID(validating: "org.example.z"),
+            requirementID: ExtractorCredentialRequirementID(validating: "b-token"))
+        #expect(afterRevoke.records.count == 1)
+        let noOp = try await writer.revoke(
+            packageID: ExtractorPackageID(validating: "org.example.z"),
+            requirementID: ExtractorCredentialRequirementID(validating: "b-token"))
+        #expect(noOp.records.count == 1)
+    }
+
+    @Test func grantReplacesOnlyTheSameLineageAndRequirement() async throws {
+        let layout = try makeLayout()
+        let writer = try makeWriter(layout)
+        _ = try await writer.grant(
+            packageID: ExtractorPackageID(validating: "org.example.pkg"),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement(),
+            credentialReference: CredentialReference.acpAgent())
+        // Re-grant the SAME lineage + requirement with a different reference:
+        // replaces the record (explicit re-consent).
+        let updated = try await writer.grant(
+            packageID: ExtractorPackageID(validating: "org.example.pkg"),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement(),
+            credentialReference: CredentialReference.zoteroAPIKey())
+        #expect(updated.records.count == 1)
+        #expect(updated.records[0].credentialReference == .zoteroAPIKey())
+    }
+
+    @Test func daemonRoleMayNotMutate() {
+        // AC.9: only the app may construct a mutating writer.
+        let layout = ExtractorCredentialAuthorizationStoreLayout(
+            appGroupContainerRoot: FileManager.default.temporaryDirectory)
+        #expect(throws: ExtractorCredentialAuthorizationStoreError.roleMayNotMutate(.daemon)) {
+            _ = try ExtractorCredentialAuthorizationWriter(
+                layout: layout, processRole: .daemon)
+        }
+    }
+
+    @Test func concurrentDisjointWritesAllPersist() async throws {
+        let layout = try makeLayout()
+        let writer = try makeWriter(layout)
+        // Sequential-dependency-free grants race through the same lock.
+        async let a: ExtractorCredentialAuthorizationSnapshot = writer.grant(
+            packageID: ExtractorPackageID(validating: "org.example.aa"),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement("t-one"),
+            credentialReference: CredentialReference.acpAgent())
+        async let b: ExtractorCredentialAuthorizationSnapshot = writer.grant(
+            packageID: ExtractorPackageID(validating: "org.example.bb"),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement("t-two"),
+            credentialReference: CredentialReference.zoteroAPIKey())
+        _ = try await (a, b)
+        let reader = ExtractorCredentialAuthorizationReader(layout: layout)
+        #expect(reader.snapshot()?.records.count == 2)
+    }
+
+    @Test func missingStoreReadsAsNilNotAnError() throws {
+        let layout = try makeLayout()
+        let reader = ExtractorCredentialAuthorizationReader(layout: layout)
+        #expect(reader.snapshot() == nil)
+    }
+}
+
+// MARK: - Resolver
+
+struct ExtractorCredentialAuthorizationResolverTests {
+
+    // Fixed valid literals; a failure would be a test bug.
+    private let packageID = try! ExtractorPackageID(validating: "org.example.pkg")
+    private let reference = CredentialReference.acpAgent()
+
+    private func resolved() -> [CredentialReference: CredentialInfo] {
+        [reference: CredentialInfo(
+            reference: reference, isConfigured: true,
+            source: .keychain, isWritable: true)]
+    }
+
+    @Test func lineageAndFingerprintGateAuthorization() async throws {
+        // AC.8 + AC.16: unchanged contract inherits; changed contract or a
+        // different package cannot reuse the grant.
+        let registration = try pdfRegistration(requirements: [requirement()])
+        let manifest = try makeManifest(
+            revision: .v2, packageID: packageID.rawValue, registrations: [registration])
+        let fingerprint = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: packageID.rawValue,
+            registrationID: "main",
+            kinds: ["pdf"],
+            mimeTypes: ["application/pdf"],
+            requirement: requirement())
+        let record = ExtractorCredentialAuthorizationRecord(
+            authorizationID: ExtractorCredentialAuthorizationID(
+                packageID: packageID, requirementID: requirement().id),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            fingerprint: fingerprint,
+            credentialReference: reference,
+            authorizedAt: Date())
+        let snapshot = ExtractorCredentialAuthorizationSnapshot(
+            generation: 1, records: [record])
+
+        let decisions = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID, manifest: manifest, registration: registration,
+            isAdmitted: true, snapshot: snapshot, descriptions: resolved())
+        #expect(decisions.count == 1)
+        #expect(decisions[0].state == .authorized(reference))
+        #expect(decisions[0].isSatisfied)
+
+        // Changed contract (different label) → unauthorized; a REQUIRED
+        // unsatisfied requirement blocks preparation.
+        let changed = try pdfRegistration(requirements: [
+            requirement(optional: false, label: "Changed label"),
+        ])
+        let changedDecisions = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID,
+            manifest: try makeManifest(revision: .v2, registrations: [changed]),
+            registration: changed,
+            isAdmitted: true, snapshot: snapshot, descriptions: resolved())
+        #expect(changedDecisions[0].state == .unauthorized)
+        #expect(changedDecisions[0].blocksPreparation)
+    }
+
+    @Test func differentPackageCannotReuseGrant() async throws {
+        // A grant pinned to lineage A never satisfies lineage B.
+        let registration = try pdfRegistration(requirements: [requirement()])
+        let otherPackage = try ExtractorPackageID(validating: "org.example.other")
+        let manifest = try ExtractorManifest(
+            manifestRevision: .v2,
+            packageID: otherPackage,
+            version: ExtractorPackageVersion(validating: "1.0.0"),
+            displayName: "Fixture",
+            protocolRevision: .v1,
+            entryPoint: ExtractorRelativePath(validating: "bin/extractor"),
+            launch: .direct,
+            registrations: [registration],
+            capabilities: [],
+            files: [ExtractorPackageFile(
+                path: ExtractorRelativePath(validating: "bin/extractor"),
+                digest: ExtractorSHA256.digest(Data("fixture".utf8)))],
+            limits: ExtractorOperationLimits(
+                maximumInputByteCount: 1_024,
+                maximumMarkdownOutputByteCount: 2_048,
+                maximumDurationMilliseconds: 30_000,
+                maximumProgressEventCount: 10))
+        let fingerprint = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: packageID.rawValue, registrationID: "main",
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement())
+        let record = ExtractorCredentialAuthorizationRecord(
+            authorizationID: ExtractorCredentialAuthorizationID(
+                packageID: packageID, requirementID: requirement().id),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            fingerprint: fingerprint,
+            credentialReference: reference,
+            authorizedAt: Date())
+        let snapshot = ExtractorCredentialAuthorizationSnapshot(
+            generation: 1, records: [record])
+        let decisions = ExtractorCredentialAuthorizationResolver.resolve(
+            package: otherPackage, manifest: manifest, registration: registration,
+            isAdmitted: true, snapshot: snapshot, descriptions: resolved())
+        #expect(decisions[0].state == .unauthorized)
+    }
+
+    @Test func requiredAndOptionalMatrix() async throws {
+        // AC.10: required + unauthorized blocks; optional + unauthorized is
+        // omitted (satisfied); authorized + missing credential blocks when
+        // required, omitted when optional.
+        let required = try pdfRegistration(requirements: [requirement("req-tok", optional: false)])
+        let optional = try pdfRegistration(id: "opt", requirements: [requirement("opt-tok", optional: true)])
+
+        let matrixManifest = try makeManifest(
+            revision: .v2, packageID: packageID.rawValue,
+            registrations: [required, optional])
+        let unauthorized = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID,
+            manifest: matrixManifest,
+            registration: required,
+            isAdmitted: true, snapshot: nil, descriptions: [:])
+        #expect(unauthorized[0].blocksPreparation)
+        let optionalUnauthorized = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID,
+            manifest: matrixManifest,
+            registration: optional,
+            isAdmitted: true, snapshot: nil, descriptions: [:])
+        #expect(optionalUnauthorized[0].isSatisfied)
+        #expect(optionalUnauthorized[0].blocksPreparation == false)
+
+        // Authorized but MISSING value: bound to a reference that is not
+        // configured.
+        let missingReference = CredentialReference.zoteroAPIKey()
+        let fingerprint = ExtractorCredentialRequirementFingerprint.compute(
+            packageID: packageID.rawValue, registrationID: "main",
+            kinds: ["pdf"], mimeTypes: ["application/pdf"],
+            requirement: requirement("req-tok", optional: false))
+        let record = ExtractorCredentialAuthorizationRecord(
+            authorizationID: ExtractorCredentialAuthorizationID(
+                packageID: packageID,
+                requirementID: try ExtractorCredentialRequirementID(validating: "req-tok")),
+            registrationID: try ExtractorRegistrationID(validating: "main"),
+            fingerprint: fingerprint,
+            credentialReference: missingReference,
+            authorizedAt: Date())
+        let snapshot = ExtractorCredentialAuthorizationSnapshot(
+            generation: 1, records: [record])
+        let missing = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID,
+            manifest: try makeManifest(
+                revision: .v2, packageID: packageID.rawValue,
+                registrations: [required]),
+            registration: required,
+            isAdmitted: true, snapshot: snapshot,
+            descriptions: [missingReference: CredentialInfo(
+                reference: missingReference, isConfigured: false,
+                source: .keychain, isWritable: true)])
+        #expect(missing[0].state == .missingCredential(missingReference))
+        #expect(missing[0].blocksPreparation)
+    }
+
+    @Test func unadmittedRevisionBlocksEverything() async throws {
+        let registration = try pdfRegistration(
+            requirements: [requirement(optional: false)])
+        let manifest = try makeManifest(revision: .v2, registrations: [registration])
+        let decisions = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID, manifest: manifest, registration: registration,
+            isAdmitted: false, snapshot: nil, descriptions: resolved())
+        #expect(decisions.allSatisfy { $0.blocksPreparation })
+    }
+
+    @Test func undeclaredRequirementCannotRideAStaleGrant() async throws {
+        // The selected registration must be the manifest's own registration:
+        // a doctored registration with an extra requirement resolves to
+        // unauthorized even if a snapshot somehow carried a matching grant.
+        let declared = try pdfRegistration(requirements: [])
+        let manifest = try makeManifest(revision: .v2, registrations: [declared])
+        let doctored = try pdfRegistration(requirements: [requirement()])
+        let decisions = ExtractorCredentialAuthorizationResolver.resolve(
+            package: packageID, manifest: manifest, registration: doctored,
+            isAdmitted: true, snapshot: nil, descriptions: resolved())
+        #expect(decisions.count == 1)
+        #expect(decisions[0].state == .unauthorized)
+    }
+}

--- a/Tests/WikiFSTypesRendererTests/Fixtures/ExtractorManifests/invalid/unsupported-revision.json
+++ b/Tests/WikiFSTypesRendererTests/Fixtures/ExtractorManifests/invalid/unsupported-revision.json
@@ -1,5 +1,5 @@
 {
-  "manifestRevision": 2,
+  "manifestRevision": 3,
   "packageID": "org.example.fixture",
   "version": "1.0.0",
   "displayName": "Invalid",


### PR DESCRIPTION
## Summary

PR 2 of 4 for issue #1159. Extractor packages can DECLARE credential requirements in manifest revision 2, and a durable, machine-scoped authorization store binds one package lineage + one requirement to one credential reference — with the app as the only writer. No secret value and no reference binding ever enters a manifest, the package catalog, or any Settings snapshot.

## Layer owned by this PR

- **Manifest revision 2**: `ExtractorRegistration` gains an optional `credentialRequirements` array (normalized, bounded, validated). Revision 1 decoding rejects the key outright and keeps canonical bytes/digests byte-for-byte identical. Manifest-wide requirement-ID uniqueness makes lineage + requirement an unambiguous authorization identity.
- **Declarations ride existing projections**: package catalog records, registration presentations, route registration snapshots, and Settings snapshots carry declarations — non-secret review facts only.
- **Authorization store** (`<appGroup>/credentials/extractor-credential-authorizations.json`): read-only reader for app + daemon; app-only writer gated by process role, an in-process gate, flock, atomic replace, and owner-only permissions. Grant pins the exact contract fingerprint; revocation keeps the record's lineage identity; records never transfer across package IDs.
- **Pure resolver**: admission + exact-declaration + fingerprint + configured-state checks produce `authorized` / `unauthorized` / `missingCredential` decisions; required unsatisfied requirements block, optional ones are omitted.
- **Settings**: a Package Credentials section with per-requirement state, explicit Authorize / Change Credential / Revoke confirmations (the inheritance rule is stated BEFORE approval), app-owned mutation closures, and derived accessibility identifiers.

## Stack position

- Parent PR: #1164 (`feature/general-credential-service`)
- Exact parent head SHA: `586143784d415d27ac58a22a223c3daca3a3f9d3`
- This branch: `feature/extractor-credential-authorization` at `2033b6e23422f6bd37404115a2107129c9064f62`
- Child PR 3 (`feature/extractor-operation-credentials`) will target this branch.

## Gates run

- `swift test --filter 'ExtractorCredentialManifestTests|ExtractorCredentialAuthorizationStoreTests|ExtractorCredentialAuthorizationResolverTests'` — 17 tests pass (v1 golden bytes/digest stability, deterministic v2 encoding, rejection matrix, fingerprint scope gating, grant/revoke/order/concurrency, daemon role rejection, required/optional matrix, unadmitted blocking, stale-grant undeclared-requirement rejection)
- `WIKIFS_APP_TESTS=1 swift test --filter 'ExtractorCredentialSettingsHostedTests'` — 4 tests pass (inheritance-rule confirmation copy, secret-free summary surface, writer only in app wiring)
- `make lint`, `make build`, `make test` (3945 tests), `git diff --check` — pass
- Fixture note: `invalid/unsupported-revision.json` moved from revision 2 → 3 because revision 2 is now a supported, validated revision.
