### PR TITLE
fix(d2): give the package version an identity independent of upstream

### DIFF
--- a/Tests/WikiFSAppTests/PackageFenceReaderPlanTests.swift
+++ b/Tests/WikiFSAppTests/PackageFenceReaderPlanTests.swift
@@ -56,7 +56,7 @@ struct PackageFenceReaderPlanTests {
             options: Self.options(claims: claims))
 
         #expect(html.contains("sdw-renderer-card"))
-        #expect(html.contains("data-renderer-reference=\"org.selfdrivingwiki.d2-readonly/0.8.2/d2\""))
+        #expect(html.contains("data-renderer-reference=\"org.selfdrivingwiki.d2-readonly/1.0.0/d2\""))
         #expect(html.contains("aria-label=\"D2 renderer\""))
         // Derived presentation: display name, not a per-format host string.
         #expect(html.contains("D2 fence"))

--- a/Tests/WikiFSAppTests/PackageFenceTestSupport.swift
+++ b/Tests/WikiFSAppTests/PackageFenceTestSupport.swift
@@ -55,7 +55,7 @@ enum PackageFenceTestSupport {
         return try! RendererDescriptor(
             reference: RendererReference(
                 packageID: RendererPackageID(rawValue: "org.selfdrivingwiki.d2-readonly")!,
-                version: RendererPackageVersion(rawValue: "0.8.2")!,
+                version: RendererPackageVersion(rawValue: "1.0.0")!,
                 registrationID: RendererRegistrationID(rawValue: "d2")!),
             displayName: "D2",
             implementation: .webPackage(.init(path: asset.path)),

--- a/Tests/WikiFSTests/D2PackageFixtures.swift
+++ b/Tests/WikiFSTests/D2PackageFixtures.swift
@@ -6,7 +6,11 @@ import Foundation
 /// cross-checks the two.
 enum D2PackageFixtures {
     static let packageID = "org.selfdrivingwiki.d2-readonly"
-    static let packageVersion = "0.8.2"
+    /// The package's own identity, which advances independently of upstream D2.
+    /// A package-only change (new wrapper bytes, a new manifest claim) has to
+    /// take a new version: the machine store reserves package/version -> hash
+    /// permanently, so re-importing changed bytes under a used version fails.
+    static let packageVersion = "1.0.0"
     static let upstreamVersion = "0.8.2"
     static let registrationID = "d2"
     static let displayName = "D2"

--- a/Tests/WikiFSTests/D2PackageLockTests.swift
+++ b/Tests/WikiFSTests/D2PackageLockTests.swift
@@ -51,9 +51,13 @@ struct D2PackageLockTests {
         #expect(package["registrationID"] as? String == D2PackageFixtures.registrationID)
         #expect(package["displayName"] as? String == D2PackageFixtures.displayName)
         #expect(package["priority"] as? Int == D2PackageFixtures.priority)
-        // Upstream and package versions move together: a regeneration bump is
-        // an explicit lock edit, never a silent drift.
-        #expect(package["version"] as? String == D2PackageFixtures.upstreamVersion)
+        // No assertion ties the package version to the upstream version. The
+        // package version is package identity: it has to advance on a
+        // package-only change (new wrapper bytes, a new manifest claim),
+        // because the machine store reserves package/version -> hash
+        // permanently and changed bytes under a used version cannot install.
+        // The two may coincide by chance; requiring either equality or
+        // inequality would be a false constraint.
         let sizeLimits = try #require(package["sizeLimits"] as? [String: Any])
         #expect(sizeLimits["maximumInputByteCount"] as? Int == D2PackageFixtures.maximumInputByteCount)
         let capabilities = try #require(package["capabilities"] as? [String])

--- a/docs/skills/renderer-package-maintainer/SKILL.md
+++ b/docs/skills/renderer-package-maintainer/SKILL.md
@@ -10,7 +10,12 @@ Read [the current package guide](references/current-package-guide.md) before you
 ## Create a package
 
 1. Copy [`assets/minimal-renderer-package/`](assets/minimal-renderer-package/) to the requested local destination.
-2. Choose valid package, version, and registration identifiers.
+2. Choose valid package, version, and registration identifiers. The package
+   version is package identity. Do not tie it to an upstream project version.
+   Bump it whenever the package bytes change. The machine store reserves
+   package version to package hash permanently, and removal keeps the
+   reservation, so changed bytes under an already-used version can never
+   install.
 3. Add only static assets.
 4. Declare every asset in `manifest.json`.
 5. Choose bounded matchers, capabilities, limits, link policy, accessibility values, compatibility, and priority.

--- a/plans/d2-renderer-package.md
+++ b/plans/d2-renderer-package.md
@@ -48,8 +48,18 @@ No D2-specific branch exists anywhere in `Sources/`.
 
 ## Package identity and shape
 
-- packageID `org.selfdrivingwiki.d2-readonly`, version `0.8.2` (mirrors
-  upstream), registrationID `d2`, revision 2 manifest.
+- packageID `org.selfdrivingwiki.d2-readonly`, version `1.0.0`, registrationID
+  `d2`, revision 2 manifest.
+- **The package version is package identity. It does not mirror upstream D2.**
+  The lock keeps the two apart (`package.version` and `upstream.version`), and
+  the package version must advance on any package-only change — new wrapper
+  bytes, a new manifest claim — even when upstream D2 does not move. The
+  machine store reserves package/version to package hash permanently in
+  `renderer_machine_expected_hash_reservations`, and removal keeps that
+  reservation. Changed bytes under an already-used version therefore fail to
+  install with `conflictingExpectedHash`. The package first shipped as `0.8.2`,
+  mirroring upstream. Adding the `d2` fence claim changed the manifest bytes
+  with no upstream change, so it had nowhere to go. The version became `1.0.0`.
 - matchers: `extensionFallback("d2")` only — D2 has no registered MIME type
   and no magic bytes; a MIME claim like `text/plain` would annex every
   plain-text source.

--- a/tools/d2/d2-package.lock.json
+++ b/tools/d2/d2-package.lock.json
@@ -15,7 +15,7 @@
   },
   "expectedAssets": {
     "LICENSE.txt": "3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04",
-    "PROVENANCE.md": "d3c53780734a298eb8094bc856db0fd6d702b7c2e12dde63a13367741491f393",
+    "PROVENANCE.md": "bd6d04dad4ceb82711bae0b56fefcaeead444d133c69618482e9955b55975a35",
     "THIRD_PARTY_NOTICES.txt": "d128e1ebb801393576c26dc2f83b9c7514eda1cae26b660f759c896bc2ef43a9",
     "d2-viewer.js": "5d3348333352e98220c542986365556f1bb18551c5c3750311590c65be33c518",
     "d2.wasm": "bd11a89bc22d37788d8befabbf0dcbfec640257e69570c600d130a74a4289ac9",
@@ -53,7 +53,7 @@
     "supportedEmbeddingRoles": [
       "disclosureRow"
     ],
-    "version": "0.8.2"
+    "version": "1.0.0"
   },
   "upstream": {
     "commit": "1c0d93ba1abffe0d425d45d5c037d9474807e4f5",


### PR DESCRIPTION
## The problem

The D2 renderer package cannot install after the fence-claim work in #1188. The import fails, and the app reports only "the renderer package could not be validated or installed".

The machine store reserves package version to package hash permanently in `renderer_machine_expected_hash_reservations`. `remove()` keeps that reservation on purpose, so changed bytes can never claim a version the machine trusted before:

```swift
/// Hash reservations are append-only authority: removing an index row must
/// not permit a different payload to claim the same package/version later.
```

The D2 lock set the package version to `0.8.2` to mirror upstream D2. Adding the `d2` fence claim changed the manifest bytes with no upstream change, so the new bytes had no version to occupy. Activation throws `conflictingExpectedHash`. Removing the package first does not help, because the tombstone keeps the reservation.

## The change

The package version is now `1.0.0` and moves on its own. `upstream.version` still records `0.8.2`. The source tarball, commit, build recipe, and every build artifact digest are unchanged. Bundled Excalidraw already versions this way.

The lock diff is the provenance record. It is two lines: the package version, and the `PROVENANCE.md` digest, which renders that version. `d2.wasm`, `d2-viewer.js`, `wasm_exec.js`, and the license digests all stay the same, which shows the build did not move.

`D2PackageLockTests` asserted that the package version equals the upstream version, with the comment "Upstream and package versions move together". That assertion held the constraint that made the fence claim unshippable, so this removes it. It adds no inverse assertion, because the two versions may coincide by chance.

The maintainer skill now warns package authors that the version is package identity and that removal does not free a reservation. `docs/user-guide/renderer-packages.md` already carried the rule that claims must bump the version. The D2 lock predates fence claims and never followed it.

## Verification

| Suite | Result |
| --- | --- |
| D2 lock, generated-package validation, viewer template, matching, neutrality | 22 tests in 5 suites passed |
| Package fence claim registry, manifest, admission | 21 tests in 3 suites passed |
| `PackageFenceReaderPlanTests` (`WIKIFS_APP_TESTS=1`) | 10 tests in 1 suite passed |
| Full suite before the change | 4111 tests in 441 suites passed |

`make d2-renderer-package` regenerates and `RendererPackageTool validate` accepts the result at `1.0.0` with the `d2` claim.

## Not included

The typed error stays swallowed. `InstalledRendererHost.installRendererDirectory` catches the error and logs a generic line, so `conflictingExpectedHash` looks the same as a malformed manifest. That cost the diagnosis here. It is worth a separate change.

Note that #1185 is stale. Its branch content already landed in main through the squash merge #1188, and it now reports `CONFLICTING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DBEeH4jBa3avXvKnzf8CEf