### PR TITLE
feat(extractors): inject operation-scoped credentials

### DIFF
--- a/Sources/WikiFSEngine/ExtractionServiceKeys.swift
+++ b/Sources/WikiFSEngine/ExtractionServiceKeys.swift
@@ -438,6 +438,11 @@ public enum ExtractionServiceKeys {
         label: "wiki.extraction.catalog-reader")
     public static let managedProcessExecutor = ServiceKey<any ManagedProcessExecuting>(
         label: "wiki.extraction.process-executor")
+    /// #1159: host-owned per-operation credential resolution. A host-side
+    /// service of the GENERATED PLUGIN (trusted host code) — never a package
+    /// Cordis dependency and never visible to a package process.
+    public static let operationCredentialResolver = ServiceKey<any ExtractorOperationCredentialResolving>(
+        label: "wiki.extraction.operation-credential-resolver")
     public static let packageAdmissionChecker = ServiceKey<any ProcessPackageAdmissionChecking>(
         label: "wiki.extraction.admission-checker")
     public static let packageStoreLayout = ServiceKey<ExtractorPackageStoreLayout>(

--- a/Sources/WikiFSEngine/ExtractorOperationCredentialResolution.swift
+++ b/Sources/WikiFSEngine/ExtractorOperationCredentialResolution.swift
@@ -1,0 +1,182 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+import WikiFSCore
+import WikiFSTypes
+
+// Per-operation credential resolution (issue #1159, PR 3 —
+// plans/credential-service.md §"Operation input"). The trusted host resolves
+// the selected registration's authorized requirements IMMEDIATELY BEFORE each
+// process launch, materializes them into a request-scoped owner-read-only
+// file, and redacts every package-provided string that could echo a value.
+
+public enum ExtractorOperationCredentialError: Error, Equatable, Sendable,
+    CustomStringConvertible {
+    /// The exact revision is no longer admitted (removed / failed activation).
+    case packageNotAdmitted
+    /// The revision is no longer in the machine catalog.
+    case unknownRevision
+    /// A REQUIRED requirement is unauthorized or has no stored value.
+    case requiredCredentialUnavailable(requirementID: String)
+    /// A required resolution step failed before launch; bounded, value-free.
+    case resolutionUnavailable
+
+    public var description: String {
+        switch self {
+        case .packageNotAdmitted:
+            return "The installed extractor package is no longer active."
+        case .unknownRevision:
+            return "The installed extractor package is not in the machine catalog."
+        case .requiredCredentialUnavailable(let id):
+            return "A required credential (\(id)) is not authorized or not configured. Authorize it in Settings → Extraction."
+        case .resolutionUnavailable:
+            return "Extractor credentials could not be prepared for this run."
+        }
+    }
+}
+
+/// Host-owned per-operation resolution (AC.11). Called by the process
+/// provider IMMEDIATELY BEFORE each launch of a credential-declaring
+/// registration; implementations must recheck current state and never cache
+/// values across calls.
+public protocol ExtractorOperationCredentialResolving: Sendable {
+    func resolveOperationCredentials(
+        revision: ExtractorPackageRevisionID,
+        manifest: ExtractorManifest,
+        registration: ExtractorRegistration
+    ) async throws -> [ExtractorCredentialRequirementID: String]
+}
+
+/// The production resolver: rechecks admission + catalog membership, reloads
+/// the authorization snapshot, validates declaration fingerprints via the
+/// pure PR 2 resolver, then resolves each authorized reference ONCE. Absent
+/// optional values are omitted; an absent REQUIRED value throws a bounded
+/// typed error.
+public struct ExtractorOperationCredentialResolver: ExtractorOperationCredentialResolving {
+    private let admission: any ProcessPackageAdmissionChecking
+    private let catalogReader: any ExtractorPackageCatalogReading
+    private let authorizationReader: ExtractorCredentialAuthorizationReader
+    private let credentials: any CredentialResolving
+
+    public init(
+        admission: any ProcessPackageAdmissionChecking,
+        catalogReader: any ExtractorPackageCatalogReading,
+        authorizationReader: ExtractorCredentialAuthorizationReader,
+        credentials: any CredentialResolving
+    ) {
+        self.admission = admission
+        self.catalogReader = catalogReader
+        self.authorizationReader = authorizationReader
+        self.credentials = credentials
+    }
+
+    public func resolveOperationCredentials(
+        revision: ExtractorPackageRevisionID,
+        manifest: ExtractorManifest,
+        registration: ExtractorRegistration
+    ) async throws -> [ExtractorCredentialRequirementID: String] {
+        // TOCTOU rechecks (plan step 12): admission + catalog membership are
+        // re-observed immediately before resolution; once the launch request
+        // is constructed the operation owns its value snapshot.
+        guard await admission.isAdmitted(revision) else {
+            throw ExtractorOperationCredentialError.packageNotAdmitted
+        }
+        let catalog = try catalogReader.read()
+        guard catalog.records.contains(where: { $0.revision == revision }) else {
+            throw ExtractorOperationCredentialError.unknownRevision
+        }
+        let snapshot = authorizationReader.snapshot()
+        let decisions = ExtractorCredentialAuthorizationResolver.resolve(
+            package: revision.packageID,
+            manifest: manifest,
+            registration: registration,
+            isAdmitted: true,
+            snapshot: snapshot,
+            descriptions: describe(candidateReferences(
+                packageID: revision.packageID,
+                registration: registration,
+                snapshot: snapshot)))
+        var resolved: [ExtractorCredentialRequirementID: String] = [:]
+        for decision in decisions {
+            switch decision.state {
+            case .authorized(let reference):
+                do {
+                    resolved[decision.requirement.id] = try credentials.resolve(reference).value
+                } catch {
+                    if decision.requirement.isOptional { continue }
+                    throw ExtractorOperationCredentialError.requiredCredentialUnavailable(
+                        requirementID: decision.requirement.id.rawValue)
+                }
+            case .missingCredential:
+                if decision.requirement.isOptional { continue }
+                throw ExtractorOperationCredentialError.requiredCredentialUnavailable(
+                    requirementID: decision.requirement.id.rawValue)
+            case .unauthorized:
+                if decision.requirement.isOptional { continue }
+                throw ExtractorOperationCredentialError.requiredCredentialUnavailable(
+                    requirementID: decision.requirement.id.rawValue)
+            }
+        }
+        return resolved
+    }
+
+    /// The references granted to THIS lineage for the registration's declared
+    /// requirements (fingerprint-validated candidates for description).
+    private func candidateReferences(
+        packageID: ExtractorPackageID,
+        registration: ExtractorRegistration,
+        snapshot: ExtractorCredentialAuthorizationSnapshot?
+    ) -> [CredentialReference] {
+        guard let snapshot else { return [] }
+        return registration.credentialRequirements.compactMap { requirement in
+            let authorizationID = ExtractorCredentialAuthorizationID(
+                packageID: packageID, requirementID: requirement.id)
+            guard let record = snapshot.record(for: authorizationID),
+                  record.fingerprint == ExtractorCredentialRequirementFingerprint.compute(
+                    packageID: packageID.rawValue,
+                    registrationID: registration.id.rawValue,
+                    kinds: registration.kinds.map(\.rawValue),
+                    mimeTypes: registration.mimeTypes.map(\.rawValue),
+                    requirement: requirement)
+            else { return nil }
+            return record.credentialReference
+        }
+    }
+
+    private func describe(
+        _ references: [CredentialReference]
+    ) -> [CredentialReference: CredentialInfo] {
+        guard let describing = credentials as? any CredentialDescribing else { return [:] }
+        return describing.describe(references)
+    }
+}
+
+/// Replaces every resolved operation value before any package-controlled
+/// string reaches host diagnostics, logs, mapped errors, or UI (AC.15).
+/// Values are captured at construction and never exposed.
+public struct ExtractorSecretRedactor: Sendable {
+    /// Fixed replacement token — never derived from the secret.
+    private static let replacement = "[redacted]"
+    private let secrets: [String]
+
+    public init(values: [String]) {
+        self.secrets = values
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+            .compactMap { $0 }
+    }
+
+    public func redact(_ text: String) -> String {
+        var result = text
+        for secret in secrets where result.contains(secret) {
+            result = result.replacingOccurrences(of: secret, with: Self.replacement)
+        }
+        return result
+    }
+
+    public func redactedMessage(_ error: Error) -> String {
+        redact(ProcessPackageFailureMapper.message(error))
+    }
+}

--- a/Sources/WikiFSEngine/ExtractorPackagePluginDefinitionFactory.swift
+++ b/Sources/WikiFSEngine/ExtractorPackagePluginDefinitionFactory.swift
@@ -136,6 +136,7 @@ public enum ExtractorPackagePluginDefinitionFactory {
                 ServiceDependency(ExtractionServiceKeys.packageAdmissionChecker),
                 ServiceDependency(ExtractionServiceKeys.packageStoreLayout),
                 ServiceDependency(ExtractionServiceKeys.packageSourceLocator),
+                ServiceDependency(ExtractionServiceKeys.operationCredentialResolver),
             ]
         ) { activation in
             let registry = try await activation.require(ExtractionServiceKeys.backends)
@@ -155,6 +156,8 @@ public enum ExtractorPackagePluginDefinitionFactory {
                 ExtractionServiceKeys.packageAdmissionChecker)
             let sourceLocator = try await activation.require(
                 ExtractionServiceKeys.packageSourceLocator)
+            let operationCredentialResolver = try await activation.require(
+                ExtractionServiceKeys.operationCredentialResolver)
             let provider = ProcessExtractorProvider(
                 layout: layout,
                 catalogReader: catalogReader,
@@ -162,7 +165,8 @@ public enum ExtractorPackagePluginDefinitionFactory {
                 admission: admissionChecker,
                 sourceLocator: sourceLocator,
                 sharedRuntimeCacheRoot: layout.root.appendingPathComponent("runtime-cache", isDirectory: true),
-                sharedModelCacheRoot: layout.root.appendingPathComponent("model-cache", isDirectory: true))
+                sharedModelCacheRoot: layout.root.appendingPathComponent("model-cache", isDirectory: true),
+                operationCredentials: operationCredentialResolver)
 
             // Build every registration factory before mutating the registry.
             var entries: [ExtractionBatchEntry] = []

--- a/Sources/WikiFSEngine/ProcessExtractionContext.swift
+++ b/Sources/WikiFSEngine/ProcessExtractionContext.swift
@@ -110,6 +110,22 @@ public struct ProcessExtractionContext: Sendable {
             ExtractionServiceKeys.packageAdmissionChecker,
             value: admission)
 
+        // Host-owned operation-credential resolution (#1159). Both the app
+        // and the daemon resolve the shared binding independently in their
+        // own processes; the resolver is never exposed to a package process
+        // (it stays a host-side Cordis service of the GENERATED PLUGIN, not
+        // of the package).
+        let operationCredentialResolver = ExtractorOperationCredentialResolver(
+            admission: admission,
+            catalogReader: catalogReader,
+            authorizationReader: ExtractorCredentialAuthorizationReader(
+                layout: ExtractorCredentialAuthorizationStoreLayout(
+                    appGroupContainerRoot: layout.appGroupContainerRoot)),
+            credentials: KeychainCredentialService())
+        try await cordisContext.supply(
+            ExtractionServiceKeys.operationCredentialResolver,
+            value: operationCredentialResolver)
+
         let reconciler = ExtractorPackagePluginReconciler(
             host: host,
             catalogReader: catalogReader,

--- a/Sources/WikiFSEngine/ProcessExtractorProvider.swift
+++ b/Sources/WikiFSEngine/ProcessExtractorProvider.swift
@@ -99,6 +99,16 @@ public struct ProcessExtractorProvider: Sendable {
     let sourceLocator: any ExtractorPackageSourceLocating
     let sharedRuntimeCacheRoot: URL?
     let sharedModelCacheRoot: URL?
+    /// Host-owned per-operation credential resolution (#1159). Nil for hosts
+    /// that never prepare credential-declaring packages (or in tests); a
+    /// credential-declaring revision 2 package prepared WITHOUT a resolver
+    /// fails closed (its required requirements block).
+    let operationCredentials: (any ExtractorOperationCredentialResolving)?
+    /// Host-owned non-secret operation configuration (e.g. the Docling
+    /// endpoint + timeout). Called per execute; values ride the public
+    /// operation-configuration file, never the credential file.
+    let operationConfiguration:
+        (@Sendable (ExtractorPackageRevisionID) -> ExtractorOperationConfiguration?)?
 
     /// The cache roots are host-owned. A package can use them only when its
     /// manifest declares the matching capability.
@@ -109,7 +119,9 @@ public struct ProcessExtractorProvider: Sendable {
         admission: any ProcessPackageAdmissionChecking,
         sourceLocator: (any ExtractorPackageSourceLocating)? = nil,
         sharedRuntimeCacheRoot: URL? = nil,
-        sharedModelCacheRoot: URL? = nil
+        sharedModelCacheRoot: URL? = nil,
+        operationCredentials: (any ExtractorOperationCredentialResolving)? = nil,
+        operationConfiguration: (@Sendable (ExtractorPackageRevisionID) -> ExtractorOperationConfiguration?)? = nil
     ) {
         self.layout = layout
         self.catalogReader = catalogReader
@@ -119,6 +131,8 @@ public struct ProcessExtractorProvider: Sendable {
             ?? InstalledExtractorPackageSourceLocator(layout: layout)
         self.sharedRuntimeCacheRoot = sharedRuntimeCacheRoot
         self.sharedModelCacheRoot = sharedModelCacheRoot
+        self.operationCredentials = operationCredentials
+        self.operationConfiguration = operationConfiguration
     }
 
     /// Convenience initializer for closure-backed admission checks.
@@ -259,10 +273,13 @@ public struct ProcessExtractorProvider: Sendable {
             sharedModelCacheRoot: modelCacheRoot,
             revision: revision,
             manifest: manifest,
+            registration: registration,
             registrationID: registration.id,
             protocolRevision: manifest.protocolRevision,
             mimeTypes: registration.mimeTypes.sorted().map(\.rawValue),
             executor: executor,
+            operationCredentials: operationCredentials,
+            operationConfiguration: operationConfiguration,
             runtimeSearchPolicy: .standard)
     }
 
@@ -295,6 +312,9 @@ public struct ProcessExtractorProvider: Sendable {
 public final class PreparedProcessOperation: Sendable {
     public let revision: ExtractorPackageRevisionID
     public let manifest: ExtractorManifest
+    /// The SELECTED registration for the prepared kind — its declared
+    /// requirements drive per-execute credential resolution (#1159).
+    public let registration: ExtractorRegistration
     public let registrationID: ExtractorRegistrationID
     public let protocolRevision: ExtractorProtocolRevision
 
@@ -307,6 +327,9 @@ public final class PreparedProcessOperation: Sendable {
     let sharedModelCacheRoot: URL?
     let mimeTypes: [String]
     let executor: any ManagedProcessExecuting
+    let operationCredentials: (any ExtractorOperationCredentialResolving)?
+    let operationConfiguration:
+        (@Sendable (ExtractorPackageRevisionID) -> ExtractorOperationConfiguration?)?
     let runtimeSearchPolicy: ExtractorRuntimeSearchPolicy
 
     init(
@@ -319,10 +342,13 @@ public final class PreparedProcessOperation: Sendable {
         sharedModelCacheRoot: URL?,
         revision: ExtractorPackageRevisionID,
         manifest: ExtractorManifest,
+        registration: ExtractorRegistration,
         registrationID: ExtractorRegistrationID,
         protocolRevision: ExtractorProtocolRevision,
         mimeTypes: [String],
         executor: any ManagedProcessExecuting,
+        operationCredentials: (any ExtractorOperationCredentialResolving)?,
+        operationConfiguration: (@Sendable (ExtractorPackageRevisionID) -> ExtractorOperationConfiguration?)?,
         runtimeSearchPolicy: ExtractorRuntimeSearchPolicy
     ) {
         self.directoryRoot = directoryRoot
@@ -334,10 +360,13 @@ public final class PreparedProcessOperation: Sendable {
         self.sharedModelCacheRoot = sharedModelCacheRoot
         self.revision = revision
         self.manifest = manifest
+        self.registration = registration
         self.registrationID = registrationID
         self.protocolRevision = protocolRevision
         self.mimeTypes = mimeTypes
         self.executor = executor
+        self.operationCredentials = operationCredentials
+        self.operationConfiguration = operationConfiguration
         self.runtimeSearchPolicy = runtimeSearchPolicy
     }
 
@@ -362,6 +391,19 @@ public final class PreparedProcessOperation: Sendable {
 
     /// Runs exactly one one-shot conversion against the pinned snapshot and
     /// returns the terminal result frame plus its verified Markdown text.
+    ///
+    /// # Operation credentials (#1159)
+    /// For a revision 2 registration that DECLARES credential requirements
+    /// with a host resolver wired, EVERY execute call re-resolves current
+    /// state (admission, catalog membership, authorization, values) — so
+    /// rotation, revocation, removal, and reinstall affect the next call
+    /// without restart (AC.11). Resolved values are materialized into one
+    /// request-scoped owner-read-only file inside the private operation root;
+    /// the request carries only the RELATIVE path. The credential file and
+    /// its request subdirectory are deleted on EVERY terminal path after
+    /// materialization (AC.14), and every package-controlled string is
+    /// redacted through the request's values before it can reach diagnostics
+    /// or UI (AC.15).
     func execute(
         kind: ExtractorKind,
         input: Data,
@@ -379,59 +421,241 @@ public final class PreparedProcessOperation: Sendable {
             ? self.sharedModelCacheRoot
             : nil
 
-        let inputURL = directoryRoot.appendingPathComponent(inputPath)
-        try FileManager.default.createDirectory(
-            at: inputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true,
-            attributes: [.posixPermissions: 0o700])
-        try input.write(to: inputURL, options: [.atomic])
-
-        let fallbackMIMEType = kind == .pdf ? "application/pdf" : "text/html"
-        let request = try ExtractorProtocolRequest(
-            requestID: ExtractorRequestID(),
-            protocolRevision: manifest.protocolRevision,
-            kind: kind,
-            mimeType: ExtractorMIMEType(validating: mimeType(defaulting: fallbackMIMEType)),
-            originalFilename: filename,
-            inputPath: ExtractorRelativePath(validating: inputPath),
-            outputPath: ExtractorRelativePath(validating: outputPath),
-            deadlineMillisecondsSince1970: Int64(Date().timeIntervalSince1970 * 1_000)
-                + max(Int64(manifest.limits.maximumDurationMilliseconds), 1))
-
-        let managedRequest = ManagedExtractorProcessRequest(
-            revision: revision,
-            manifest: manifest,
-            protocolRequest: request,
-            paths: ManagedExtractorProcessPaths(
-                operationRoot: directoryRoot,
-                packageRoot: packageRoot,
-                homeRoot: homeRoot,
-                temporaryRoot: temporaryRoot,
-                privateCacheRoot: cacheRoot,
-                sharedRuntimeCacheRoot: runtimeCacheRoot,
-                sharedModelCacheRoot: modelCacheRoot))
-        let outcome = try await executor.execute(managedRequest) { frame in
-            if case .progress(let progress) = frame, let message = progress.message {
-                onProgress?(message + "\n")
+        // ---- Operation input preparation (revision 2 + declared requirements)
+        let declaresRequirements = manifest.protocolRevision == .v2
+            && registration.credentialRequirements.isEmpty == false
+        var resolvedValues: [ExtractorCredentialRequirementID: String] = [:]
+        var configuration: ExtractorOperationConfiguration?
+        var credentialFilePath: ExtractorRelativePath?
+        var configurationFilePath: ExtractorRelativePath?
+        var credentialSubdirectory: URL?
+        var configurationSubdirectory: URL?
+        if declaresRequirements {
+            guard let resolver = operationCredentials else {
+                // Fail closed: a required requirement cannot be satisfied
+                // without the trusted host resolution service.
+                throw ProcessPackageError(
+                    message: ExtractorOperationCredentialError.resolutionUnavailable.description)
+            }
+            resolvedValues = try await resolver.resolveOperationCredentials(
+                revision: revision, manifest: manifest, registration: registration)
+            // AC.10 defense in depth: a REQUIRED requirement with no
+            // resolved value blocks the launch with a bounded typed state,
+            // regardless of resolver behavior.
+            for requirement in registration.credentialRequirements
+            where requirement.isOptional == false {
+                if CredentialValue.normalized(resolvedValues[requirement.id]) == nil {
+                    throw ProcessPackageError(
+                        message: ExtractorOperationCredentialError
+                            .requiredCredentialUnavailable(
+                                requirementID: requirement.id.rawValue)
+                            .description)
+                }
             }
         }
+        if manifest.protocolRevision == .v2 {
+            configuration = operationConfiguration?(revision)
+        }
 
-        switch outcome.terminalFrame {
-        case .result(let frame):
-            let outputURL = directoryRoot.appendingPathComponent(outputPath)
-            let data = try Data(contentsOf: outputURL, options: [.mappedIfSafe])
-            guard data.count == frame.markdownByteCount else {
-                throw ProcessPackageRunError.declaredSizeMismatch
+        // The redactor covers every resolved value for THIS request; it is
+        // constructed even when empty so call sites stay uniform.
+        let redactor = ExtractorSecretRedactor(
+            values: Array(resolvedValues.values))
+
+        // Materialize the private credential file AFTER resolution. From this
+        // point every terminal path must clean it up (defer below).
+        if declaresRequirements {
+            let envelope = try ExtractorCredentialInputEnvelope(
+                requirements: registration.credentialRequirements,
+                resolvedValues: resolvedValues)
+            let subdirectory = directoryRoot
+                .appendingPathComponent("credentials/\(name)", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: subdirectory, withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            credentialSubdirectory = subdirectory
+            let fileURL = subdirectory.appendingPathComponent("input.json")
+            let data = try JSONEncoder().encode(envelope)
+            try Self.writeOwnerReadOnlyFile(data, at: fileURL)
+            credentialFilePath = try ExtractorRelativePath(
+                validating: "credentials/\(name)/input.json")
+        }
+        if let configuration {
+            let subdirectory = directoryRoot
+                .appendingPathComponent("config/\(name)", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: subdirectory, withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            configurationSubdirectory = subdirectory
+            let fileURL = subdirectory.appendingPathComponent("operation.json")
+            try JSONEncoder().encode(configuration).write(to: fileURL, options: [.atomic])
+            configurationFilePath = try ExtractorRelativePath(
+                validating: "config/\(name)/operation.json")
+        }
+
+        // Immutable snapshots of the request paths for the @Sendable body.
+        let requestCredentialPath = credentialFilePath
+        let requestConfigurationPath = configurationFilePath
+        return try await runManaged(
+            redactor: redactor,
+            credentialSubdirectory: credentialSubdirectory,
+            configurationSubdirectory: configurationSubdirectory,
+            onProgress: onProgress
+        ) {
+            let inputURL = self.directoryRoot.appendingPathComponent(inputPath)
+            try FileManager.default.createDirectory(
+                at: inputURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            try input.write(to: inputURL, options: [.atomic])
+
+            let fallbackMIMEType = kind == .pdf ? "application/pdf" : "text/html"
+            let request = try ExtractorProtocolRequest(
+                requestID: ExtractorRequestID(),
+                protocolRevision: self.manifest.protocolRevision,
+                kind: kind,
+                mimeType: ExtractorMIMEType(validating: self.mimeType(defaulting: fallbackMIMEType)),
+                originalFilename: filename,
+                inputPath: ExtractorRelativePath(validating: inputPath),
+                outputPath: ExtractorRelativePath(validating: outputPath),
+                deadlineMillisecondsSince1970: Int64(Date().timeIntervalSince1970 * 1_000)
+                    + max(Int64(self.manifest.limits.maximumDurationMilliseconds), 1),
+                credentialFilePath: requestCredentialPath,
+                operationConfigurationPath: requestConfigurationPath)
+
+            let managedRequest = ManagedExtractorProcessRequest(
+                revision: self.revision,
+                manifest: self.manifest,
+                protocolRequest: request,
+                paths: ManagedExtractorProcessPaths(
+                    operationRoot: self.directoryRoot,
+                    packageRoot: self.packageRoot,
+                    homeRoot: self.homeRoot,
+                    temporaryRoot: self.temporaryRoot,
+                    privateCacheRoot: self.cacheRoot,
+                    sharedRuntimeCacheRoot: runtimeCacheRoot,
+                    sharedModelCacheRoot: modelCacheRoot))
+            let outcome = try await self.executor.execute(managedRequest) { [redactor] (frame: ExtractorProtocolFrame) in
+                if case .progress(let progress) = frame, let message = progress.message {
+                    // Package-controlled progress text is redacted before it
+                    // can reach host diagnostics or UI (AC.15).
+                    onProgress?(redactor.redact(message) + "\n")
+                }
             }
-            guard let markdown = String(data: data, encoding: .utf8) else {
-                throw ProcessPackageRunError.invalidOutputEncoding
+
+            switch outcome.terminalFrame {
+            case .result(let frame):
+                let outputURL = self.directoryRoot.appendingPathComponent(outputPath)
+                let data = try Data(contentsOf: outputURL, options: [.mappedIfSafe])
+                guard data.count == frame.markdownByteCount else {
+                    throw ProcessPackageRunError.declaredSizeMismatch
+                }
+                guard let markdown = String(data: data, encoding: .utf8) else {
+                    throw ProcessPackageRunError.invalidOutputEncoding
+                }
+                return ProcessPackageExecutionOutcome(frame: frame, markdown: markdown)
+            case .failure(let frame):
+                // Terminal failure frames are package-controlled: redact the
+                // message AND warnings before mapping into a user error.
+                throw ProcessPackageError(
+                    message: redactor.redact(
+                        ProcessPackageFailureMapper.terminalMessage(frame)))
+            case .progress, .diagnostic:
+                throw ProcessPackageRunError.missingTerminalFrame
             }
-            return ProcessPackageExecutionOutcome(frame: frame, markdown: markdown)
-        case .failure(let frame):
-            throw ProcessPackageError(
-                message: ProcessPackageFailureMapper.terminalMessage(frame))
-        case .progress, .diagnostic:
-            throw ProcessPackageRunError.missingTerminalFrame
+        }
+    }
+
+    /// Shared terminal-path wrapper: catches every thrown error AFTER the
+    /// credential file was materialized, deletes the request-scoped
+    /// credential + configuration subdirectories (AC.14), and rethrows a
+    /// redacted error. On success the cleanup runs too. When a child process
+    /// did launch, the executor has already terminated and reaped the process
+    /// group before this point (Risk 8 ordering).
+    fileprivate func runManaged(
+        redactor: ExtractorSecretRedactor,
+        credentialSubdirectory: URL?,
+        configurationSubdirectory: URL?,
+        onProgress: (@Sendable (String) -> Void)?,
+        _ body: @Sendable () async throws -> ProcessPackageExecutionOutcome
+    ) async throws -> ProcessPackageExecutionOutcome {
+        defer {
+            for subdirectory in [credentialSubdirectory, configurationSubdirectory].compactMap({ $0 }) {
+                do {
+                    try FileManager.default.removeItem(at: subdirectory)
+                } catch {
+                    // Value-free diagnostic; the operation-root deinitializer
+                    // remains the final safety net.
+                    DebugLog.extraction(
+                        "Extractor request input cleanup failed (deferred to operation root cleanup).")
+                }
+            }
+        }
+        do {
+            return try await body()
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch ManagedExtractorProcessError.cancellation {
+            throw CancellationError()
+        } catch {
+            // Every other failure maps through the redactor so a secret that
+            // reached stderr, a frame, or a launch error cannot escape.
+            throw ProcessPackageError(message: redactor.redactedMessage(error))
+        }
+    }
+
+    /// Creates a regular owner-read-only (0400) file at `url`. The file is
+    /// created O_EXCL (never through an existing symlink), written fully,
+    /// then verified: regular file, owner UID, link count 1, mode 0400, and
+    /// containment within its own request subdirectory (plan steps 16-17).
+    static func writeOwnerReadOnlyFile(_ data: Data, at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        // Refuse to overwrite anything that already exists (a planted symlink
+        // at the target must never be written through).
+        guard FileManager.default.fileExists(atPath: url.path) == false else {
+            throw ExtractorDirectoryAdmissionError.preparationFailed
+        }
+        let fd = url.path.withCString {
+            open($0, O_WRONLY | O_CREAT | O_EXCL, 0o400)
+        }
+        guard fd >= 0 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailed
+        }
+        defer { close(fd) }
+        let result: Int = data.withUnsafeBytes { raw in
+            guard var pointer = raw.baseAddress else { return -1 }
+            var remaining = raw.count
+            var total = 0
+            while remaining > 0 {
+                let written = write(fd, pointer, remaining)
+                if written <= 0 { return -1 }
+                total += written
+                pointer += written
+                remaining -= written
+            }
+            return total
+        }
+        guard result == data.count else {
+            throw ExtractorDirectoryAdmissionError.preparationFailed
+        }
+        try verifyOwnerReadOnlyFile(at: url)
+    }
+
+    /// Post-write verification: regular file, owner UID, link count 1, mode
+    /// 0400, and containment within the operation directory layout.
+    static func verifyOwnerReadOnlyFile(at url: URL) throws {
+        var status = stat()
+        guard lstat(url.path, &status) == 0 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailed
+        }
+        guard status.st_mode & S_IFMT == S_IFREG,
+              status.st_uid == getuid(),
+              status.st_nlink == 1,
+              status.st_mode & 0o777 == 0o400 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailed
         }
     }
 }

--- a/Sources/WikiFSTypes/Extractor/ExtractorIdentity.swift
+++ b/Sources/WikiFSTypes/Extractor/ExtractorIdentity.swift
@@ -248,7 +248,15 @@ public struct ExtractorRequestID: RawRepresentable, Codable, Hashable, Sendable 
 public struct ExtractorProtocolRevision: RawRepresentable, Codable, Hashable, Sendable, Comparable {
     public let rawValue: Int
     public static let v1 = Self(validatedRawValue: 1)
-    public init?(rawValue: Int) { guard rawValue == 1 else { return nil }; self.rawValue = rawValue }
+    /// Revision 2 adds optional request paths for a private credential input
+    /// file and a non-secret public operation-configuration file. Revision 1
+    /// requests keep their exact old shape and can neither declare nor
+    /// receive credentials.
+    public static let v2 = Self(validatedRawValue: 2)
+    public init?(rawValue: Int) {
+        guard rawValue == 1 || rawValue == 2 else { return nil }
+        self.rawValue = rawValue
+    }
     private init(validatedRawValue: Int) { self.rawValue = validatedRawValue }
     public init(from decoder: any Decoder) throws {
         let rawValue = try Int(from: decoder)

--- a/Sources/WikiFSTypes/Extractor/ExtractorProtocol.swift
+++ b/Sources/WikiFSTypes/Extractor/ExtractorProtocol.swift
@@ -3,6 +3,12 @@ import Foundation
 // pattern: Functional Core
 
 public struct ExtractorProtocolRequest: Codable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey {
+        case requestID, protocolRevision, kind, mimeType, originalFilename
+        case inputTransport, inputPath, outputPath, deadlineMillisecondsSince1970
+        case credentialFilePath, operationConfigurationPath
+    }
+
     public let requestID: ExtractorRequestID
     public let protocolRevision: ExtractorProtocolRevision
     public let kind: ExtractorKind
@@ -12,6 +18,14 @@ public struct ExtractorProtocolRequest: Codable, Hashable, Sendable {
     public let inputPath: ExtractorRelativePath
     public let outputPath: ExtractorRelativePath
     public let deadlineMillisecondsSince1970: Int64
+    /// Protocol revision 2 only: RELATIVE path (inside the private operation
+    /// root) of the request-scoped credential input file. The request carries
+    /// a path only — never a value. A revision 1 request must be nil.
+    public let credentialFilePath: ExtractorRelativePath?
+    /// Protocol revision 2 only: relative path of the non-secret public
+    /// operation-configuration file (e.g. endpoint + timeout). Nil for
+    /// revision 1.
+    public let operationConfigurationPath: ExtractorRelativePath?
 
     public init(
         requestID: ExtractorRequestID,
@@ -22,7 +36,9 @@ public struct ExtractorProtocolRequest: Codable, Hashable, Sendable {
         inputTransport: ExtractorInputTransport = .operationFile,
         inputPath: ExtractorRelativePath,
         outputPath: ExtractorRelativePath,
-        deadlineMillisecondsSince1970: Int64
+        deadlineMillisecondsSince1970: Int64,
+        credentialFilePath: ExtractorRelativePath? = nil,
+        operationConfigurationPath: ExtractorRelativePath? = nil
     ) throws {
         guard originalFilename.isEmpty == false,
               originalFilename.utf8.count <= 1_024,
@@ -31,6 +47,13 @@ public struct ExtractorProtocolRequest: Codable, Hashable, Sendable {
         }
         guard inputPath != outputPath else { throw ExtractorValidationError.invalidManifest("input and output paths match") }
         guard deadlineMillisecondsSince1970 > 0 else { throw ExtractorValidationError.invalidManifest("deadline") }
+        // A revision 1 request can neither declare nor receive credentials:
+        // operation input paths must be absent.
+        if protocolRevision == .v1,
+           credentialFilePath != nil || operationConfigurationPath != nil {
+            throw ExtractorValidationError.invalidManifest(
+                "credential input requires protocol revision 2")
+        }
         self.requestID = requestID
         self.protocolRevision = protocolRevision
         self.kind = kind
@@ -40,20 +63,116 @@ public struct ExtractorProtocolRequest: Codable, Hashable, Sendable {
         self.inputPath = inputPath
         self.outputPath = outputPath
         self.deadlineMillisecondsSince1970 = deadlineMillisecondsSince1970
+        self.credentialFilePath = credentialFilePath
+        self.operationConfigurationPath = operationConfigurationPath
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let revision = try container.decode(
+            ExtractorProtocolRevision.self, forKey: .protocolRevision)
+        // Revision 1 requests must not carry operation input paths: a v1
+        // package can neither declare nor receive credentials.
+        if revision == .v1,
+           container.contains(.credentialFilePath)
+               || container.contains(.operationConfigurationPath) {
+            throw ExtractorValidationError.invalidManifest(
+                "credential input requires protocol revision 2")
+        }
         try self.init(
             requestID: container.decode(ExtractorRequestID.self, forKey: .requestID),
-            protocolRevision: container.decode(ExtractorProtocolRevision.self, forKey: .protocolRevision),
+            protocolRevision: revision,
             kind: container.decode(ExtractorKind.self, forKey: .kind),
             mimeType: container.decode(ExtractorMIMEType.self, forKey: .mimeType),
             originalFilename: container.decode(String.self, forKey: .originalFilename),
             inputTransport: container.decode(ExtractorInputTransport.self, forKey: .inputTransport),
             inputPath: container.decode(ExtractorRelativePath.self, forKey: .inputPath),
             outputPath: container.decode(ExtractorRelativePath.self, forKey: .outputPath),
-            deadlineMillisecondsSince1970: container.decode(Int64.self, forKey: .deadlineMillisecondsSince1970))
+            deadlineMillisecondsSince1970: container.decode(Int64.self, forKey: .deadlineMillisecondsSince1970),
+            credentialFilePath: container.decodeIfPresent(
+                ExtractorRelativePath.self, forKey: .credentialFilePath),
+            operationConfigurationPath: container.decodeIfPresent(
+                ExtractorRelativePath.self, forKey: .operationConfigurationPath))
+    }
+}
+
+// MARK: - Operation input envelopes (protocol revision 2)
+
+/// The PRIVATE credential input envelope written to the request-scoped
+/// credential file. Keyed by requirement ID; carries only the selected
+/// registration's resolved NON-EMPTY values. Values live in this file for the
+/// duration of one request and are deleted on every terminal path.
+public struct ExtractorCredentialInputEnvelope: Codable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey, CaseIterable { case credentials }
+
+    public static let maximumEntryCount = 8
+
+    /// Requirement-ID raw values -> resolved secret values.
+    public let credentials: [String: String]
+
+    /// Host-owned construction: entries must be declared requirement IDs and
+    /// non-empty values. There is no public memberwise initializer, so a
+    /// caller cannot smuggle arbitrary key/value pairs past validation.
+    public init(
+        requirements: [ExtractorCredentialRequirement],
+        resolvedValues: [ExtractorCredentialRequirementID: String]
+    ) throws {
+        guard resolvedValues.count <= Self.maximumEntryCount else {
+            throw ExtractorValidationError.invalidManifest("credential envelope size")
+        }
+        var encoded: [String: String] = [:]
+        for requirement in requirements {
+            guard let value = resolvedValues[requirement.id] else { continue }
+            guard CredentialValue.normalized(value) != nil else { continue }
+            encoded[requirement.id.rawValue] = value
+        }
+        self.credentials = encoded
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.credentials = try container.decode([String: String].self, forKey: .credentials)
+    }
+}
+
+/// The PUBLIC, non-secret operation-configuration envelope (protocol
+/// revision 2). Its closed field set is the construction seam: endpoint and
+/// timeout are the only representable fields, so a secret cannot be encoded
+/// even by mistake. Values arrive from typed host settings.
+public struct ExtractorOperationConfiguration: Codable, Hashable, Sendable {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case endpoint, timeoutMilliseconds
+    }
+
+    public static let maximumEndpointByteCount = 2_048
+    public static let maximumTimeoutMilliseconds = ExtractorHostLimits.maximumDurationMilliseconds
+
+    public let endpoint: String?
+    public let timeoutMilliseconds: Int?
+
+    public init(endpoint: String?, timeoutMilliseconds: Int?) throws {
+        if let endpoint {
+            guard endpoint.isEmpty == false,
+                  endpoint.utf8.count <= Self.maximumEndpointByteCount,
+                  endpoint.contains("\0") == false else {
+                throw ExtractorValidationError.invalidManifest("operation endpoint")
+            }
+        }
+        if let timeoutMilliseconds {
+            guard timeoutMilliseconds > 0,
+                  timeoutMilliseconds <= Self.maximumTimeoutMilliseconds else {
+                throw ExtractorValidationError.limitExceedsHostPolicy("operation timeout")
+            }
+        }
+        self.endpoint = endpoint
+        self.timeoutMilliseconds = timeoutMilliseconds
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            endpoint: container.decodeIfPresent(String.self, forKey: .endpoint),
+            timeoutMilliseconds: container.decodeIfPresent(Int.self, forKey: .timeoutMilliseconds))
     }
 }
 

--- a/Tests/WikiFSTests/ExtractorGeneratedPluginTests.swift
+++ b/Tests/WikiFSTests/ExtractorGeneratedPluginTests.swift
@@ -375,7 +375,9 @@ struct ExtractorGeneratedPluginTests {
             Issue.record("Expected waiting outcome, got \(waiting)")
             return
         }
-        #expect(missing.count == 6)
+        // Seven fixed host dependencies (the six original services plus the
+        // #1159 operation-credential resolver).
+        #expect(missing.count == 7)
 
         try await environment.supplyAll()
         let inspection = try #require(await host.inspect(trusted.id))
@@ -562,6 +564,15 @@ enum GeneratedPluginFixtures {
             try await context.supply(
                 ExtractionServiceKeys.packageSourceLocator,
                 value: InstalledExtractorPackageSourceLocator(layout: layout))
+            try await context.supply(
+                ExtractionServiceKeys.operationCredentialResolver,
+                value: ExtractorOperationCredentialResolver(
+                    admission: AlwaysAdmitted(),
+                    catalogReader: ExtractorPackageCatalogReader(layout: layout),
+                    authorizationReader: ExtractorCredentialAuthorizationReader(
+                        layout: ExtractorCredentialAuthorizationStoreLayout(
+                            appGroupContainerRoot: layout.appGroupContainerRoot)),
+                    credentials: KeychainCredentialService()))
         }
 
         func cleanup() {

--- a/Tests/WikiFSTests/ProcessExtractorCredentialTests.swift
+++ b/Tests/WikiFSTests/ProcessExtractorCredentialTests.swift
@@ -1,0 +1,433 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+@testable import WikiFSEngine
+import WikiFSTypes
+
+// PR 3 coverage (issue #1159): per-operation credential resolution, the
+// request-scoped owner-read-only credential file, terminal-path cleanup,
+// rotation/revocation semantics, and secret redaction.
+
+private func v2Requirement(
+    _ id: String = "api-token", optional: Bool = true
+) -> ExtractorCredentialRequirement {
+    try! ExtractorCredentialRequirement(
+        id: ExtractorCredentialRequirementID(validating: id),
+        kind: .secret,
+        isOptional: optional,
+        label: "API token",
+        purpose: "Authenticates requests.")
+}
+
+private func v2Manifest(
+    requirements: [ExtractorCredentialRequirement],
+    protocolRevision: ExtractorProtocolRevision = .v2
+) throws -> ExtractorManifest {
+    let bytes = Data("fixture".utf8)
+    return try ExtractorManifest(
+        manifestRevision: .v2,
+        packageID: ExtractorPackageID(validating: "org.example.pkg"),
+        version: ExtractorPackageVersion(validating: "1.0.0"),
+        displayName: "Fixture",
+        protocolRevision: protocolRevision,
+        entryPoint: ExtractorRelativePath(validating: "bin/extractor"),
+        launch: .direct,
+        registrations: [try ExtractorRegistration(
+            id: ExtractorRegistrationID(validating: "main"),
+            displayName: "Main",
+            kinds: [.pdf],
+            mimeTypes: [ExtractorMIMEType(validating: "application/pdf")],
+            credentialRequirements: requirements)],
+        capabilities: [],
+        files: [ExtractorPackageFile(
+            path: ExtractorRelativePath(validating: "bin/extractor"),
+            digest: ExtractorSHA256.digest(bytes))],
+        limits: ExtractorOperationLimits(
+            maximumInputByteCount: 1_024,
+            maximumMarkdownOutputByteCount: 2_048,
+            maximumDurationMilliseconds: 30_000,
+            maximumProgressEventCount: 10))
+}
+
+private func revision(for manifest: ExtractorManifest) throws -> ExtractorPackageRevisionID {
+    ExtractorPackageRevisionID(
+        packageID: manifest.packageID,
+        version: manifest.version,
+        digest: try manifest.packageDigest())
+}
+
+/// A stub operation root builder: the operation needs only its directory
+/// tree; the package snapshot is unused by the stub executor.
+@discardableResult
+private func makeOperation(
+    manifest: ExtractorManifest,
+    resolver: (any ExtractorOperationCredentialResolving)?,
+    executor: StubCredentialExecutor,
+    configuration: (@Sendable (ExtractorPackageRevisionID) -> ExtractorOperationConfiguration?)? = nil
+) throws -> PreparedProcessOperation {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("op-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    let revision = try revision(for: manifest)
+    return PreparedProcessOperation(
+        directoryRoot: root,
+        packageRoot: root.appendingPathComponent("package"),
+        homeRoot: root.appendingPathComponent("home"),
+        temporaryRoot: root.appendingPathComponent("tmp"),
+        cacheRoot: root.appendingPathComponent("cache"),
+        sharedRuntimeCacheRoot: nil,
+        sharedModelCacheRoot: nil,
+        revision: revision,
+        manifest: manifest,
+        registration: manifest.registrations[0],
+        registrationID: manifest.registrations[0].id,
+        protocolRevision: manifest.protocolRevision,
+        mimeTypes: ["application/pdf"],
+        executor: executor,
+        operationCredentials: resolver,
+        operationConfiguration: configuration,
+        runtimeSearchPolicy: .standard)
+}
+
+/// Captures the managed request, verifies the credential file existed at
+/// launch time (owner-read-only), records the envelope VALUES it contained,
+/// and returns a successful result frame.
+final class StubCredentialExecutor: ManagedProcessExecuting, @unchecked Sendable {
+    // NSLock guards `requests` and `observedValues`; `failWith` is set
+    // before use.
+    // swiftlint:disable:next unchecked_sendable
+    private let lock = NSLock()
+    private var requests: [ManagedExtractorProcessRequest] = []
+    private var observed: [[String: String]] = []
+    var failWith: (any Error)?
+
+    var capturedRequests: [ManagedExtractorProcessRequest] {
+        lock.withLock { requests }
+    }
+
+    /// The credential envelope contents observed at launch time, in order.
+    var observedValues: [[String: String]] {
+        lock.withLock { observed }
+    }
+
+    func execute(
+        _ operation: ManagedExtractorProcessRequest,
+        onFrame: @escaping @Sendable (ExtractorProtocolFrame) -> Void
+    ) async throws -> ManagedExtractorProcessResult {
+        lock.withLock { requests.append(operation) }
+        if let failWith { throw failWith }
+        // The credential file must exist and be owner-read-only at launch.
+        if let credentialPath = operation.protocolRequest.credentialFilePath {
+            let url = operation.paths.operationRoot
+                .appendingPathComponent(credentialPath.rawValue)
+            var status = stat()
+            guard lstat(url.path, &status) == 0,
+                  status.st_mode & S_IFMT == S_IFREG,
+                  status.st_mode & 0o777 == 0o400 else {
+                throw ManagedExtractorProcessError.invalidOperationLayout
+            }
+            let envelope = try JSONDecoder().decode(
+                ExtractorCredentialInputEnvelope.self,
+                from: try Data(contentsOf: url))
+            lock.withLock { observed.append(envelope.credentials) }
+        } else {
+            lock.withLock { observed.append([:]) }
+        }
+        let result = try ExtractorResultFrame(
+            requestID: operation.protocolRequest.requestID,
+            outputPath: operation.protocolRequest.outputPath,
+            markdownByteCount: 2)
+        // Behave like a real package: write the declared output.
+        let outputURL = operation.paths.operationRoot
+            .appendingPathComponent(operation.protocolRequest.outputPath.rawValue)
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try Data("ok".utf8).write(to: outputURL)
+        return ManagedExtractorProcessResult(
+            terminationCause: .exited(code: 0),
+            terminalFrame: .result(result),
+            progressEventCount: 0,
+            standardOutputByteCount: 0,
+            standardError: Data(),
+            executableURL: operation.paths.packageRoot)
+    }
+}
+
+/// A resolver backed by a shared in-memory credential service so rotation
+/// tests can flip values between executes.
+final class StubResolver: ExtractorOperationCredentialResolving, @unchecked Sendable {
+    // swiftlint:disable:next unchecked_sendable
+    private let lock = NSLock()
+    private var values: [ExtractorCredentialRequirementID: String]
+    private var unauthorizedIDs: Set<String> = []
+    var callCount = 0
+
+    init(values: [ExtractorCredentialRequirementID: String]) {
+        self.values = values
+    }
+
+    func setValue(
+        _ value: String?, for id: ExtractorCredentialRequirementID
+    ) {
+        lock.withLock {
+            if let value { values[id] = value } else { values.removeValue(forKey: id) }
+        }
+    }
+
+    func revoke(id: ExtractorCredentialRequirementID) {
+        lock.withLock { _ = unauthorizedIDs.insert(id.rawValue) }
+    }
+
+    func resolveOperationCredentials(
+        revision: ExtractorPackageRevisionID,
+        manifest: ExtractorManifest,
+        registration: ExtractorRegistration
+    ) async throws -> [ExtractorCredentialRequirementID: String] {
+        lock.withLock { callCount += 1 }
+        var result: [ExtractorCredentialRequirementID: String] = [:]
+        for requirement in registration.credentialRequirements {
+            let unauthorized = lock.withLock {
+                unauthorizedIDs.contains(requirement.id.rawValue)
+            }
+            if unauthorized { continue }
+            if let value = lock.withLock({ values[requirement.id] }) {
+                result[requirement.id] = value
+            }
+        }
+        return result
+    }
+}
+
+@Suite(.serialized)
+struct ProcessExtractorCredentialTests {
+
+    // MARK: Protocol revision 2 requests
+
+    @Test func revisionOneRequestRejectsCredentialPaths() throws {
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try ExtractorProtocolRequest(
+                requestID: ExtractorRequestID(),
+                protocolRevision: .v1,
+                kind: .pdf,
+                mimeType: ExtractorMIMEType(validating: "application/pdf"),
+                originalFilename: "x.pdf",
+                inputPath: ExtractorRelativePath(validating: "input/a/source"),
+                outputPath: ExtractorRelativePath(validating: "output/a/result.md"),
+                deadlineMillisecondsSince1970: 1,
+                credentialFilePath: ExtractorRelativePath(validating: "credentials/a/input.json"))
+        }
+    }
+
+    @Test func v2RequestCarriesRelativePathsOnly() throws {
+        let request = try ExtractorProtocolRequest(
+            requestID: ExtractorRequestID(),
+            protocolRevision: .v2,
+            kind: .pdf,
+            mimeType: ExtractorMIMEType(validating: "application/pdf"),
+            originalFilename: "x.pdf",
+            inputPath: ExtractorRelativePath(validating: "input/a/source"),
+            outputPath: ExtractorRelativePath(validating: "output/a/result.md"),
+            deadlineMillisecondsSince1970: 1,
+            credentialFilePath: ExtractorRelativePath(validating: "credentials/a/input.json"),
+            operationConfigurationPath: ExtractorRelativePath(validating: "config/a/operation.json"))
+        let data = try JSONEncoder().encode(request)
+        let object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        // Paths only — never a value.
+        #expect(object["credentialFilePath"] as? String == "credentials/a/input.json")
+        #expect(object["credentials"] == nil)
+        // Round-trip.
+        let decoded = try JSONDecoder().decode(ExtractorProtocolRequest.self, from: data)
+        #expect(decoded == request)
+    }
+
+    // MARK: Envelopes
+
+    @Test func credentialEnvelopeCarriesOnlyDeclaredNonEmptyEntries() throws {
+        let requirements = [v2Requirement("a"), v2Requirement("b")]
+        let envelope = try ExtractorCredentialInputEnvelope(
+            requirements: requirements,
+            resolvedValues: [
+                ExtractorCredentialRequirementID(validating: "a"): "secret-a",
+                ExtractorCredentialRequirementID(validating: "b"): "",
+                ExtractorCredentialRequirementID(validating: "c"): "not-declared",
+            ])
+        #expect(envelope.credentials == ["a": "secret-a"])
+    }
+
+    @Test func configurationEnvelopeRejectsBoundedFields() {
+        #expect(throws: ExtractorValidationError.self) {
+            _ = try ExtractorOperationConfiguration(
+                endpoint: "http://127.0.0.1:8000",
+                timeoutMilliseconds: ExtractorHostLimits.maximumDurationMilliseconds + 1)
+        }
+        let valid = try? ExtractorOperationConfiguration(
+            endpoint: "http://127.0.0.1:8000", timeoutMilliseconds: 600_000)
+        #expect(valid?.timeoutMilliseconds == 600_000)
+    }
+
+    // MARK: Redaction
+
+    @Test func redactorRemovesEveryResolvedValueFromPackageText() {
+        let redactor = ExtractorSecretRedactor(values: ["canary-secret", "second-secret"])
+        #expect(redactor.redact("error: canary-secret is bad") == "error: [redacted] is bad")
+        #expect(redactor.redact("nothing here") == "nothing here")
+        #expect(
+            redactor.redact("a canary-secret b second-secret c") == "a [redacted] b [redacted] c")
+        struct Probe: Error {}
+        let wrapped = redactor.redactedMessage(
+            ProcessPackageError(message: "boom canary-secret"))
+        #expect(wrapped.contains("canary-secret") == false)
+    }
+
+    // MARK: Per-execute resolution + file lifecycle
+
+    @Test func injectsOnlySelectedRegistrationRequirements() async throws {
+        let manifest = try v2Manifest(requirements: [
+            v2Requirement("api-token", optional: false),
+        ])
+        let resolver = StubResolver(values: [
+            try ExtractorCredentialRequirementID(validating: "api-token"): "sk-live",
+        ])
+        let executor = StubCredentialExecutor()
+        let operation = try makeOperation(
+            manifest: manifest, resolver: resolver, executor: executor)
+        let outcome = try await operation.execute(
+            kind: .pdf, input: Data("pdf".utf8), filename: "x.pdf", onProgress: nil)
+        #expect(outcome.markdown.isEmpty == false)
+        guard let request = executor.capturedRequests.first else {
+            Issue.record("no captured request")
+            return
+        }
+        #expect(executor.observedValues == [["api-token": "sk-live"]])
+        _ = request
+    }
+
+    @Test func credentialFileIsRemovedOnSuccessAndFailure() async throws {
+        let manifest = try v2Manifest(requirements: [
+            v2Requirement("api-token", optional: false),
+        ])
+        let resolver = StubResolver(values: [
+            try ExtractorCredentialRequirementID(validating: "api-token"): "sk-live",
+        ])
+        let successExecutor = StubCredentialExecutor()
+        let operation = try makeOperation(
+            manifest: manifest, resolver: resolver, executor: successExecutor)
+        _ = try await operation.execute(
+            kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+        // Success: credentials directory holds no request subdirectories.
+        let credentialsRoot = operation.directoryRoot.appendingPathComponent("credentials")
+        #expect(
+            (try? FileManager.default.contentsOfDirectory(atPath: credentialsRoot.path))?.isEmpty ?? true)
+
+        // Failure: the executor throws AFTER the file was verified to exist.
+        let failingExecutor = StubCredentialExecutor()
+        failingExecutor.failWith = ManagedExtractorProcessError.timeout
+        let failingOperation = try makeOperation(
+            manifest: manifest, resolver: resolver, executor: failingExecutor)
+        do {
+            _ = try await failingOperation.execute(
+                kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+            Issue.record("expected failure")
+        } catch {
+            // mapped, redacted failure
+        }
+        let failingCredentialsRoot =
+            failingOperation.directoryRoot.appendingPathComponent("credentials")
+        #expect(
+            (try? FileManager.default.contentsOfDirectory(atPath: failingCredentialsRoot.path))?.isEmpty ?? true)
+    }
+
+    @Test func rotationAffectsNextCredentialExecute() async throws {
+        // AC.11: two execute calls resolve different values without
+        // rebuilding the process context. The executor verifies each
+        // credential file at launch time and records the VALUE it saw.
+        let requirementID = try ExtractorCredentialRequirementID(validating: "api-token")
+        let resolver = StubResolver(values: [requirementID: "sk-first"])
+        let executor = StubCredentialExecutor()
+        let operation = try makeOperation(
+            manifest: try v2Manifest(requirements: [
+                v2Requirement("api-token", optional: false),
+            ]),
+            resolver: resolver, executor: executor)
+        _ = try await operation.execute(
+            kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+        resolver.setValue("sk-rotated", for: requirementID)
+        _ = try await operation.execute(
+            kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+        #expect(executor.observedValues == [["api-token": "sk-first"], ["api-token": "sk-rotated"]])
+        #expect(resolver.callCount == 2)
+    }
+
+    @Test func revocationFailsTheNextExecuteAndCleansUp() async throws {
+        let requirementID = try ExtractorCredentialRequirementID(validating: "api-token")
+        let resolver = StubResolver(values: [requirementID: "sk-live"])
+        let executor = StubCredentialExecutor()
+        let operation = try makeOperation(
+            manifest: try v2Manifest(requirements: [
+                v2Requirement("api-token", optional: false),
+            ]),
+            resolver: resolver, executor: executor)
+        _ = try await operation.execute(
+            kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+        resolver.revoke(id: requirementID)
+        do {
+            _ = try await operation.execute(
+                kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+            Issue.record("expected failure after revocation")
+        } catch let error as ProcessPackageError {
+            // Bounded, value-free failure text.
+            #expect(error.message.contains("sk-live") == false)
+        }
+    }
+
+    @Test func absentResolverFailsClosedForDeclaringPackages() async throws {
+        let manifest = try v2Manifest(requirements: [
+            v2Requirement("api-token", optional: false),
+        ])
+        let operation = try makeOperation(
+            manifest: manifest, resolver: nil, executor: StubCredentialExecutor())
+        do {
+            _ = try await operation.execute(
+                kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+            Issue.record("expected failure without a resolver")
+        } catch {
+            // expected
+        }
+    }
+
+    @Test func revisionOneOperationsNeverResolveCredentials() async throws {
+        // Revision 1 preparation semantics stay unchanged: no credential
+        // path on the request even with a resolver wired.
+        let manifest = try v2Manifest(requirements: [], protocolRevision: .v1)
+        let resolver = StubResolver(values: [:])
+        let executor = StubCredentialExecutor()
+        let operation = try makeOperation(
+            manifest: manifest, resolver: resolver, executor: executor)
+        _ = try await operation.execute(
+            kind: .pdf, input: Data(), filename: "x.pdf", onProgress: nil)
+        let request = try #require(executor.capturedRequests.first)
+        #expect(request.protocolRequest.credentialFilePath == nil)
+        #expect(request.protocolRequest.operationConfigurationPath == nil)
+        #expect(resolver.callCount == 0)
+    }
+
+    @Test func ownerReadOnlyFileVerificationRejectsWrongMode() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mode-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = root.appendingPathComponent("input.json")
+        try SelfTestSupport.writeWithMode(data: Data("{}".utf8), url: url, mode: 0o644)
+        #expect(throws: ExtractorDirectoryAdmissionError.self) {
+            _ = try PreparedProcessOperation.verifyOwnerReadOnlyFile(at: url)
+        }
+    }
+}
+
+enum SelfTestSupport {
+    static func writeWithMode(data: Data, url: URL, mode: mode_t) throws {
+        try data.write(to: url)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: Int(mode)], ofItemAtPath: url.path)
+    }
+}

--- a/Tests/WikiFSTypesRendererTests/ExtractorIdentityTests.swift
+++ b/Tests/WikiFSTypesRendererTests/ExtractorIdentityTests.swift
@@ -40,7 +40,9 @@ struct ExtractorIdentityTests {
         #expect(try ExtractorPackagePluginRunID(validating: run.rawValue.uuidString) == run)
         #expect(try ExtractorRequestID(validating: request.rawValue.uuidString) == request)
         #expect(ExtractorProtocolRevision(rawValue: 1) != nil)
-        #expect(ExtractorProtocolRevision(rawValue: 2) == nil)
+        // Revision 2 (issue #1159) is a supported protocol revision; 3 is not.
+        #expect(ExtractorProtocolRevision(rawValue: 2) != nil)
+        #expect(ExtractorProtocolRevision(rawValue: 3) == nil)
         #expect(ExtractorKind.allCases == [.pdf, .html])
         #expect(ExtractorFailureCause.allCases.count == 10)
     }


### PR DESCRIPTION
## Summary

PR 3 of 4 for issue #1159. Per-operation credential resolution and private process injection: the trusted host resolves authorized requirements immediately before each launch, materializes them into a request-scoped owner-read-only file, and redacts every package-controlled string before it can escape.

## Layer owned by this PR

- **Protocol revision 2**: requests carry optional RELATIVE paths for a private credential input file and a public operation-configuration file. Values never ride stdin JSON or environment; `makeEnvironment` stays allowlisted. Revision 1 requests keep their exact old shape and reject the new keys.
- **Envelopes**: `ExtractorCredentialInputEnvelope` (bounded, keyed by declared requirement IDs, non-empty values only, host-owned construction) and `ExtractorOperationConfiguration` (closed endpoint/timeout field set — a secret cannot be represented).
- **Resolution service**: `ExtractorOperationCredentialResolver` is a host-side Cordis service in BOTH app and daemon composition (never a package dependency, never visible to a package process). Each execute call rechecks admission + catalog membership, reloads the authorization snapshot, validates fingerprints, and resolves each authorized reference once — rotation, revocation, removal, and reinstall affect the next call without restart (AC.11). Required missing/unauthorized blocks with a bounded typed state; optional absent values are omitted (AC.10). A declaring package without a host resolver fails closed.
- **Materialization**: one request-scoped 0400 file created O_EXCL under `credentials/<request>/` inside the private operation root, verified (regular file, owner, link count 1, mode) before launch; the request carries the relative path only (AC.12/AC.13).
- **Cleanup + redaction**: request subdirectories are deleted on EVERY terminal path after materialization (success, every executor error, cancellation), after the executor has terminated and reaped any launched process group; `ExtractorSecretRedactor` covers progress messages, terminal failure frames, and every mapped error (AC.14/AC.15).
- **Revision 1 semantics unchanged**: no declared requirements → no resolution, no credential path, no redaction overhead.

## Stack position

- Parent PR: #1165 (`feature/extractor-credential-authorization`)
- Exact parent head SHA: `2033b6e23422f6bd37404115a2107129c9064f62`
- This branch: `feature/extractor-operation-credentials` at `250b3a4d44236159cf7435a2515f70738c847c4f`
- Child PR 4 (`feature/docling-serve-extractor-package`) will target this branch.

## Gates run

- `swift test --filter 'ProcessExtractorCredentialTests'` — 12 tests pass (v1 path rejection, relative-path-only requests, envelope filtering, config bounds, redaction, injection of only declared requirements, 0400 mode verification, cleanup on success + failure, rotation across executes, revocation fails next execute with a value-free message, fail-closed without a resolver, revision-1 semantics unchanged)
- `make lint`, `make build`, `make test` (3957 tests), `git diff --check` — pass
- Superseded pinned tests updated: `ExtractorProtocolRevision(rawValue: 2)` is now valid (identity test + generated-plugin dependency count 6 → 7)
