### PR TITLE
fix(sources): refresh reader head when derived-markdown writes land

### DIFF
--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -559,17 +559,18 @@ struct SourceDetailView: View {
             updateRightSidebarRegistration()
         }
         .onChange(of: showsSourceOutlineTab) { _, _ in updateRightSidebarRegistration() }
-        // #842 PR2 C6: refresh the transcript head when the store's source list
-        // changes. `appendProcessedMarkdown` routes through `mutate()` → emits
-        // a `ResourceChangeEvent(.source, .updated)` → the model's bus
-        // subscriber calls `reloadFromStore()` → `reloadSources()` bumps
-        // `store.sources`. This onChange picks up that bump and re-reads
-        // `processedMarkdownHead` so the reader shows the new transcript
-        // immediately after the queue worker persists it — without relying
-        // solely on `runTranscription`'s post-completion refresh (which only
-        // fires for the view that initiated the job; another wiki window
-        // viewing the same source would see the stale head without this).
-        .onChange(of: store.sources) { _, _ in
+        // #842 PR2 C6, #1179: refresh the derived head whenever the store's
+        // source data reloads. Extraction and transcript writes
+        // (`appendDerivedMarkdown`) never touch the `sources` row, so a rebuild
+        // can produce an `==` `sources` array and a value-based
+        // `.onChange(of: store.sources)` stays silent — the reader kept showing
+        // the raw source after import auto-extraction. `sourcesVersion` is a
+        // monotonic counter bumped on every `reloadSources()`, so this always
+        // fires and re-reads `processedMarkdownHead`: import auto-extraction in
+        // this window, and the queue worker's transcript persist in another
+        // window, both update without relying on the initiating view's own
+        // post-completion refresh.
+        .onChange(of: store.sourcesVersion) { _, _ in
             if !isEditing {
                 headVersion = store.processedMarkdownHead(for: file)
                 refreshRendererPresentation()

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -196,6 +196,17 @@ public final class WikiStoreModel {
     /// projection leaf, or path in either the log title or note.
     private var sourceIngestedStatus: [SourceID: Bool] = [:]
 
+    /// Monotonic counter bumped on every `reloadSources()`. Extraction and
+    /// transcript writes (`appendDerivedMarkdown`) never touch the `sources`
+    /// row, so a rebuild can produce an `==` `sources` array and
+    /// `.onChange(of: sources)` never fires — leaving the reader on a stale
+    /// `headVersion` after import auto-extraction (#1179). This counter always
+    /// changes, so views observe it via `.onChange(of: sourcesVersion)` to
+    /// reload per-source derived state after any store mutation (local writes
+    /// self-manage through `reloadSources()`; external writes arrive via the
+    /// `WikiEventBus` → `reloadFromStore()` → `reloadSources()`).
+    public private(set) var sourcesVersion: Int = 0
+
     // MARK: - Bookmark nodes (v16 — Bookmarks sidebar tree)
 
     /// Flat bookmark nodes, rebuilt from store after mutation (§3.1 pattern).
@@ -4375,6 +4386,10 @@ public final class WikiStoreModel {
     }
 
     private func reloadSources() {
+        // Bump FIRST and unconditionally: extraction/transcript writes leave the
+        // `sources` array `==`, and views key their derived-state refresh on this
+        // counter (#1179), so the bump must not depend on the array changing.
+        sourcesVersion &+= 1
         sources = DebugLog.trying("listSources", operation: { try store.listSources() }) ?? []
         // Authoritative source: the flag the agent stamps via
         // `wikictl log append --kind ingest --source <id>` on success.

--- a/Tests/WikiFSAppTests/SourceExtractionRefreshTests.swift
+++ b/Tests/WikiFSAppTests/SourceExtractionRefreshTests.swift
@@ -1,0 +1,78 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+
+/// #1179: an import auto-extraction (or any derived-markdown write) never
+/// touches the `sources` row, so the rebuilt `WikiStoreModel.sources` array can
+/// be `==` to the previous one. A value-based `.onChange(of: store.sources)`
+/// therefore never fires, and the reader keeps its stale `headVersion` (the raw
+/// source) until the user re-extracts manually. The model bumps
+/// `sourcesVersion` on every `reloadSources()` so views can observe
+/// markdown-only changes. These tests pin that contract at the model seam.
+@MainActor
+struct SourceExtractionRefreshTests {
+
+    /// A derived-markdown write must advance `sourcesVersion` even when the
+    /// `sources` array is value-equal before and after the reload — the exact
+    /// condition under which the old `onChange(of: store.sources)` stayed
+    /// silent.
+    @Test func derivedMarkdownWriteAdvancesSourcesVersionWithEqualSourcesArray() async throws {
+        let store = try TestStoreFactory.inMemory()
+        store.eventBus = WikiEventBus(wikiID: WikiID(rawValue: "extraction-refresh"))
+        let model = WikiStoreModel(store: store)
+        model.reloadFromStore()
+
+        let source = try store.addSource(filename: "report.docx", data: Data("docx-bytes".utf8))
+        try await waitUntil("source import reloads the model") {
+            model.sources.contains { $0.id == source.id }
+        }
+        let baselineVersion = model.sourcesVersion
+        let baselineSources = model.sources
+
+        // The markdown-only write: extraction output persisted for the source,
+        // exactly what `runImportExtraction` does after an import.
+        let body = "# Report\n\nextracted markdown body"
+        _ = try store.appendProcessedMarkdown(
+            sourceID: source.id, content: body, origin: .extraction,
+            note: "extract via docx-to-markdown")
+
+        // The bus-driven reload must advance the counter...
+        try await waitUntil("derived markdown write advances sourcesVersion") {
+            model.sourcesVersion > baselineVersion
+        }
+        // ...while the `sources` array stays value-equal (no `sources` row
+        // changed). A value-based onChange on the array itself could not have
+        // fired under this condition — the regression from #1179.
+        #expect(model.sources == baselineSources)
+
+        // The reader's reload path resolves the new HEAD, so the view that
+        // observes `sourcesVersion` shows the markdown, not the raw source.
+        let summary = try #require(model.sources.first { $0.id == source.id })
+        #expect(model.processedMarkdownHead(for: summary)?.content == body)
+    }
+
+    private func waitUntil(
+        _ description: String, condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(2)
+        while !condition() {
+            guard Date() < deadline else {
+                throw RefreshWaitError.timedOut(description)
+            }
+            await Task.yield()
+        }
+    }
+
+    private enum RefreshWaitError: Error, LocalizedError {
+        case timedOut(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .timedOut(let description): "Timed out waiting for \(description)."
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
# Fix: import auto-extraction stayed invisible in the source reader

Fixes #1179.

## Problem

When a source with an auto-extractable type (for example `.docx`) was imported, the app extracted it automatically and set the result as HEAD. But the reader kept showing the raw source. It showed the markdown only after the user clicked **Extract** again.

## Root cause

`appendDerivedMarkdown` writes `source_markdown_versions`, `activities`, `refs`, and `source_search`. It never changes the `sources` row. So the bus-driven `reloadSources()` rebuild produced an `==` `sources` array. SwiftUI `onChange` fires only when the observed value changes, so the reload block in `SourceDetailView` never ran. The view had loaded `headVersion` once at tab open, before the extraction committed, and it stayed `nil`.

The manual **Extract** button worked because `runDocxExtraction` assigns `headVersion` directly from the returned version.

The old comment above the `onChange` claimed `reloadSources()` "bumps" `store.sources`. It did not. The cross-window transcript refresh from #842 PR2 C6 could not fire for the same reason.

## Change

- `WikiStoreModel` gains `sourcesVersion`, a monotonic counter bumped on every `reloadSources()`. This mirrors `messageVersion` (#858), which solved the same problem for chats.
- `SourceDetailView` keys its `onChange` on `store.sourcesVersion` instead of `store.sources`. The reload block now always fires after any store event, including markdown-only writes.
- New regression test `SourceExtractionRefreshTests`: a derived-markdown write must advance `sourcesVersion` while the `sources` array stays value-equal. That is the exact condition under which the old `onChange` stayed silent.

## Verification

- `make build` passes.
- `make test` passes: 4041 tests, 430 suites. (One unrelated extractor-admission test flaked under `--parallel` on a first run and passed in isolation and in the full re-run.)
- `WIKIFS_APP_TESTS=1 swift test --filter SourceExtractionRefreshTests` passes.

## Notes for review

- The compare sheet reads alternatives fresh on open, so it needed no change.
- `sourcesVersion` covers a superset of the old trigger: every `reloadSources()` call bumps it, including real `sources` list changes.
