### PR TITLE
Separate local package import from extractor packages

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -585,11 +585,13 @@ struct ExtractionSettingsView: View {
             }
 
             // Installed extractor-package lifecycle (Phase 7): read-only list
-            // of exact registry admissions with progressive disclosure, plus
-            // app-only import/removal. Hidden when no snapshot loader was
-            // wired (tests, headless hosts).
+            // of exact registry admissions and app-only removal. Hidden when no
+            // snapshot loader was wired (tests, headless hosts).
             if packageSnapshot != nil {
                 installedPackagesSection
+                if packageModel.canImport {
+                    packageImportSection
+                }
             }
 
         }
@@ -1236,8 +1238,7 @@ struct ExtractionSettingsView: View {
     // MARK: - Installed extractor packages (Phase 7)
 
     /// Lifecycle list of the process registry's installed exact registrations,
-    /// packages that failed to activate, app-only import + removal, and the
-    /// per-kind default package selection persisted into `ExtractionConfig`.
+    /// packages that failed to activate, and app-only removal.
     /// Each control carries a stable accessibility identifier, an accessible
     /// name, and a state value (Phase 7.10); the contract test asserts these
     /// strings exist.
@@ -1251,16 +1252,6 @@ struct ExtractionSettingsView: View {
             .disabled(packageModel.isBusy)
             .accessibilityIdentifier(PackageAccessibility.refreshButton)
             .accessibilityLabel("Refresh installed extractor packages")
-
-            if packageModel.canImport {
-                DisclosureGroup {
-                    importDisclosureContent
-                } label: {
-                    Text(ExtractorSettingsPackagePicker.disclosureTitle)
-                }
-                .accessibilityIdentifier(PackageAccessibility.importDisclosure)
-                .accessibilityLabel("Advanced local extractor package import")
-            }
 
             if packageModel.isBusy {
                 ProgressView(packageModel.busyMessage ?? ExtractorPackageSettingsModel.checkingMessage)
@@ -1304,6 +1295,23 @@ struct ExtractionSettingsView: View {
             Text("Manage exact validated package revisions and their credential access. Choose defaults in the Default Extractors section above.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+        }
+    }
+
+    /// A separate section for the app-only local package import workflow.
+    /// Keep the workflow behind a disclosure so installed package rows remain
+    /// the focus of the package section.
+    @ViewBuilder private var packageImportSection: some View {
+        Section {
+            DisclosureGroup {
+                importDisclosureContent
+            } label: {
+                Label("Import a local package", systemImage: "square.and.arrow.down")
+            }
+            .accessibilityIdentifier(PackageAccessibility.importDisclosure)
+            .accessibilityLabel("Advanced local extractor package import")
+        } header: {
+            Text(ExtractorSettingsPackagePicker.disclosureTitle)
         }
     }
 

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -421,6 +421,10 @@ struct ExtractorPackageSettingsTests {
 
         // Local-directory-only import contract + executable-code trust warning.
         #expect(viewSource.contains("Advanced Local Package Import"))
+        // Keep import controls in a separate top-level Form section from the
+        // installed package rows.
+        #expect(viewSource.contains("installedPackagesSection\n                if packageModel.canImport {\n                    packageImportSection"))
+        #expect(viewSource.contains("@ViewBuilder private var packageImportSection: some View {\n        Section {"))
         #expect(viewSource.contains("Import Extractor Package…"))
         #expect(viewSource.contains("Select one local extractor package folder as an import source."))
         #expect(viewSource.contains("Files and archives are not supported."))

--- a/docs/user-guide/extractor-packages.md
+++ b/docs/user-guide/extractor-packages.md
@@ -44,7 +44,9 @@ Older package versions stay available while a newer version is installed. A fail
 
 ## Installed packages in Settings
 
-Use **Installed Extractor Packages** to manage exact revisions. This section does not contain another default picker. Expand a row to see its version, digest prefix, and registration name.
+Use **Installed Extractor Packages** to manage exact revisions. This section does not contain another default picker or the local import workflow. Expand a row to see its version, digest prefix, and registration name.
+
+Use **Advanced Local Package Import** in its separate section to add a local package folder. The app validates and copies the folder into the extractor store on this Mac.
 
 Use **Refresh** after you install, update, or remove a runtime such as Bun or uv. The list reads the live process state, so a row appears only when its package has activated in this process.
 

--- a/progress/2026-08-30T001336Z-separate-extractor-package-import.md
+++ b/progress/2026-08-30T001336Z-separate-extractor-package-import.md
@@ -1,0 +1,32 @@
+---
+timestamp: 2026-08-30T001336Z
+title: Separate extractor package import settings
+branch: feature/separate-local-package-import
+status: complete
+---
+
+# Separate extractor package import settings
+
+## Progress
+
+The Extraction settings page now shows local package import in its own top-level
+section. The Installed Extractor Packages section now contains package lifecycle
+controls and package rows only.
+
+The import disclosure, directory picker, trust warning, mutation gates, and
+accessibility identifiers remain unchanged. Read-only and headless views still
+hide the import section when the app does not provide an import action.
+
+## Verification
+
+- `git diff --check` passed.
+- LSP reported no diagnostics for `ExtractionSettingsView.swift`.
+- `make build` passed.
+- `WIKIFS_APP_TESTS=1 swift test --filter ExtractorPackageSettingsTests` passed
+  with 21 tests.
+- An initial `make test` run reached 3,974 tests and found one transient
+  filesystem failure in
+  `ProcessExtractorProviderTests/pdfConversionPreservesCancellationIdentity`.
+- The provider test passed when rerun alone with
+  `swift test --filter ProcessExtractorProviderTests/pdfConversionPreservesCancellationIdentity`.
+- A final `make test` run passed all 3,974 tests in 424 suites.


### PR DESCRIPTION
## Summary

- Move Advanced Local Package Import into its own top-level Extraction settings section.
- Keep Installed Extractor Packages focused on lifecycle controls and package rows.
- Preserve the import action, trust warning, picker validation, and accessibility identifiers.
- Update the package guide and add a source-contract regression check.

## Verification

- `git diff --check`
- `make build`
- `WIKIFS_APP_TESTS=1 swift test --filter ExtractorPackageSettingsTests`
- `make test` — 3,974 tests passed in 424 suites
- SwiftLint pre-commit hook — 0 violations
