### PR TITLE
refactor(extraction): remove retired backend and htmlBackend config fields

### DIFF
--- a/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
+++ b/Sources/WikiFSCore/Integrations/ExtractionConfig.swift
@@ -11,12 +11,6 @@ import Foundation
 /// pattern exactly (pure value type, explicit injected directory, atomic write),
 /// and `WikiRegistry`'s degrade-to-empty-on-corrupt rule.
 public struct ExtractionConfig: JSONSidecarConfig {
-    /// DEPRECATED legacy input (decode-only): the pre-route PDF backend choice.
-    /// Runtime selection lives in `routeExtractors`; the decoder migrates this
-    /// value into a PDF route record and new files never write the key. Only
-    /// the retired test-only extraction runtime still reads the field.
-    public var backend: ExtractionBackend
-
     /// For the `.acp` backend: the provider id (from `AgentProvidersConfig`)
     /// to use for extraction. nil = use the app's default provider. Ignored by
     /// other backends. Forward-compatible: a missing key decodes to nil.
@@ -60,11 +54,6 @@ public struct ExtractionConfig: JSONSidecarConfig {
         return doclingServeTimeoutMilliseconds
     }
 
-    /// DEPRECATED legacy input (decode-only): the pre-route HTML backend
-    /// choice. The decoder migrates this value into an HTML route record and
-    /// new files never write the key.
-    public var htmlBackend: HtmlExtractionBackend?
-
     /// The podcast→transcript backend to use when the user explicitly
     /// transcribes a podcast source (issue #799 PR4 — framework only here;
     /// the Transcribe trigger and `#if PODCAST_TRANSCRIPTS` gating land in
@@ -89,7 +78,6 @@ public struct ExtractionConfig: JSONSidecarConfig {
     public static let fileName = "extraction-config.json"
 
     public init(
-        backend: ExtractionBackend = .localPdf2md,
         acpProviderId: String? = nil,
         anthropicModel: String = ExtractionConfig.defaultAnthropicModel,
         anthropicBaseURLOverride: String? = nil,
@@ -97,11 +85,9 @@ public struct ExtractionConfig: JSONSidecarConfig {
         geminiBaseURLOverride: String? = nil,
         doclingServeEndpoint: String? = nil,
         doclingServeTimeoutMilliseconds: Int? = nil,
-        htmlBackend: HtmlExtractionBackend? = nil,
         podcastBackend: PodcastTranscriptionBackend? = nil,
         routeExtractors: [ExtractorRouteSelectionRecord] = []
     ) {
-        self.backend = backend
         self.acpProviderId = acpProviderId
         self.anthropicModel = anthropicModel
         self.anthropicBaseURLOverride = anthropicBaseURLOverride
@@ -109,7 +95,6 @@ public struct ExtractionConfig: JSONSidecarConfig {
         self.geminiBaseURLOverride = geminiBaseURLOverride
         self.doclingServeEndpoint = doclingServeEndpoint
         self.doclingServeTimeoutMilliseconds = doclingServeTimeoutMilliseconds
-        self.htmlBackend = htmlBackend
         self.podcastBackend = podcastBackend
         self.routeExtractors = routeExtractors.normalizedForPersistence().records
     }
@@ -131,21 +116,11 @@ public struct ExtractionConfig: JSONSidecarConfig {
 
     public static let defaultGeminiBaseURL = "https://generativelanguage.googleapis.com"
 
-    /// The configured model id for the current backend, where applicable (used to
-    /// stamp the extraction agent's `version`). nil for backends without a model.
-    public var currentModelVersion: String? {
-        switch backend {
-        case .anthropic: return anthropicModel
-        case .gemini: return geminiModel
-        case .acp, .localPdf2md, .doclingServe: return nil
-        }
-    }
-
     // MARK: - Resilient Codable
 
     /// Decode each field with `decodeIfPresent` + a default fallback so a missing
-    /// key (forward-compat: a new field added later) or an unknown backend raw
-    /// value degrades to the default instead of throwing — same philosophy as
+    /// key (forward-compat: a new field added later) or an unknown raw value
+    /// degrades to the default instead of throwing — same philosophy as
     /// `load`'s corrupt-file handling.
     private enum CodingKeys: String, CodingKey {
         case backend, acpProviderId
@@ -160,7 +135,6 @@ public struct ExtractionConfig: JSONSidecarConfig {
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.backend = DebugLog.trying("init(from:) decode backend") { try c.decode(ExtractionBackend.self, forKey: .backend) } ?? .localPdf2md
         self.acpProviderId = try c.decodeIfPresent(String.self, forKey: .acpProviderId)
         self.anthropicModel = try c.decodeIfPresent(String.self, forKey: .anthropicModel)
             ?? ExtractionConfig.defaultAnthropicModel
@@ -172,16 +146,23 @@ public struct ExtractionConfig: JSONSidecarConfig {
         // #1159: absent key = the 600-second compatibility default via
         // `effectiveDoclingServeTimeoutMilliseconds`.
         self.doclingServeTimeoutMilliseconds = try c.decodeIfPresent(Int.self, forKey: .doclingServeTimeoutMilliseconds)
+        // The retired `backend` / `htmlBackend` keys are decode-only migration
+        // inputs consumed as locals below (#1178): each value migrates into a
+        // route record at most once and never becomes stored state. A missing
+        // key OR an unknown raw value (a future/typo'd backend) degrades
+        // gracefully — the same resilient decode philosophy as every other
+        // field.
+        let legacyBackend = DebugLog.trying("init(from:) decode backend") {
+            try c.decode(ExtractionBackend.self, forKey: .backend)
+        } ?? .localPdf2md
         // Forward-compat for issue #799 PR1: a config file written before
         // this field shipped (no `htmlBackend`/`podcastBackend` key) decodes
-        // to nil — the user picks a backend on first extraction. Mirrors the
-        // exact pattern `backend` uses below: `try? c.decode(...)` so a missing
-        // key OR an unknown raw value (a future/typo'd backend) degrades
-        // gracefully rather than rejecting the whole file. The "default" for
-        // these optional fields is `nil` (vs `backend`'s `.localPdf2md`), so a
-        // typo silently picks "prompt me" instead of "PDF" — same resilient
-        // decode philosophy as `unknownBackendValueDegradesToLocalPdf2md`.
-        self.htmlBackend = DebugLog.trying("init(from:) decode htmlBackend") { try c.decode(HtmlExtractionBackend.self, forKey: .htmlBackend) }
+        // to nil — the user picks a backend on first extraction. `try?`
+        // decoding means a typo silently picks "prompt me" instead of a
+        // wrong backend.
+        let legacyHTMLBackend = DebugLog.trying("init(from:) decode htmlBackend") {
+            try c.decode(HtmlExtractionBackend.self, forKey: .htmlBackend)
+        }
         self.podcastBackend = DebugLog.trying("init(from:) decode podcastBackend") { try c.decode(PodcastTranscriptionBackend.self, forKey: .podcastBackend) }
         var routes = Self.decodedRouteRecords(from: c)
         // One-time migration: every retired format-specific selection key is a
@@ -197,15 +178,15 @@ public struct ExtractionConfig: JSONSidecarConfig {
         if routes.contains(where: { $0.route == .canonicalPDF }) == false {
             if let legacyPDF {
                 routes.append(.init(route: .canonicalPDF, extractor: legacyPDF))
-            } else if let migrated = Self.migratedSelection(fromPDFBackend: backend) {
+            } else if let migrated = Self.migratedSelection(fromPDFBackend: legacyBackend) {
                 routes.append(.init(route: .canonicalPDF, extractor: migrated))
             }
         }
         if routes.contains(where: { $0.route == .canonicalHTML }) == false {
             if let legacyHTML {
                 routes.append(.init(route: .canonicalHTML, extractor: legacyHTML))
-            } else if let htmlBackend,
-                      let migrated = Self.migratedSelection(fromHTMLBackend: htmlBackend) {
+            } else if let legacyHTMLBackend,
+                      let migrated = Self.migratedSelection(fromHTMLBackend: legacyHTMLBackend) {
                 routes.append(.init(route: .canonicalHTML, extractor: migrated))
             }
         }

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -330,11 +330,13 @@ public final class WikiStoreModel {
     @ObservationIgnored public var searchServices: any SearchServices = UnavailableSearchServices()
 
     /// The configured HTML extraction backend (issue #799 PR2). Set at app
-    /// wiring time from `ExtractionConfig.htmlBackend` so the Extract button
-    /// and the "Re-extract with" menu have a default to use when the user
-    /// taps Extract without picking a backend explicitly. `nil` = no default
-    /// chosen (a fresh install, or a config file written before this field
-    /// shipped) — the menu then lists `HtmlExtractionBackend.allCases` so the
+    /// wiring time from `ExtractionConfig.htmlSelectionLabel` — the canonical
+    /// HTML route selection, which is where the retired `ExtractionConfig
+    /// .htmlBackend` field used to feed in before #1178 removed it — so the
+    /// Extract button and the "Re-extract with" menu have a default to use
+    /// when the user taps Extract without picking a backend explicitly.
+    /// `nil` = no default chosen (a fresh install, or no HTML route record)
+    /// — the menu then lists `HtmlExtractionBackend.allCases` so the
     /// user picks one. The process extraction facade resolves the selected
     /// adapter when extraction starts.
     @ObservationIgnored public var htmlBackend: HtmlExtractionBackend?

--- a/Sources/WikiFSEngine/ExtractionCoordinator.swift
+++ b/Sources/WikiFSEngine/ExtractionCoordinator.swift
@@ -178,8 +178,14 @@ public actor ExtractionRuntime: ExtractionServices {
 
     public func prepare(backendOverride: ExtractionBackend?) async throws -> ExtractionPreparation {
         guard !disposed else { throw ExtractionServicesError.unavailable }
+        // #1178: the retired `ExtractionConfig.backend` fallback is gone, so
+        // this test-only runtime receives its backend explicitly and fails
+        // closed when a caller supplies no override. Production resolves
+        // default selections through the route records instead.
+        guard let effectiveBackend = backendOverride else {
+            throw ExtractionServicesError.unavailable
+        }
         let configuration = try readConfiguration()
-        let effectiveBackend = backendOverride ?? configuration.backend
         let preparation = try await resolveBackend(configuration, effectiveBackend)
         guard !disposed else { throw ExtractionServicesError.unavailable }
         return preparation
@@ -231,8 +237,14 @@ private final class LegacyExtractionServices: ExtractionServices {
     }
 
     func prepare(backendOverride: ExtractionBackend?) async throws -> ExtractionPreparation {
+        // #1178: the retired `ExtractionConfig.backend` fallback is gone, so
+        // this test-only seam receives its backend explicitly and fails closed
+        // when a caller supplies no override. Production resolves default
+        // selections through the route records instead.
+        guard let backend = backendOverride else {
+            throw ExtractionServicesError.unavailable
+        }
         let configuration = ExtractionConfig.load(from: containerDirectory)
-        let backend = backendOverride ?? configuration.backend
         let extractor: any MarkdownExtractor
         switch backend {
         case .localPdf2md:

--- a/Tests/WikiFSAppTests/ExtractionCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionCoordinatorTests.swift
@@ -7,11 +7,12 @@ import WikiFSEngine
 @testable import WikiFS
 @testable import WikiFSEngine
 
-/// `ExtractionCoordinator` backend resolution + readiness mapping. Uses an
-/// `InMemoryExtractionCredentialStore` and a temp container directory so tests
-/// are hermetic (no real Keychain pollution). The backend is driven through
-/// `ExtractionConfig` (the single source of truth), matching how
-/// `ExtractionSettingsView`'s Save writes it. The coordinator is `@MainActor`.
+/// `ExtractionCoordinator` backend resolution + readiness mapping over the
+/// test-only legacy seam. Uses an `InMemoryExtractionCredentialStore` and a
+/// temp container directory so tests are hermetic (no real Keychain
+/// pollution). #1178 removed the retired `ExtractionConfig.backend` fallback,
+/// so the seam receives its backend explicitly through `backendOverride` and
+/// fails closed when a caller supplies none. The coordinator is `@MainActor`.
 @MainActor
 struct ExtractionCoordinatorTests {
 
@@ -22,16 +23,15 @@ struct ExtractionCoordinatorTests {
         return dir
     }
 
-    /// A coordinator over `dir` with an in-memory secret store. `backend` is the
-    /// configured backend (written to `ExtractionConfig` before construction).
+    /// A coordinator over `dir` with an in-memory secret store. The config file
+    /// holds only persisted settings (models, endpoints, provider ids); the
+    /// backend itself is passed explicitly per `prepare(backendOverride:)` call.
     private func makeCoordinator(
-        backend: ExtractionBackend = .localPdf2md,
         dir: URL,
         seeds: [ExtractionSecret: String] = [:],
         configure: ((inout ExtractionConfig) -> Void)? = nil
     ) throws -> ExtractionCoordinator {
         var cfg = ExtractionConfig()
-        cfg.backend = backend
         configure?(&cfg)
         try cfg.save(to: dir)
         return ExtractionCoordinator(
@@ -43,126 +43,116 @@ struct ExtractionCoordinatorTests {
 
     // MARK: - Backend resolution
 
-    @Test func defaultsToLocalPdf2md() async throws {
+    @Test func localPdf2mdOverrideResolvesLocalExtractor() async throws {
         let coord = try makeCoordinator(dir: tempDirectory())
-        #expect((try await coord.prepare()).backend == .localPdf2md)
-        #expect((try await coord.prepare()).extractor is CoordinatorStubExtractor)
+        let preparation = try await coord.prepare(backendOverride: .localPdf2md)
+        #expect(preparation.backend == .localPdf2md)
+        #expect(preparation.extractor is CoordinatorStubExtractor)
+    }
+
+    /// #1178: with the retired `ExtractionConfig.backend` fallback gone, a
+    /// prepare call without an explicit backend fails closed instead of
+    /// inventing a default. Production resolves defaults through the route
+    /// records; this legacy seam does not.
+    @Test func missingOverrideFailsClosed() async throws {
+        let coord = try makeCoordinator(dir: tempDirectory())
+        await #expect(throws: ExtractionServicesError.unavailable) {
+            try await coord.prepare()
+        }
     }
 
     @Test func resolvesAnthropicBackend() async throws {
-        let coord = try makeCoordinator(backend: .anthropic, dir: tempDirectory(),
+        let coord = try makeCoordinator(dir: tempDirectory(),
                                         seeds: [.anthropicAPIKey: "k"])
-        #expect((try await coord.prepare()).extractor is AnthropicExtractionClient)
-    }
-
-    @Test func resolvesDoclingBackend() async throws {
-        let coord = try makeCoordinator(backend: .doclingServe, dir: tempDirectory())
-        #expect((try await coord.prepare()).extractor is DoclingServeClient)
+        #expect((try await coord.prepare(backendOverride: .anthropic)).extractor is AnthropicExtractionClient)
     }
 
     @Test func resolvesGeminiBackend() async throws {
-        let coord = try makeCoordinator(backend: .gemini, dir: tempDirectory(),
+        let coord = try makeCoordinator(dir: tempDirectory(),
                                         seeds: [.geminiAPIKey: "k"])
-        #expect((try await coord.prepare()).extractor is GeminiExtractionClient)
+        #expect((try await coord.prepare(backendOverride: .gemini)).extractor is GeminiExtractionClient)
     }
 
     @Test func geminiNeedsSetupWithoutKey() async throws {
-        let coord = try makeCoordinator(backend: .gemini, dir: tempDirectory())
-        let r = await (try await coord.prepare()).extractor.readiness()
+        let coord = try makeCoordinator(dir: tempDirectory())
+        let r = await (try await coord.prepare(backendOverride: .gemini)).extractor.readiness()
         if case .needsSetup = r { } else { Issue.record("expected .needsSetup") }
     }
 
     @Test func geminiReadyWithKey() async throws {
-        let coord = try makeCoordinator(backend: .gemini, dir: tempDirectory(),
+        let coord = try makeCoordinator(dir: tempDirectory(),
                                         seeds: [.geminiAPIKey: "AIza-x"])
-        #expect(await (try await coord.prepare()).extractor.readiness() == .ready)
+        #expect(await (try await coord.prepare(backendOverride: .gemini)).extractor.readiness() == .ready)
     }
 
     @Test func geminiClientUsesConfiguredModel() async throws {
-        let coord = try makeCoordinator(backend: .gemini, dir: tempDirectory(),
+        let coord = try makeCoordinator(dir: tempDirectory(),
                                         seeds: [.geminiAPIKey: "k"]) { cfg in
             cfg.geminiModel = "gemini-3.1-flash-lite"
         }
-        #expect(((try await coord.prepare()).extractor as? GeminiExtractionClient)?.model == "gemini-3.1-flash-lite")
+        #expect(((try await coord.prepare(backendOverride: .gemini)).extractor as? GeminiExtractionClient)?.model == "gemini-3.1-flash-lite")
     }
 
     // MARK: - Readiness mapping
 
     @Test func anthropicNeedsSetupWithoutKey() async throws {
-        let coord = try makeCoordinator(backend: .anthropic, dir: tempDirectory())
-        let r = await (try await coord.prepare()).extractor.readiness()
+        let coord = try makeCoordinator(dir: tempDirectory())
+        let r = await (try await coord.prepare(backendOverride: .anthropic)).extractor.readiness()
         if case .needsSetup = r { } else { Issue.record("expected .needsSetup") }
     }
 
     @Test func anthropicReadyWithKey() async throws {
-        let coord = try makeCoordinator(backend: .anthropic, dir: tempDirectory(),
+        let coord = try makeCoordinator(dir: tempDirectory(),
                                         seeds: [.anthropicAPIKey: "sk-ant-x"])
-        #expect(await (try await coord.prepare()).extractor.readiness() == .ready)
+        #expect(await (try await coord.prepare(backendOverride: .anthropic)).extractor.readiness() == .ready)
     }
 
-    @Test func doclingNeedsSetupWithoutEndpoint() async throws {
-        // No endpoint in config → coordinator passes "" → readiness .needsSetup.
-        let coord = try makeCoordinator(backend: .doclingServe, dir: tempDirectory())
-        let r = await (try await coord.prepare()).extractor.readiness()
-        if case .needsSetup = r { } else { Issue.record("expected .needsSetup") }
-    }
-
-    @Test func doclingReadyWithEndpoint() async throws {
-        let coord = try makeCoordinator(backend: .doclingServe, dir: tempDirectory()) { cfg in
+    /// #1159: the legacy seam keeps no direct Docling execution path — Docling
+    /// runs through the reviewed package, so an explicit `.doclingServe`
+    /// override fails closed here regardless of the configured endpoint.
+    @Test func doclingServeOverrideFailsClosed() async throws {
+        let coord = try makeCoordinator(dir: tempDirectory()) { cfg in
             cfg.doclingServeEndpoint = "http://localhost:5001"
         }
-        #expect(await (try await coord.prepare()).extractor.readiness() == .ready)
+        await #expect(throws: ExtractionServicesError.unavailable) {
+            try await coord.prepare(backendOverride: .doclingServe)
+        }
     }
 
     // MARK: - Config reload + default-model wiring
 
     @Test func configReloadsAfterSave() async throws {
         let dir = tempDirectory()
-        let coord = try makeCoordinator(backend: .anthropic, dir: dir)
-        #expect((try await coord.prepare()).modelVersion == ExtractionConfig.defaultAnthropicModel)
+        let coord = try makeCoordinator(dir: dir)
+        #expect((try await coord.prepare(backendOverride: .anthropic)).modelVersion == ExtractionConfig.defaultAnthropicModel)
         var cfg = ExtractionConfig.load(from: dir)
         cfg.anthropicModel = "claude-sonnet-4-6"
         try cfg.save(to: dir)
-        #expect((try await coord.prepare()).modelVersion == "claude-sonnet-4-6")
+        #expect((try await coord.prepare(backendOverride: .anthropic)).modelVersion == "claude-sonnet-4-6")
     }
 
     @Test func anthropicClientUsesConfiguredModel() async throws {
-        let coord = try makeCoordinator(backend: .anthropic, dir: tempDirectory(),
+        let coord = try makeCoordinator(dir: tempDirectory(),
                                         seeds: [.anthropicAPIKey: "k"]) { cfg in
             cfg.anthropicModel = "claude-sonnet-4-6"
         }
-        let client = (try await coord.prepare()).extractor as? AnthropicExtractionClient
+        let client = (try await coord.prepare(backendOverride: .anthropic)).extractor as? AnthropicExtractionClient
         #expect(client?.model == "claude-sonnet-4-6")
-    }
-
-    @Test func unknownBackendInConfigDegradesToLocal() async throws {
-        // A corrupt/unknown backend value in the JSON file should never crash a
-        // resolve — `ExtractionConfig` degrades it to `.localPdf2md`.
-        let dir = tempDirectory()
-        let url = dir.appendingPathComponent(ExtractionConfig.fileName, isDirectory: false)
-        try Data(#"{"backend":"definitely_not_real"}"#.utf8).write(to: url)
-        let coord = ExtractionCoordinator(
-            containerDirectory: dir,
-            credentialStore: InMemoryExtractionCredentialStore(),
-            fetcher: FakeHTTPFetcher(body: "x"),
-            localExtractorFactory: { CoordinatorStubExtractor() })
-        #expect((try await coord.prepare()).backend == .localPdf2md)
-        #expect((try await coord.prepare()).extractor is CoordinatorStubExtractor)
     }
 
     // MARK: - ACP backend
 
-    @Test func acpBackendWithNoProviderFallsBackToLocal() async throws {
-        // When .acp is configured but no ACP provider can be resolved (no
-        // command on PATH), the coordinator falls back to the local extractor
-        // rather than crashing. The resolveCommand closure returns nil.
+    /// An absent provider is an unavailable selection: with `.acp` requested
+    /// explicitly but no resolvable provider command, the seam fails closed
+    /// instead of substituting the local extractor.
+    @Test func acpOverrideWithoutResolvableProviderFailsClosed() async throws {
         let dir = tempDirectory()
         var cfg = ExtractionConfig()
-        cfg.backend = .acp
         cfg.acpProviderId = "claude-acp"
         try cfg.save(to: dir)
 
-        // Seed agent-providers.json so the provider exists + is enabled.
+        // Seed agent-providers.json so the provider exists + is enabled, but
+        // its command cannot be resolved (the path does not exist).
         let providersConfig = AgentProvidersConfig(providers: [
             AgentProvider(id: ProviderID(rawValue: "claude-acp"), label: "Claude", command: ["/nonexistent/claude"], enabled: true, isDefault: true)
         ])
@@ -174,9 +164,9 @@ struct ExtractionCoordinatorTests {
             acpCredentialStore: InMemoryACPCredentialStore(),
             fetcher: FakeHTTPFetcher(body: "x"),
             localExtractorFactory: { CoordinatorStubExtractor() })
-        #expect((try await coord.prepare()).backend == .acp)
-        // Falls back to local because the command cannot be resolved on PATH.
-        #expect((try await coord.prepare()).extractor is CoordinatorStubExtractor)
+        await #expect(throws: ExtractionServicesError.unavailable) {
+            try await coord.prepare(backendOverride: .acp)
+        }
     }
 }
 

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -364,7 +364,7 @@ struct ExtractionRouteTableHostedTests {
             registrationID: try ExtractorRegistrationID(validating: "main"))
 
         // The table's write path, exercised end to end: mapping write + save.
-        var config = ExtractionConfig(backend: .acp)
+        var config = ExtractionConfig()
         ExtractorRouteSettingsMapping.write(.installed(logical), route: .canonicalPDF, into: &config)
         try config.save(to: dir)
 
@@ -394,7 +394,7 @@ struct ExtractionRouteTableHostedTests {
             packageID: try ExtractorPackageID(validating: "org.example.gone.docx"),
             registrationID: try ExtractorRegistrationID(validating: "document"))
 
-        var config = ExtractionConfig(backend: .acp)
+        var config = ExtractionConfig()
         ExtractorRouteSettingsMapping.write(.installed(logical), route: .canonicalDOCX, into: &config)
         try config.save(to: dir)
 

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -148,9 +148,7 @@ struct ExtractorPackageSettingsTests {
         ExtractorRouteSettingsMapping.write(.connectedService(.acp), route: .canonicalPDF, into: &config)
         ExtractorRouteSettingsMapping.write(.builtInTagBased, route: .canonicalHTML, into: &config)
 
-        // The retired typed fields are never rewritten by selection writes.
-        #expect(config.backend == .localPdf2md)
-        #expect(config.htmlBackend == nil)
+        // The retired typed selection keys are never rewritten by selection writes.
         #expect(config.extractorSelection(for: .canonicalPDF) == ExtractorRouteHostCatalog.acpReference)
         #expect(config.extractorSelection(for: .canonicalHTML) == ExtractorRouteHostCatalog.tagBasedReference)
     }

--- a/Tests/WikiFSTests/ExtractionConfigTests.swift
+++ b/Tests/WikiFSTests/ExtractionConfigTests.swift
@@ -23,20 +23,16 @@ struct ExtractionConfigTests {
         return .host(HostExtractorReference(adapterID: adapterID))
     }
 
-    /// The in-disk value of an in-memory config: the retired typed fields are
-    /// decode-only and not persisted, so a round trip resets them to defaults.
-    /// Load never bakes the bundled default-route policy into the file —
-    /// defaults participate at read time via `selectionOrDefault`.
+    /// The in-disk value of an in-memory config: every field persists, so a
+    /// round trip is exact. Load never bakes the bundled default-route policy
+    /// into the file — defaults participate at read time via
+    /// `selectionOrDefault`.
     private func persisted(_ config: ExtractionConfig) -> ExtractionConfig {
-        var result = config
-        result.backend = .localPdf2md
-        result.htmlBackend = nil
-        return result
+        config
     }
 
-    @Test func defaultsAreLocalPdf2mdAndSonnetModel() {
+    @Test func defaultsMatchBundledModels() {
         let config = ExtractionConfig()
-        #expect(config.backend == .localPdf2md)
         #expect(config.anthropicModel == ExtractionConfig.defaultAnthropicModel)
         #expect(config.anthropicBaseURLOverride == nil)
         #expect(config.geminiModel == ExtractionConfig.defaultGeminiModel)
@@ -48,7 +44,6 @@ struct ExtractionConfigTests {
     @Test func savesAndLoadsRoundTrip() throws {
         let dir = tempDirectory()
         var config = ExtractionConfig()
-        config.backend = .gemini
         config.anthropicModel = "claude-sonnet-4-6"
         config.anthropicBaseURLOverride = "https://proxy.example.com"
         config.geminiModel = "gemini-3.1-flash-lite"
@@ -91,30 +86,27 @@ struct ExtractionConfigTests {
         // still load, with the newer fields defaulting rather than throwing.
         let json = Data(#"{"backend":"anthropic"}"#.utf8)
         let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
-        #expect(config.backend == .anthropic)
         #expect(config.anthropicModel == ExtractionConfig.defaultAnthropicModel)
         #expect(config.anthropicBaseURLOverride == nil)
         #expect(config.geminiModel == ExtractionConfig.defaultGeminiModel)
         #expect(config.geminiBaseURLOverride == nil)
         #expect(config.doclingServeEndpoint == nil)
-        // The retired `backend` value migrates into a PDF host record.
+        // The retired `backend` key migrates into a PDF host record.
         #expect(config.extractorSelection(for: .canonicalPDF) == host("anthropic"))
     }
 
-    @Test func unknownBackendValueDegradesToLocalPdf2md() throws {
+    @Test func unknownBackendValueContributesNoRouteRecord() throws {
         // A future/typo'd backend raw value shouldn't crash the decode; it
-        // falls back to the safe local default and contributes no route
-        // record (the bundled default policy still fills the route).
+        // contributes no route record (the bundled default policy still fills
+        // the route).
         let json = Data(#"{"backend":"totally_made_up"}"#.utf8)
         let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
-        #expect(config.backend == .localPdf2md)
         #expect(config.routeExtractors.isEmpty)
     }
 
     @Test func nilFieldsRoundTripAsNil() throws {
         let dir = tempDirectory()
         let config = ExtractionConfig(
-            backend: .doclingServe,
             anthropicModel: "claude-opus-4-8",
             anthropicBaseURLOverride: nil,
             doclingServeEndpoint: nil)
@@ -145,13 +137,12 @@ struct ExtractionConfigTests {
     @Test func acpProviderIdRoundTrips() throws {
         let dir = tempDirectory()
         var config = ExtractionConfig()
-        config.backend = .acp
         config.acpProviderId = "claude-acp"
         try config.save(to: dir)
 
         let loaded = ExtractionConfig.load(from: dir)
-        // The provider id persists; the retired `backend` field does not, so
-        // the PDF route resolves through the bundled default policy.
+        // The provider id persists and the PDF route resolves through the
+        // bundled default policy.
         #expect(loaded.acpProviderId == "claude-acp")
         let pdf2md = LogicalExtractorReference(
             packageID: try ExtractorPackageID(validating: "org.selfdrivingwiki.pdf2md"),
@@ -169,7 +160,7 @@ struct ExtractionConfigTests {
 
     @Test func acpProviderIdRoundTripsNil() throws {
         let dir = tempDirectory()
-        let config = ExtractionConfig(backend: .acp, acpProviderId: nil)
+        let config = ExtractionConfig(acpProviderId: nil)
         try config.save(to: dir)
         let loaded = ExtractionConfig.load(from: dir)
         #expect(loaded.acpProviderId == nil)
@@ -188,13 +179,12 @@ struct ExtractionConfigTests {
         #expect(loaded.podcastBackend == .appleTranscript)
     }
 
-    /// The retired `htmlBackend` field is a decode-only migration input: a
+    /// The retired `htmlBackend` key is a decode-only migration input: a
     /// decode adopts it into an HTML route record, and a re-encode never
     /// writes the key again.
-    @Test func htmlBackendFieldIsDecodeOnly() throws {
+    @Test func htmlBackendKeyMigratesAndIsNotReEncoded() throws {
         let json = Data(#"{"backend":"anthropic","htmlBackend":"defuddle"}"#.utf8)
         let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
-        #expect(config.htmlBackend == .defuddle)
         #expect(config.extractorSelection(for: .canonicalHTML) == host("defuddle"))
 
         let data = try JSONEncoder().encode(config)
@@ -202,27 +192,22 @@ struct ExtractionConfigTests {
         #expect(object?["htmlBackend"] == nil)
     }
 
-    @Test func htmlAndPodcastBackendsDecodeAsNilWhenAbsent() throws {
+    @Test func podcastBackendDecodesAsNilWhenAbsent() throws {
         let json = Data(#"{"backend":"anthropic"}"#.utf8)
         let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
-        #expect(config.backend == .anthropic)
-        #expect(config.htmlBackend == nil)
         #expect(config.podcastBackend == nil)
     }
 
-    /// Unknown raw values for the retired optional fields degrade silently to
-    /// nil — symmetric with `unknownBackendValueDegradesToLocalPdf2md`: the
-    /// whole config still loads and no route record is produced.
+    /// Unknown raw values for the retired optional keys degrade silently to
+    /// nil — the whole config still loads and no route record is produced.
     @Test func unknownHtmlAndPodcastBackendValuesDegradeToNil() throws {
         let json = Data(#"""
         {"backend":"anthropic","htmlBackend":"whisper","podcastBackend":"rev_ai"}
         """#.utf8)
         let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
-        #expect(config.backend == .anthropic)
-        #expect(config.htmlBackend == nil)
         #expect(config.podcastBackend == nil)
         // The unknown HTML/podcast values contribute nothing, but the backend
-        // value still migrates into its PDF host record.
+        // key still migrates into its PDF host record.
         #expect(config.extractorSelection(for: .canonicalPDF) == host("anthropic"))
         #expect(config.extractorSelection(for: .canonicalHTML) == nil)
     }
@@ -292,7 +277,6 @@ struct ExtractionConfigTests {
     @Test func malformedLegacyKeyDegradesToNoRecord() throws {
         let json = Data(#"{"backend":"anthropic","pdfExtractor":{"kind":"future"}}"#.utf8)
         let config = try JSONDecoder().decode(ExtractionConfig.self, from: json)
-        #expect(config.backend == .anthropic)
         #expect(config.extractorSelection(for: .canonicalPDF) == host("anthropic"))
     }
 
@@ -303,20 +287,13 @@ struct ExtractionConfigTests {
             packageID: try ExtractorPackageID(validating: "org.example.html"),
             registrationID: try ExtractorRegistrationID(validating: "article"))
         let config = ExtractionConfig(
-            backend: .gemini,
             routeExtractors: [
                 .init(route: .canonicalPDF, extractor: host("acp")),
                 .init(route: .canonicalHTML, extractor: .installed(logical)),
             ])
         let data = try JSONEncoder().encode(config)
         let decoded = try JSONDecoder().decode(ExtractionConfig.self, from: data)
-        var reset = config
-        reset.backend = .localPdf2md
-        reset.htmlBackend = nil
-        #expect(decoded == reset)
-        // The retired `backend` field is not persisted, so the decode falls
-        // back to its default regardless of the in-memory value.
-        #expect(decoded.backend == .localPdf2md)
+        #expect(decoded == config)
 
         let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         #expect(object?["pdfExtractor"] == nil)
@@ -459,19 +436,16 @@ struct ExtractionConfigTests {
         #expect(config.extractorSelection(for: .canonicalPDF) == nil)
     }
 
-    /// A canonical route write touches ONLY the route table: the retired
-    /// typed fields keep whatever value they decoded with and are never
-    /// rewritten by selection writes.
+    /// A canonical route write touches ONLY the route table — no other config
+    /// field is rewritten by selection writes.
     @Test func canonicalRouteWritesTouchOnlyRouteRecords() throws {
-        var config = ExtractionConfig(backend: .anthropic, htmlBackend: .defuddle)
+        var config = ExtractionConfig()
 
         config.setExtractorSelection(host("acp"), for: .canonicalPDF)
         #expect(config.extractorSelection(for: .canonicalPDF) == host("acp"))
-        #expect(config.backend == .anthropic)
 
         config.setExtractorSelection(host("tagBased"), for: .canonicalHTML)
         #expect(config.extractorSelection(for: .canonicalHTML) == host("tagBased"))
-        #expect(config.htmlBackend == .defuddle)
 
         config.setExtractorSelection(nil, for: .canonicalPDF)
         #expect(config.extractorSelection(for: .canonicalPDF) == nil)
@@ -720,7 +694,7 @@ struct ExtractionConfigTests {
     /// The route-aware entry point agrees with the per-kind entry points on the
     /// canonical routes and declines routes without a host execution path.
     @Test func routeAwareEntryMatchesPerKindEntryPoints() throws {
-        let config = ExtractionConfig(backend: .anthropic, htmlBackend: .defuddle)
+        let config = ExtractionConfig()
         #expect(ExtractorSelectionResolver.resolve(.canonicalPDF, configuration: config, activeRegistrations: []) ==
             ExtractorSelectionResolver.resolvePDF(configuration: config, activeRegistrations: []))
         #expect(ExtractorSelectionResolver.resolve(.canonicalHTML, configuration: config, activeRegistrations: []) ==

--- a/Tests/WikiFSTests/ExtractionRuntimeFactoryTests.swift
+++ b/Tests/WikiFSTests/ExtractionRuntimeFactoryTests.swift
@@ -10,9 +10,9 @@ struct ExtractionRuntimeFactoryTests {
     @Test("shuffled registration builds a ready runtime")
     func shuffledRegistrationBuildsReadyRuntime() async throws {
         let handle = try await makeAssembly(
-            state: ExtractionRuntimeTestState(configuration: ExtractionConfig(backend: .acp)))
+            state: ExtractionRuntimeTestState(configuration: ExtractionConfig()))
             .assemble(registrationOrder: ExtractionRuntimeFactory.Component.allCases.shuffled())
-        let preparation = try await handle.services.prepare()
+        let preparation = try await handle.services.prepare(backendOverride: .acp)
 
         #expect(preparation.backend == .acp)
         #expect(preparation.extractor.displayName == "local-1")
@@ -39,15 +39,19 @@ struct ExtractionRuntimeFactoryTests {
 
     @Test("preparations freeze one configuration and later calls read updates")
     func preparationFreezesConfiguration() async throws {
-        let state = ExtractionRuntimeTestState(configuration: ExtractionConfig(backend: .anthropic))
+        // #1178: the runtime no longer derives its backend from the config, so
+        // both preparations state the backend explicitly; the frozen-vs-fresh
+        // configuration property is unchanged — each preparation snapshots the
+        // config at call time and later calls observe updates.
+        let state = ExtractionRuntimeTestState(configuration: ExtractionConfig())
         let handle = try await makeAssembly(state: state).assemble()
-        let first = try await handle.services.prepare()
+        let first = try await handle.services.prepare(backendOverride: .anthropic)
 
-        state.updateConfiguration { configuration in
-            configuration.backend = .gemini
-            configuration.geminiModel = "gemini-next"
+        state.updateConfiguration {
+            $0.anthropicModel = "claude-next"
+            $0.geminiModel = "gemini-next"
         }
-        let second = try await handle.services.prepare()
+        let second = try await handle.services.prepare(backendOverride: .gemini)
 
         #expect(first.backend == .anthropic)
         #expect(first.modelVersion == ExtractionConfig.defaultAnthropicModel)
@@ -60,7 +64,7 @@ struct ExtractionRuntimeFactoryTests {
 
     @Test("backend override builds and reports the overridden backend")
     func backendOverrideBuildsAndReportsTheOverriddenBackend() async throws {
-        let state = ExtractionRuntimeTestState(configuration: ExtractionConfig(backend: .localPdf2md))
+        let state = ExtractionRuntimeTestState(configuration: ExtractionConfig())
         state.updateConfiguration { $0.anthropicModel = "claude-override" }
         let handle = try await makeAssembly(state: state).assemble()
 
@@ -74,11 +78,11 @@ struct ExtractionRuntimeFactoryTests {
 
     @Test("each preparation constructs a distinct ACP extractor")
     func concurrentPreparationsReturnDistinctExtractorInstances() async throws {
-        let state = ExtractionRuntimeTestState(configuration: ExtractionConfig(backend: .acp))
+        let state = ExtractionRuntimeTestState(configuration: ExtractionConfig())
         let handle = try await makeAssembly(state: state).assemble()
 
-        async let first = handle.services.prepare()
-        async let second = handle.services.prepare()
+        async let first = handle.services.prepare(backendOverride: .acp)
+        async let second = handle.services.prepare(backendOverride: .acp)
         let preparations = try await [first, second]
 
         #expect(Set(preparations.map(\.extractor.displayName)).count == 2)
@@ -127,9 +131,11 @@ struct ExtractionRuntimeFactoryTests {
         ExtractionRuntimeFactory(
             readConfiguration: { state.configuration },
             readCredential: { _ in "test-secret" },
-            resolveACP: { configuration in
-                guard configuration.backend == .acp else { return nil }
-                return ExtractionRuntimeExtractor(name: state.nextExtractorName())
+            resolveACP: { _ in
+                // The resolver only runs on the `.acp` resolution path, so no
+                // backend check is needed here (#1178 removed the config field
+                // it used to compare against).
+                ExtractionRuntimeExtractor(name: state.nextExtractorName())
             },
             httpFetcher: ExtractionRuntimeHTTPFetcher())
     }

--- a/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
+++ b/Tests/WikiFSTests/ExtractorRouteTableBuilderTests.swift
@@ -79,7 +79,7 @@ struct ExtractorRouteTableBuilderTests {
     @Test func rowsSortDeterministically() throws {
         func buildInput() throws -> ExtractorRouteTableBuilder.Input {
             ExtractorRouteTableBuilder.Input(
-                configuration: ExtractionConfig(backend: .acp),
+                configuration: ExtractionConfig(),
                 registrations: [
                     try snapshot(
                         packageID: "org.example.multi",
@@ -102,7 +102,7 @@ struct ExtractorRouteTableBuilderTests {
 
     @Test func unknownMIMEUsesStableGenericLabel() throws {
         let input = ExtractorRouteTableBuilder.Input(
-            configuration: ExtractionConfig(backend: .acp),
+            configuration: ExtractionConfig(),
             registrations: [
                 try snapshot(
                     packageID: "org.example.x",
@@ -127,7 +127,7 @@ struct ExtractorRouteTableBuilderTests {
 
     @Test func multipleExactVersionsProduceOneLogicalChoice() throws {
         let input = ExtractorRouteTableBuilder.Input(
-            configuration: ExtractionConfig(backend: .acp),
+            configuration: ExtractionConfig(),
             registrations: [
                 try snapshot(
                     packageID: "org.example.pdf",
@@ -169,7 +169,7 @@ struct ExtractorRouteTableBuilderTests {
             kinds: [.pdf],
             mimeTypes: ["application/pdf"])
         let rows = ExtractorRouteTableBuilder.build(.init(
-            configuration: ExtractionConfig(backend: .acp),
+            configuration: ExtractionConfig(),
             registrations: [reviewed],
             availableRegistrations: [reviewed]))
         let pdf = try #require(rows.first { $0.route == .canonicalPDF })
@@ -196,7 +196,7 @@ struct ExtractorRouteTableBuilderTests {
             mimeTypes: ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
             extensions: ["docx"])
         let rows = ExtractorRouteTableBuilder.build(.init(
-            configuration: ExtractionConfig(backend: .acp),
+            configuration: ExtractionConfig(),
             registrations: [reviewed],
             availableRegistrations: [reviewed]))
         let docx = try #require(rows.first { $0.route == .canonicalDOCX })
@@ -219,7 +219,7 @@ struct ExtractorRouteTableBuilderTests {
         let logical = LogicalExtractorReference(
             packageID: try ExtractorPackageID(validating: "org.example.gone"),
             registrationID: try ExtractorRegistrationID(validating: "main"))
-        var config = ExtractionConfig(backend: .acp, htmlBackend: .defuddle)
+        var config = ExtractionConfig()
         config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
         config.setExtractorSelection(.installed(logical), for: .canonicalHTML)
         let rows = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
@@ -241,7 +241,7 @@ struct ExtractorRouteTableBuilderTests {
         let logical = LogicalExtractorReference(
             packageID: try ExtractorPackageID(validating: "org.example.pending"),
             registrationID: try ExtractorRegistrationID(validating: "main"))
-        var config = ExtractionConfig(backend: .acp)
+        var config = ExtractionConfig()
         config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
 
         let waiting = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
@@ -271,7 +271,7 @@ struct ExtractorRouteTableBuilderTests {
         let logical = LogicalExtractorReference(
             packageID: try ExtractorPackageID(validating: "org.example.gone"),
             registrationID: try ExtractorRegistrationID(validating: "main"))
-        var config = ExtractionConfig(backend: .acp)
+        var config = ExtractionConfig()
         config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
         let pdf = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
             configuration: config,
@@ -289,7 +289,7 @@ struct ExtractorRouteTableBuilderTests {
         let logical = LogicalExtractorReference(
             packageID: try ExtractorPackageID(validating: "org.example.mime"),
             registrationID: try ExtractorRegistrationID(validating: "main"))
-        var config = ExtractionConfig(backend: .acp)
+        var config = ExtractionConfig()
         config.setExtractorSelection(.installed(logical), for: .canonicalPDF)
         let rows = ExtractorRouteTableBuilder.build(ExtractorRouteTableBuilder.Input(
             configuration: config,
@@ -363,7 +363,7 @@ struct ExtractorRouteTableBuilderTests {
                 mimeTypes: ["text/html"]),
         ]
         let input = ExtractorRouteTableBuilder.Input(
-            configuration: ExtractionConfig(backend: .acp),
+            configuration: ExtractionConfig(),
             registrations: active,
             availableRegistrations: available)
         let rows = ExtractorRouteTableBuilder.build(input)
@@ -391,7 +391,7 @@ struct ExtractorRouteTableBuilderTests {
     /// choices never re-enter the route table.
     @Test func directModelAPIChoicesRemainAbsent() throws {
         let input = ExtractorRouteTableBuilder.Input(
-            configuration: ExtractionConfig(backend: .anthropic),
+            configuration: ExtractionConfig(),
             registrations: [])
         let rows = ExtractorRouteTableBuilder.build(input)
         for row in rows {
@@ -408,7 +408,7 @@ struct ExtractorRouteTableBuilderTests {
     /// registration-declared future route never inherits host choices.
     @Test func reviewedChoicesStayOnCanonicalRoutes() throws {
         let input = ExtractorRouteTableBuilder.Input(
-            configuration: ExtractionConfig(backend: .acp),
+            configuration: ExtractionConfig(),
             registrations: [
                 try snapshot(
                     packageID: "org.example.pdf",

--- a/progress/2026-08-30T183000Z-extraction-config-retired-fields.md
+++ b/progress/2026-08-30T183000Z-extraction-config-retired-fields.md
@@ -1,0 +1,49 @@
+---
+timestamp: 2026-08-30T183000Z
+title: ExtractionConfig retires the backend and htmlBackend stored fields
+branch: chore/remove-retired-extraction-config-fields
+status: complete
+---
+
+# ExtractionConfig retires the backend and htmlBackend stored fields
+
+Issue #1178.
+
+## Progress
+
+`ExtractionConfig` no longer stores `backend` or `htmlBackend`. The decoder
+consumes both keys as local migration values inside `init(from:)` and feeds
+them into the one-time route-record migration, so an old config file still
+resolves to the same selection it always had. Encode never wrote the keys;
+now no stored state can hold them either. A decoded-but-never-persisted
+field was a trap: a reader could see a value that the next save resets.
+
+The initializer lost its `backend:` and `htmlBackend:` parameters.
+`currentModelVersion` is deleted too — it switched on `backend` and had no
+callers left.
+
+The two test-only runtimes in `ExtractionCoordinator.swift`
+(`ExtractionRuntime` and `LegacyExtractionServices`) received their backend
+from the retired field when a caller passed no override. They now require an
+explicit `backendOverride` and fail closed with
+`ExtractionServicesError.unavailable` when none is supplied. Production is
+unchanged: `ProcessExtractionServices` resolves defaults through the route
+records, and the Extract wiring already read
+`ExtractionConfig.htmlSelectionLabel`, not the retired field.
+
+Tests that asserted `config.backend` or `config.htmlBackend` were removed or
+rewritten to assert the migration and the fail-closed contract. The
+`WikiStoreModel.htmlBackend` doc comment now names the real injection
+source (`htmlSelectionLabel`).
+
+## Verification
+
+- `rg 'htmlBackend|\.backend\b' Sources` shows no `ExtractionConfig` field
+  readers. The remaining matches are unrelated properties, Codable keys of
+  other types, and comments.
+- `make build` passes.
+- `make test` passes: 4041 tests in 430 suites.
+- `WIKIFS_APP_TESTS=1 swift test --filter ExtractionCoordinatorTests`
+  passes: 13 tests. The same run with
+  `ExtractorPackageSettingsTests|ExtractionRouteTableHostedTests` passes:
+  50 tests in 5 suites.


### PR DESCRIPTION
## What changed

Issue #1178. `ExtractionConfig` no longer stores the retired `backend` and
`htmlBackend` properties.

- `init(from:)` consumes both keys as local migration values and feeds them
  into the existing one-time route-record migration. A config file written
  by any earlier build still resolves to the same selection it always had,
  and encode still never writes the keys.
- The initializer loses its `backend:` and `htmlBackend:` parameters.
  `currentModelVersion` is deleted as well — it switched on `backend` and
  had no callers.
- The test-only runtimes in `ExtractionCoordinator.swift`
  (`ExtractionRuntime` and `LegacyExtractionServices`) used to default to
  the retired field when a caller passed no override. They now require an
  explicit `backendOverride` and fail closed with
  `ExtractionServicesError.unavailable` when none is supplied.
- Production behavior is unchanged: `ProcessExtractionServices` resolves
  defaults through the route records, and the Extract wiring already read
  `htmlSelectionLabel`, not the retired field.
- Tests that asserted `config.backend` or `config.htmlBackend` are removed
  or rewritten to assert the migration and the fail-closed contract. The
  `WikiStoreModel.htmlBackend` doc comment now names its real injection
  source.

## Why

A decoded-but-never-persisted stored property is a trap: a future reader
can see a value that resets on the next save. The route records are the
sole persisted extractor selection; keeping shadow fields invites dual
writes back in.

## Verification

- `rg 'htmlBackend|\.backend\b' Sources` shows no `ExtractionConfig` field
  readers; the remaining matches are unrelated properties, Codable keys of
  other types, and comments.
- `make build` passes.
- `make test` passes: 4041 tests in 430 suites.
- `WIKIFS_APP_TESTS=1 swift test` for the touched suites passes:
  `ExtractionCoordinatorTests` (13 tests) and
  `ExtractorPackageSettingsTests` + `ExtractionRouteTableHostedTests`
  (50 tests in 5 suites).

Note: an unrelated live-web test (`hostedYouTubeEmbedLoadsUnderRealOrigin…`
in `YouTubeEmbedWebViewTests`, opt-in app-tests target) failed in one run on
this machine — it asserts live YouTube iframe attributes over the network
and this change does not touch that path.
