### PR TITLE
fix(sources): show extraction and source dates at second precision

### DIFF
--- a/Sources/WikiFS/Detail/MetadataValueRenderer.swift
+++ b/Sources/WikiFS/Detail/MetadataValueRenderer.swift
@@ -29,7 +29,10 @@ enum MetadataValueRenderer {
             formatter.locale = locale
             formatter.calendar = calendar
             formatter.dateStyle = .medium
-            formatter.timeStyle = .short
+            // Seconds, not minutes: extraction runs seconds apart must be
+            // distinguishable in the panel (two docx2md runs in one import
+            // session looked identical at `.short` precision).
+            formatter.timeStyle = .medium
             return .text(formatter.string(from: date), usesTabularDigits: false)
         case .byteCount(let count):
             let formatter = ByteCountFormatter()

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -1697,7 +1697,7 @@ struct SourceDetailView: View {
                         headVersion = store.processedMarkdownHead(for: file)
                     } label: {
                         Label {
-                            Text("\(ExtractionAlternative.backendDisplayName(agentName: agent)) — \(version.createdAt, style: .date)")
+                            Text("\(ExtractionAlternative.backendDisplayName(agentName: agent)) — \(version.createdAt, format: .dateTime.year().month().day().hour().minute().second())")
                         } icon: {
                             Image(systemName: version.id.rawValue == headID
                                   ? "checkmark.circle.fill" : "doc.text")

--- a/Tests/WikiFSAppTests/MetadataValueRendererTests.swift
+++ b/Tests/WikiFSAppTests/MetadataValueRendererTests.swift
@@ -13,7 +13,11 @@ struct MetadataValueRendererTests {
 
     @Test func rendersDate() {
         if case .text(let value, _) = render(.date(Date(timeIntervalSince1970: 0))) {
-            #expect(!value.isEmpty)
+            // Second precision: runs seconds apart must stay distinguishable.
+            // The time portion must be h:mm:ss ("4:00:00 PM"), not the
+            // minute-only h:mm ("4:00 PM"). Epoch 0 renders in the machine's
+            // timezone, so match the shape, not a literal time.
+            #expect(value.range(of: #"\d{1,2}:\d{2}:\d{2}"#, options: .regularExpression) != nil)
         } else { Issue.record("date must render as text") }
     }
 


### PR DESCRIPTION
# Fix: show extraction and source dates at second precision

Found during the #1179 investigation.

## Problem

One import session wrote two extraction versions 20 seconds apart (auto-extract at import, then a manual Extract). The UI could not show the difference:

- The metadata panel rendered dates with minute-only time (`timeStyle = .short`): "Aug 30, 2026 at 3:14 PM" for both runs.
- The "Active extraction" history menu rendered date-only (`style: .date`): "Aug 30, 2026" for both runs.

Two runs from one session looked like the same extraction.

## Change

- `MetadataValueRenderer` renders `.date` values with `timeStyle = .medium`, so every metadata date shows h:mm:ss. This covers the source "Created" and "Updated" rows and the "Extracted" row.
- The history menu entries render full date-time including seconds.
- The renderer test now pins the h:mm:ss shape. It asserted only non-empty output before.

## Verification

- `WIKIFS_APP_TESTS=1 swift test --filter MetadataValueRendererTests` passes.
- `make test` passes: 4041 tests, 430 suites.

## Notes

The app has no separate "ingested at" date display today. Ingest state is a boolean badge backed by the ingest log, not the `sources.ingested_at` column. If a true ingestion timestamp row is wanted, that is a separate feature.
