### PR TITLE
Make extractor package rows collapsible

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -1306,12 +1306,15 @@ struct ExtractionSettingsView: View {
             DisclosureGroup {
                 importDisclosureContent
             } label: {
-                Label("Import a local package", systemImage: "square.and.arrow.down")
+                HStack {
+                    Text(ExtractorSettingsPackagePicker.disclosureTitle)
+                    Spacer(minLength: 0)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
             .accessibilityIdentifier(PackageAccessibility.importDisclosure)
             .accessibilityLabel("Advanced local extractor package import")
-        } header: {
-            Text(ExtractorSettingsPackagePicker.disclosureTitle)
         }
     }
 
@@ -1375,6 +1378,8 @@ struct ExtractionSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
         .accessibilityIdentifier("\(PackageAccessibility.rowPrefix).\(row.id)")
         .accessibilityLabel("\(row.packageID), version \(row.version), for \(kindDisplayName(row.kind))")
@@ -1398,6 +1403,8 @@ struct ExtractionSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         }
         .accessibilityIdentifier("\(PackageAccessibility.failurePrefix).\(failure.id)")
         .accessibilityLabel("\(failure.packageID), version \(failure.version), failed to activate")

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -422,9 +422,14 @@ struct ExtractorPackageSettingsTests {
         // Local-directory-only import contract + executable-code trust warning.
         #expect(viewSource.contains("Advanced Local Package Import"))
         // Keep import controls in a separate top-level Form section from the
-        // installed package rows.
+        // installed package rows. The visible title is the disclosure label.
         #expect(viewSource.contains("installedPackagesSection\n                if packageModel.canImport {\n                    packageImportSection"))
         #expect(viewSource.contains("@ViewBuilder private var packageImportSection: some View {\n        Section {"))
+        #expect(viewSource.contains("Text(ExtractorSettingsPackagePicker.disclosureTitle)"))
+        #expect(viewSource.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
+        #expect(viewSource.contains(".contentShape(Rectangle())"))
+        #expect(viewSource.contains("            .contentShape(Rectangle())\n        }\n        .accessibilityIdentifier(\"\\(PackageAccessibility.rowPrefix).\\(row.id)\")"))
+        #expect(viewSource.contains("            .contentShape(Rectangle())\n        }\n        .accessibilityIdentifier(\"\\(PackageAccessibility.failurePrefix).\\(failure.id)\")"))
         #expect(viewSource.contains("Import Extractor Package…"))
         #expect(viewSource.contains("Select one local extractor package folder as an import source."))
         #expect(viewSource.contains("Files and archives are not supported."))

--- a/docs/user-guide/extractor-packages.md
+++ b/docs/user-guide/extractor-packages.md
@@ -46,9 +46,9 @@ Older package versions stay available while a newer version is installed. A fail
 
 Use **Installed Extractor Packages** to manage exact revisions. This section does not contain another default picker or the local import workflow. Expand a row to see its version, digest prefix, and registration name.
 
-Use **Advanced Local Package Import** in its separate section to add a local package folder. The app validates and copies the folder into the extractor store on this Mac.
+Click the **Advanced Local Package Import** row to expand or contract it. Use the row's **Import Extractor Package…** button to add a local package folder. The app validates and copies the folder into the extractor store on this Mac.
 
-Use **Refresh** after you install, update, or remove a runtime such as Bun or uv. The list reads the live process state, so a row appears only when its package has activated in this process.
+Click an installed package row to expand or contract its details. Use **Refresh** after you install, update, or remove a runtime such as Bun or uv. The list reads the live process state, so a row appears only when its package has activated in this process.
 
 Lifecycle states use plain terms: a package is **Active** when you can select it. A package can also wait for a host service, fail to activate, or be in the process of stopping or removal. Raw identifiers and detailed history stay behind the disclosure rows.
 

--- a/scripts/voiceover-extractor-settings-smoke.md
+++ b/scripts/voiceover-extractor-settings-smoke.md
@@ -49,19 +49,22 @@ Run this test on macOS with VoiceOver enabled. Use a test App Group and a dispos
 45. Confirm that the copied text equals the report in the sheet.
 46. Confirm that the report contains no token, header, URL path, URL query, source content, or private path.
 47. Activate **Done** and confirm that the sheet closes.
-48. Open **Advanced Local Package Import**.
-49. Confirm that VoiceOver reads the executable-code warning.
-50. Import the disposable package and select it for its route.
-51. Confirm that the selected route reads **Ready**.
-52. Activate **Remove Package…**.
-53. Confirm that the dialog says removal blocks a selected route.
-54. Remove the package.
-55. Confirm that VoiceOver announces removal progress and completion.
-56. Confirm that the unavailable selection remains selected.
-57. Confirm that the route reads **Not installed**.
-58. Open **Extractor Status**.
-59. Confirm that the sheet offers refresh, another selection, and diagnostic copy actions.
-60. Confirm that the app does not select or run another extractor automatically.
-61. Tab through the section and confirm a logical focus order.
+48. Click the **Advanced Local Package Import** row.
+49. Confirm that the row expands and VoiceOver reads the executable-code warning.
+50. Click the row again and confirm that it contracts.
+51. Click the line of an installed package.
+52. Confirm that the package details expand. Click the line again and confirm that they contract.
+53. Import the disposable package and select it for its route.
+54. Confirm that the selected route reads **Ready**.
+55. Activate **Remove Package…**.
+56. Confirm that the dialog says removal blocks a selected route.
+57. Remove the package.
+58. Confirm that VoiceOver announces removal progress and completion.
+59. Confirm that the unavailable selection remains selected.
+60. Confirm that the route reads **Not installed**.
+61. Open **Extractor Status**.
+62. Confirm that the sheet offers refresh, another selection, and diagnostic copy actions.
+63. Confirm that the app does not select or run another extractor automatically.
+64. Tab through the section and confirm a logical focus order.
 
 Record the macOS version, app build, package digest prefix, and each incorrect announcement. Do not record source content or credentials.


### PR DESCRIPTION
## Summary

- Make the visible **Advanced Local Package Import** title the disclosure label.
- Expand the import, active package, and failed package labels to the full row.
- Keep native `DisclosureGroup` behavior, accessibility identifiers, and package actions unchanged.
- Update the settings guide and VoiceOver smoke steps.

## Verification

- `WIKIFS_APP_TESTS=1 swift test --filter ExtractorPackageSettingsTests` — 21 tests passed
- `make build` — passed
- `git diff --check` — passed
- Pre-commit SwiftLint — 0 violations
- `TEST_TIMEOUT=120 make test-watchdog` — bounded run confirmed an unrelated full-suite hang in Cordis/daemon tests and terminated the owned test process
