### PR TITLE
refactor(extraction): centralize host adapter presentation roles in the route host catalog

### DIFF
--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -183,9 +183,9 @@ enum ExtractorRouteRecoveryPresenter {
         let logical = logicalReference(row.savedSelection)
         let requirement = matchingRequiredRequirement(logical: logical, facts: facts)
         let failure = newestFailure(logical: logical, facts: facts)
-        let isACP = row.savedSelection == ExtractorRouteHostCatalog.acpReference
-        let isDocling = row.savedSelection == .installed(ProcessExtractionServices.reviewedDoclingLogical)
-            || row.savedSelection == ExtractorRouteHostCatalog.legacyDoclingServeReference
+        let savedRole = ExtractorRouteHostCatalog.role(for: row.savedSelection)
+        let isACP = savedRole == .connectedServiceACP
+        let isDocling = savedRole == .doclingLineage
 
         let status: ExtractorRouteStatus
         if let failure {
@@ -813,8 +813,7 @@ struct ExtractionSettingsView: View {
             if case .installed(let logical) = choice.reference { return .unavailableInstalled(logical) }
             return .prompt
         case .connectedService:
-            if case .host(let host) = choice.reference,
-               host.adapterID.rawValue == ExtractionBackend.acp.rawValue {
+            if ExtractorRouteHostCatalog.role(for: choice.reference) == .connectedServiceACP {
                 return .connectedService(.acp)
             }
             return .prompt
@@ -1980,16 +1979,14 @@ enum ExtractorRouteSettingsMapping {
                 }
                 return installedSelection(logical, row: row)
             case .host(let host):
-                switch host.adapterID.rawValue {
-                case ExtractionBackend.acp.rawValue:
-                    return .connectedService(.acp)
-                case ExtractionBackend.anthropic.rawValue, ExtractionBackend.gemini.rawValue:
+                switch ExtractorRouteHostCatalog.role(forHostAdapterID: host.adapterID) {
+                case .connectedServiceACP, .retiredDirectAnthropicAPI, .retiredDirectGeminiAPI:
                     // Retired direct-API selections display as their ACP
                     // successor; execution no longer consults them.
                     return .connectedService(.acp)
-                case ExtractionBackend.doclingServe.rawValue:
+                case .doclingLineage:
                     return .reviewedDocling
-                case ExtractionBackend.localPdf2md.rawValue:
+                case .pdf2mdLineage:
                     return .reviewedPdf2md
                 default:
                     return .prompt
@@ -2011,10 +2008,10 @@ enum ExtractorRouteSettingsMapping {
                     ? .reviewedDefuddle
                     : installedSelection(logical, row: row)
             case .host(let host):
-                switch host.adapterID.rawValue {
-                case HtmlExtractionBackend.defuddle.rawValue:
+                switch ExtractorRouteHostCatalog.role(forHostAdapterID: host.adapterID) {
+                case .defuddleLineage:
                     return .reviewedDefuddle
-                case HtmlExtractionBackend.tagBased.rawValue:
+                case .builtInTagBased:
                     return .builtInTagBased
                 default:
                     return .prompt
@@ -2127,10 +2124,10 @@ enum ExtractorSettingsSelectionMapping {
         // its ACP successor's provider; every other selection keeps the
         // stored provider draft.
         if case .host(let host)? = config.selectionOrDefault(for: .canonicalPDF) {
-            switch host.adapterID.rawValue {
-            case ExtractionBackend.anthropic.rawValue:
+            switch ExtractorRouteHostCatalog.role(forHostAdapterID: host.adapterID) {
+            case .retiredDirectAnthropicAPI:
                 return claudeACPProviderID.rawValue
-            case ExtractionBackend.gemini.rawValue:
+            case .retiredDirectGeminiAPI:
                 return geminiACPProviderID.rawValue
             default:
                 break

--- a/Sources/WikiFSEngine/ExtractorRoutePresentation.swift
+++ b/Sources/WikiFSEngine/ExtractorRoutePresentation.swift
@@ -158,6 +158,31 @@ public struct ExtractorRouteSettingsRow: Hashable, Sendable, Identifiable {
     public var id: String { descriptor.route.description }
 }
 
+/// Which well-known host adapter a raw adapter ID names (#1177).
+/// `HostExtractorID` intentionally carries no enum, so this role type is the
+/// single place that assigns presentation meaning to well-known IDs: display
+/// mappings and the recovery presenter ask the catalog instead of comparing
+/// raw values. Unknown IDs resolve to nil and callers take their generic
+/// fallback path.
+public enum ExtractorRouteHostRole: Hashable, Sendable {
+    /// The connected-service ACP adapter (the host's one PDF service choice).
+    case connectedServiceACP
+    /// Retired direct-API host names. Presentation folds both into their ACP
+    /// successor; the provider picker distinguishes them to prefill the
+    /// successor's provider draft. Execution never consults them.
+    case retiredDirectAnthropicAPI
+    case retiredDirectGeminiAPI
+    /// The Docling execution family: the reviewed installed lineage or the
+    /// retired Docling Serve host name. Both present and recover identically.
+    case doclingLineage
+    /// The reviewed pdf2md lineage, named by the retired local host id.
+    case pdf2mdLineage
+    /// The reviewed Defuddle lineage, named by the retired defuddle host id.
+    case defuddleLineage
+    /// The built-in tag-based HTML adapter.
+    case builtInTagBased
+}
+
 /// Host-owned route descriptors and non-package choices for the canonical
 /// routes. Package choices come from validated catalog records.
 public enum ExtractorRouteHostCatalog {
@@ -183,6 +208,41 @@ public enum ExtractorRouteHostCatalog {
             preconditionFailure("Invalid host adapter literal: \(rawValue)")
         }
         return .host(HostExtractorReference(adapterID: adapterID))
+    }
+
+    /// The one presentation map from well-known host adapter IDs to roles
+    /// (#1177). Every "which well-known adapter is this?" question routes
+    /// through here; no caller compares raw adapter values itself. An unknown
+    /// ID resolves to nil.
+    public static func role(forHostAdapterID adapterID: HostExtractorID) -> ExtractorRouteHostRole? {
+        switch adapterID.rawValue {
+        case ExtractionBackend.acp.rawValue: return .connectedServiceACP
+        case ExtractionBackend.anthropic.rawValue: return .retiredDirectAnthropicAPI
+        case ExtractionBackend.gemini.rawValue: return .retiredDirectGeminiAPI
+        case ExtractionBackend.doclingServe.rawValue: return .doclingLineage
+        case ExtractionBackend.localPdf2md.rawValue: return .pdf2mdLineage
+        case HtmlExtractionBackend.defuddle.rawValue: return .defuddleLineage
+        case HtmlExtractionBackend.tagBased.rawValue: return .builtInTagBased
+        default: return nil
+        }
+    }
+
+    /// Presentation role for a saved selection. Host names resolve through
+    /// `role(forHostAdapterID:)`; the Docling family additionally spans
+    /// namespaces, so the reviewed installed Docling lineage reports the same
+    /// role as the retired host name (the recovery presenter treats both as
+    /// one execution family). Every other reference — installed lineages and
+    /// the explicit no-default record — resolves to nil so callers take their
+    /// generic paths.
+    public static func role(for reference: ExtractionBackendReference?) -> ExtractorRouteHostRole? {
+        switch reference {
+        case .host(let host):
+            return role(forHostAdapterID: host.adapterID)
+        case .installed(let logical) where logical == ProcessExtractionServices.reviewedDoclingLogical:
+            return .doclingLineage
+        default:
+            return nil
+        }
     }
 
     /// Canonical routes in host display order (PDF first, then HTML, then

--- a/Tests/WikiFSTests/ExtractorRouteHostCatalogTests.swift
+++ b/Tests/WikiFSTests/ExtractorRouteHostCatalogTests.swift
@@ -1,0 +1,39 @@
+#if os(macOS)
+import Testing
+@testable import WikiFSCore
+@testable import WikiFSEngine
+
+/// #1177: the host catalog is the single presentation map from well-known
+/// adapter IDs to roles. Unknown IDs and non-host references resolve to nil
+/// so callers take their generic fallback paths; the Docling family is the
+/// one cross-namespace exception (retired host name and reviewed installed
+/// lineage present identically).
+@Suite("Extractor route host catalog presentation roles")
+struct ExtractorRouteHostCatalogTests {
+    @Test func wellKnownAdapterIDsMapToRoles() {
+        func role(_ rawValue: String) -> ExtractorRouteHostRole? {
+            ExtractorRouteHostCatalog.role(for: ExtractorRouteHostCatalog.hostReference(rawValue))
+        }
+
+        #expect(role("acp") == .connectedServiceACP)
+        #expect(role("anthropic") == .retiredDirectAnthropicAPI)
+        #expect(role("gemini") == .retiredDirectGeminiAPI)
+        #expect(role("doclingServe") == .doclingLineage)
+        #expect(role("localPdf2md") == .pdf2mdLineage)
+        #expect(role("defuddle") == .defuddleLineage)
+        #expect(role("tagBased") == .builtInTagBased)
+        #expect(role("future-adapter") == nil)
+    }
+
+    @Test func doclingFamilySpansNamespaces() {
+        #expect(ExtractorRouteHostCatalog.role(for: ExtractorRouteHostCatalog.legacyDoclingServeReference) == .doclingLineage)
+        #expect(ExtractorRouteHostCatalog.role(for: .installed(ProcessExtractionServices.reviewedDoclingLogical)) == .doclingLineage)
+    }
+
+    @Test func otherReferencesResolveToNil() {
+        #expect(ExtractorRouteHostCatalog.role(for: nil) == nil)
+        #expect(ExtractorRouteHostCatalog.role(for: ExtractionBackendReference.none) == nil)
+        #expect(ExtractorRouteHostCatalog.role(for: .installed(ProcessExtractionServices.reviewedPDFLogical)) == nil)
+    }
+}
+#endif

--- a/progress/2026-08-30T164500Z-host-adapter-presentation-roles.md
+++ b/progress/2026-08-30T164500Z-host-adapter-presentation-roles.md
@@ -1,0 +1,51 @@
+---
+timestamp: 2026-08-30T164500Z
+title: Host adapter presentation roles centralize in ExtractorRouteHostCatalog
+branch: feature/centralize-host-adapter-presentation
+status: complete
+---
+
+# Host adapter presentation roles centralize in ExtractorRouteHostCatalog
+
+Issue #1177.
+
+## Progress
+
+`ExtractorRouteHostCatalog` now owns the single map from well-known host
+adapter IDs to presentation meaning. The new `ExtractorRouteHostRole` enum
+names the roles: the connected-service ACP adapter, the retired direct-API
+names (anthropic and gemini stay distinct so the provider picker can prefill
+the right successor), the Docling family, the pdf2md and Defuddle lineages,
+and the built-in tag-based HTML adapter. `role(forHostAdapterID:)` maps raw
+IDs; `role(for:)` maps a saved selection, folding the Docling family across
+namespaces (the retired host name and the reviewed installed lineage report
+the same role). Unknown IDs and other references resolve to nil.
+
+Five call sites in `ExtractionSettingsView.swift` had re-derived "which
+well-known adapter is this?" from raw values: the connected-service tag in
+`selection(for:)`, the PDF and HTML branches of
+`ExtractorRouteSettingsMapping.selection`, the ACP provider prefill, and the
+recovery presenter's `isACP` / `isDocling`. All five now ask the catalog.
+Display and recovery behavior is unchanged.
+
+Engine-side registry keys (`ExtractionPlugins`, `ProcessExtractionServices`)
+still construct `ExtractionBackendKey` literals — that is execution wiring,
+not presentation. `ExtractorRouteDefaults.htmlSelectionLabel` in WikiFSCore
+also compares adapter IDs; it cannot use the engine catalog because
+WikiFSCore sits below WikiFSEngine. Both stay as they are.
+
+## Verification
+
+- `rg` over `Sources/WikiFS` shows no raw-value comparisons against
+  well-known adapter IDs outside the catalog.
+- `make build` passes.
+- `make test` passes: 4044 tests in 431 suites. Two earlier runs each hit
+  one unrelated transient failure in live-process suites (a full rerun with
+  no code change passed; the repo keeps
+  `scripts/test-with-watchdog.sh` for exactly this).
+- `WIKIFS_APP_TESTS=1 swift test --filter "ExtractorPackageSettingsTests|
+  ExtractionRouteTableHostedTests"` passes: 37 tests in 4 suites, including
+  the recovery presenter and route diagnostics suites.
+- New `ExtractorRouteHostCatalogTests` pins the role map: well-known IDs,
+  the cross-namespace Docling family, and nil for unknown IDs and other
+  references.


### PR DESCRIPTION
## What changed

Issue #1177. `ExtractorRouteHostCatalog` now owns the single presentation
map from well-known host adapter IDs to meaning.

- New engine-owned `ExtractorRouteHostRole` enum: the connected-service ACP
  adapter, the retired direct-API names (anthropic and gemini stay distinct
  so the provider picker prefills the right successor), the Docling family,
  the pdf2md and Defuddle lineages, and the built-in tag-based HTML adapter.
- `role(forHostAdapterID:)` maps raw adapter IDs; `role(for:)` maps a saved
  selection and folds the Docling family across namespaces (the retired host
  name and the reviewed installed lineage report the same role). Unknown IDs
  and every other reference resolve to nil.
- Five call sites in `ExtractionSettingsView.swift` that re-derived "which
  well-known adapter is this?" from raw values now ask the catalog: the
  connected-service tag in `selection(for:)`, the PDF and HTML branches of
  `ExtractorRouteSettingsMapping.selection`, the ACP provider prefill, and
  the recovery presenter's `isACP` / `isDocling`.
- New `ExtractorRouteHostCatalogTests` pins the map.

## Why

`HostExtractorID` intentionally carries no enum, so "which well-known
adapter is this?" kept being re-derived from raw strings at each site.
Adding an adapter meant finding and updating every comparison. One map in
the catalog makes that a single-case change.

## Behavior

Unchanged. Every rewritten switch arm maps to the same display selection or
recovery flag as before, including the retired direct-API → ACP fold and
the exact-`acp` (not retired) `isACP` match. The suites that pin these
paths — "Extractor route recovery presenter", "Extractor route
diagnostics", `ExtractorPackageSettingsTests`, `ExtractionRouteTableHostedTests`
— pass untouched.

## Verification

- `rg` over `Sources/WikiFS`: no raw-value comparisons against well-known
  adapter IDs remain outside the catalog.
- `make build` passes.
- `make test` passes: 4044 tests in 431 suites. (Two earlier runs each hit
  one unrelated transient failure in live-process suites; a rerun with no
  code change passed. The repo keeps `scripts/test-with-watchdog.sh` for
  exactly this class of flake.)
- `WIKIFS_APP_TESTS=1 swift test --filter "ExtractorPackageSettingsTests|
  ExtractionRouteTableHostedTests"` passes: 37 tests in 4 suites.

## Out of scope

Engine-side registry keys (`ExtractionPlugins`, `ProcessExtractionServices`)
still construct `ExtractionBackendKey` literals — execution wiring, not
presentation. `ExtractorRouteDefaults.htmlSelectionLabel` in WikiFSCore
also compares adapter IDs but cannot use the engine catalog (WikiFSCore
sits below WikiFSEngine). Both intentionally stay.
