### PR TITLE
refactor(settings): renderer package table with inline diagnostics

### DIFF
--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -9,12 +9,114 @@ import WikiFSTypes
 
 // pattern: Functional Core
 
+/// What one installed package version can do right now, derived from the
+/// machine record instead of stored as a cluster of flags. The machine index
+/// keeps the lifecycle state, the safe-mode suppression, and a closed redacted
+/// diagnostic as three separate fields; settings has to present one answer, so
+/// this enum resolves them in precedence order once and every column, tint, and
+/// explanation reads from it.
+enum RendererPackageStatus: Hashable {
+    case available
+    case superseded
+    case safeModeSuppressed
+    /// The record exists but never became renderable. The associated value is
+    /// the machine index's closed diagnostic, which may be absent on an
+    /// unvalidated reservation that has not failed yet.
+    case unavailable(RendererPackageInstallDiagnostic?)
+
+    static func resolve(_ record: RendererPackageInstallRecord) -> RendererPackageStatus {
+        switch record.state {
+        case .unvalidated, .quarantined, .removed:
+            return .unavailable(record.diagnostic)
+        case .validated, .superseded:
+            if record.isSafeModeSuppressed { return .safeModeSuppressed }
+            return record.state == .superseded ? .superseded : .available
+        }
+    }
+
+    /// The short Status column label. It never wraps, so the icon carries the
+    /// state and the sentence lives in ``explanation``.
+    var label: String {
+        switch self {
+        case .available: "Available"
+        case .superseded: "Superseded"
+        case .safeModeSuppressed: "Safe mode"
+        case .unavailable: "Unavailable"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .available: "checkmark.circle.fill"
+        case .superseded: "clock.arrow.circlepath"
+        case .safeModeSuppressed: "exclamationmark.shield.fill"
+        case .unavailable: "xmark.octagon.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .available: .green
+        case .superseded: .secondary
+        case .safeModeSuppressed: .orange
+        case .unavailable: .red
+        }
+    }
+
+    /// The inline diagnostic sentence shown with the package it belongs to.
+    var explanation: String {
+        switch self {
+        case .available:
+            "This version is validated. Every wiki on this Mac can use it."
+        case .superseded:
+            "A newer version is installed. This version stays available for rollback."
+        case .safeModeSuppressed:
+            "A renderer failure suppressed this exact version. Reset safe mode to use it again."
+        case .unavailable(let diagnostic):
+            switch diagnostic {
+            case .packageValidationFailed:
+                "Validation rejected this version, so it never became available."
+            case .packageQuarantined:
+                "This version is quarantined and cannot render."
+            case .packageRemoved:
+                "This version was removed from this Mac."
+            case .indexConsistencyFailure:
+                "The machine index is inconsistent for this version. Refresh the registry."
+            case nil:
+                "This version is not validated yet, so it cannot render."
+            }
+        }
+    }
+}
+
 struct RendererSettingsRow: Identifiable, Hashable {
     let record: RendererPackageInstallRecord
     let displayName: String
     let registrations: [String]
+    let status: RendererPackageStatus
 
     var id: String { "\(record.packageID.rawValue)@\(record.version.rawValue)" }
+}
+
+/// Where a settings outcome belongs. A package-scoped outcome renders with the
+/// row it describes; the pane scope is for outcomes no installed row owns — an
+/// import that never produced a record, or a removal whose row is now gone.
+enum RendererSettingsNoticeScope: Hashable {
+    case pane
+    case package(RendererSettingsRow.ID)
+}
+
+/// One settings outcome, kept scoped so the message can render next to the
+/// package it is about rather than in a shared diagnostics section.
+struct RendererSettingsNotice: Hashable {
+    enum Severity: Hashable {
+        case success
+        case failure
+    }
+
+    let severity: Severity
+    let message: String
+    let scope: RendererSettingsNoticeScope
 }
 
 /// Settings-facing adapter for machine package management and source-specific
@@ -25,13 +127,27 @@ struct RendererSettingsRow: Identifiable, Hashable {
 @MainActor
 @Observable
 final class RendererSettingsModel {
+    static let installFailureMessage = "The renderer package could not be validated or installed."
+
     let host: InstalledRendererHost
     private(set) var wiki: WikiStoreModel?
 
     private(set) var rows: [RendererSettingsRow] = []
     private(set) var isBusy = false
-    private(set) var diagnostic: String?
-    private(set) var lastError: String?
+    /// The single latest outcome. Severity and scope are derived from it rather
+    /// than tracked as parallel fields, so an error can never outlive the
+    /// success that replaced it.
+    private(set) var notice: RendererSettingsNotice?
+
+    var diagnostic: String? {
+        guard let notice, notice.severity == .success else { return nil }
+        return notice.message
+    }
+
+    var lastError: String? {
+        guard let notice, notice.severity == .failure else { return nil }
+        return notice.message
+    }
 
     init(host: InstalledRendererHost, wiki: WikiStoreModel?) {
         self.host = host
@@ -48,8 +164,19 @@ final class RendererSettingsModel {
         rebuildRows()
     }
 
+    func notice(for row: RendererSettingsRow) -> RendererSettingsNotice? {
+        guard let notice, notice.scope == .package(row.id) else { return nil }
+        return notice
+    }
+
+    var paneNotice: RendererSettingsNotice? {
+        guard let notice, notice.scope == .pane else { return nil }
+        return notice
+    }
+
     func refresh() async {
         isBusy = true
+        notice = nil
         defer { isBusy = false }
         await host.refresh()
         rebuildRows()
@@ -57,44 +184,68 @@ final class RendererSettingsModel {
 
     func install(directory: URL) async {
         isBusy = true
-        lastError = nil
+        notice = nil
         defer { isBusy = false }
+        let known = Set(rows.map(\.id))
         guard await host.installRendererDirectory(directory) else {
-            lastError = "The renderer package could not be validated or installed."
+            notice = RendererSettingsNotice(
+                severity: .failure,
+                message: Self.installFailureMessage,
+                scope: .pane)
             return
         }
-        diagnostic = "Renderer registry refreshed after installation."
         rebuildRows()
+        // Scope the success to the row the import produced so the confirmation
+        // lands on the new package. An import that replaced nothing visible
+        // falls back to the pane.
+        let added = rows.map(\.id).filter { known.contains($0) == false }
+        notice = RendererSettingsNotice(
+            severity: .success,
+            message: "Renderer registry refreshed after installation.",
+            scope: added.count == 1 ? .package(added[0]) : .pane)
     }
 
     func remove(_ row: RendererSettingsRow) async {
         isBusy = true
-        lastError = nil
+        notice = nil
         defer { isBusy = false }
         guard await host.removeRenderer(packageID: row.record.packageID, version: row.record.version) else {
-            lastError = "The renderer version could not be removed."
+            notice = RendererSettingsNotice(
+                severity: .failure,
+                message: "The renderer version could not be removed.",
+                scope: .package(row.id))
             return
         }
-        diagnostic = "Removed \(row.record.packageID.rawValue) \(row.record.version.rawValue). Source data and wiki preferences were preserved."
         rebuildRows()
+        // The row this described is gone, so the confirmation belongs to the pane.
+        notice = RendererSettingsNotice(
+            severity: .success,
+            message: "Removed \(row.displayName) \(row.record.version.rawValue). Source data and wiki preferences were preserved.",
+            scope: .pane)
     }
 
     func resetSafeMode(_ row: RendererSettingsRow) async {
         isBusy = true
-        lastError = nil
+        notice = nil
         defer { isBusy = false }
         guard await host.resetInstalledRendererSafeMode(
             packageID: row.record.packageID,
             version: row.record.version) else {
-            lastError = "Safe-mode reset was rejected."
+            notice = RendererSettingsNotice(
+                severity: .failure,
+                message: "Safe-mode reset was rejected.",
+                scope: .package(row.id))
             return
         }
-        diagnostic = "Safe mode reset for \(row.record.packageID.rawValue) \(row.record.version.rawValue)."
         rebuildRows()
+        notice = RendererSettingsNotice(
+            severity: .success,
+            message: "Safe mode reset. This version can render again.",
+            scope: .package(row.id))
     }
 
     func report(error: String) {
-        lastError = error
+        notice = RendererSettingsNotice(severity: .failure, message: error, scope: .pane)
     }
 
     /// Version selection is an exact preference on a source. This keeps
@@ -102,13 +253,36 @@ final class RendererSettingsModel {
     /// machine registry or replacing an active pane pin.
     func selectVersion(_ descriptor: RendererDescriptor, for source: SourceID) {
         guard let wiki else {
-            lastError = "Open a wiki before selecting a renderer version."
+            notice = RendererSettingsNotice(
+                severity: .failure,
+                message: "Open a wiki before selecting a renderer version.",
+                scope: .pane)
             return
         }
         wiki.setRendererSourcePreference(
             sourceID: source,
             preference: .exact(descriptor.reference))
-        diagnostic = "Selected \(descriptor.displayName) \(descriptor.reference.version.rawValue) for this source."
+        notice = RendererSettingsNotice(
+            severity: .success,
+            message: "Selected \(descriptor.displayName) \(descriptor.reference.version.rawValue) for this source.",
+            scope: .pane)
+    }
+
+    /// Clearing the preference returns the source to automatic resolution. It
+    /// is a distinct operation from pinning, not a pin to a sentinel version.
+    func clearVersionSelection(for source: SourceID) {
+        guard let wiki else {
+            notice = RendererSettingsNotice(
+                severity: .failure,
+                message: "Open a wiki before selecting a renderer version.",
+                scope: .pane)
+            return
+        }
+        wiki.removeRendererSourcePreference(sourceID: source)
+        notice = RendererSettingsNotice(
+            severity: .success,
+            message: "This source now uses the automatically resolved renderer.",
+            scope: .pane)
     }
 
     func descriptors(for row: RendererSettingsRow) -> [RendererDescriptor] {
@@ -117,27 +291,49 @@ final class RendererSettingsModel {
             .validatedDescriptors ?? []
     }
 
+    /// Every renderer a source can be pinned to. Only validated records project
+    /// descriptors, so an unavailable package cannot become a pinned choice.
+    var selectableDescriptors: [RendererDescriptor] {
+        rows.filter { $0.record.state == .validated }.flatMap { descriptors(for: $0) }
+    }
+
+    /// Every package version the machine index still holds, except removal
+    /// tombstones. Unavailable versions stay in the table on purpose: their
+    /// status is the only place a quarantine or a validation failure is
+    /// explained to the user.
     private func rebuildRows() {
         rows = (host.machineIndex?.records ?? [])
-            .filter { $0.state == .validated }
+            .filter { $0.state != .removed }
             .sorted()
             .map { record in
                 let descriptor = record.validatedDescriptors.first
                 return RendererSettingsRow(
                     record: record,
                     displayName: descriptor?.displayName ?? record.packageID.rawValue,
-                    registrations: record.validatedDescriptors.map { $0.reference.registrationID.rawValue })
+                    registrations: record.validatedDescriptors.map { $0.reference.registrationID.rawValue },
+                    status: .resolve(record))
             }
     }
 }
 
 struct RendererSettingsView: View {
+    private enum Metrics {
+        /// Four columns (Package 160+, Version 80+, Renders 120+, Status 110+)
+        /// need room for roughly five rows before the table scrolls internally,
+        /// so the Settings window never grows with the package count.
+        static let tableHeight: CGFloat = 168
+        static let detailSpacing: CGFloat = 6
+        static let sectionSpacing: CGFloat = 10
+        static let actionBarSpacing: CGFloat = 6
+    }
+
     private let wiki: WikiStoreModel?
     private let wikiID: WikiID?
     @State private var model: RendererSettingsModel
     @State private var showingPackageHelp = false
     @State private var showingPicker = false
     @State private var removalCandidate: RendererSettingsRow?
+    @State private var selectedPackageID: RendererSettingsRow.ID?
     @State private var selectedSourceID: SourceID?
 
     init(host: InstalledRendererHost, wiki: WikiStoreModel?, wikiID: WikiID?) {
@@ -146,48 +342,27 @@ struct RendererSettingsView: View {
         _model = State(initialValue: RendererSettingsModel(host: host, wiki: wiki))
     }
 
+    private var selectedRow: RendererSettingsRow? {
+        model.rows.first { $0.id == selectedPackageID }
+    }
+
     var body: some View {
         @Bindable var model = model
         Form {
             Section {
-                RendererPackageHelpControl(isPresented: $showingPackageHelp)
-                DisclosureGroup("Advanced Local Renderer Package Import") {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(RendererSettingsPackagePicker.localImportSourceMessage)
-                        Text(RendererSettingsPackagePicker.localImportStorageMessage)
-                        Text(RendererSettingsPackagePicker.localImportAfterMessage)
-                        Text("Files and archives are not supported.")
-                        Button(RendererSettingsPackagePicker.importButtonTitle, systemImage: "square.and.arrow.down") {
-                            showingPicker = true
-                        }
-                        .disabled(model.isBusy)
-                    }
-                }
-                .accessibilityLabel("Advanced local renderer package import")
-                Button("Refresh Registry", systemImage: "arrow.clockwise") {
-                    Task { await model.refresh() }
-                }
-                .disabled(model.isBusy)
-                if model.isBusy {
-                    ProgressView("Updating renderer packages…")
-                        .controlSize(.small)
-                        .accessibilityLabel("Updating renderer packages")
-                        .accessibilityAddTraits(.updatesFrequently)
-                }
+                packageTable
             } header: {
-                Text("Package Management")
-            }
-
-            Section {
-                if model.rows.isEmpty {
-                    ContentUnavailableView("No renderer packages are installed on this Mac.", systemImage: "square.stack.3d.up.slash")
-                } else {
-                    ForEach(model.rows) { row in
-                        rendererRow(row, model: model)
-                    }
+                HStack {
+                    Text("Installed on This Mac")
+                    Spacer()
+                    RendererPackageHelpControl(isPresented: $showingPackageHelp)
+                        .buttonStyle(.borderless)
+                        .labelStyle(.iconOnly)
                 }
-            } header: {
-                Text("Installed on This Mac")
+            } footer: {
+                Text("\(RendererSettingsPackagePicker.localImportSourceMessage) \(RendererSettingsPackagePicker.localImportStorageMessage) \(RendererSettingsPackagePicker.localImportAfterMessage)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section {
@@ -205,25 +380,6 @@ struct RendererSettingsView: View {
             } header: {
                 Text("Source Renderer Preferences")
             }
-
-            if let diagnostic = model.diagnostic {
-                Section("Diagnostics") {
-                    DisclosureGroup("Latest renderer diagnostic") {
-                        Text(diagnostic)
-                            .font(.body)
-                            .textSelection(.enabled)
-                    }
-                }
-            }
-            if let error = model.lastError {
-                Section {
-                        Label(error, systemImage: "exclamationmark.triangle")
-                            .foregroundStyle(.red)
-                            .accessibilityLabel("Renderer management unavailable. \(error)")
-                } header: {
-                    Text("Renderer management unavailable")
-                }
-            }
         }
         .formStyle(.grouped)
         .padding()
@@ -231,15 +387,24 @@ struct RendererSettingsView: View {
             model.updateWiki(wiki)
             selectedSourceID = wiki?.sources.first?.id
             await model.refresh()
+            selectFirstPackageIfNeeded()
+        }
+        .onChange(of: model.rows) { _, _ in
+            selectFirstPackageIfNeeded()
+        }
+        // An outcome that belongs to one package selects it, so its inline
+        // diagnostic is the one on screen when the message appears.
+        .onChange(of: model.notice) { _, notice in
+            if case .package(let id) = notice?.scope {
+                selectedPackageID = id
+            }
+            if let notice, notice.severity == .failure {
+                announceAccessibility(notice.message)
+            }
         }
         .onChange(of: model.isBusy) { _, isBusy in
             if isBusy {
                 announceAccessibility("Updating renderer packages")
-            }
-        }
-        .onChange(of: model.lastError) { _, error in
-            if let error {
-                announceAccessibility("Renderer management unavailable. \(error)")
             }
         }
         .onChange(of: showingPicker) { _, isPresented in
@@ -272,40 +437,158 @@ struct RendererSettingsView: View {
             }
     }
 
+    // MARK: - Installed package table
+
+    /// The package table, its add/remove bar, and the inline detail for the
+    /// selected package. The table takes a fixed height and scrolls internally
+    /// so a machine with many installed versions cannot stretch the Settings
+    /// window.
     @ViewBuilder
-    private func rendererRow(_ row: RendererSettingsRow, model: RendererSettingsModel) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                VStack(alignment: .leading) {
-                    Text(row.displayName).font(.headline)
-                    Text("Version \(row.record.version.rawValue)").foregroundStyle(.secondary)
+    private var packageTable: some View {
+        VStack(alignment: .leading, spacing: Metrics.sectionSpacing) {
+            Table(model.rows, selection: $selectedPackageID) {
+                TableColumn("Package") { (row: RendererSettingsRow) in
+                    Text(row.displayName)
+                        .help(row.record.packageID.rawValue)
                 }
-                Spacer()
-                Text(row.record.state == .validated ? "Validated" : row.record.state.rawValue.capitalized)
-                    .foregroundStyle(row.record.state == .validated ? .green : .secondary)
-            }
-            if row.registrations.isEmpty == false {
-                Text("Registrations: \(row.registrations.joined(separator: ", "))")
-                    .font(.body)
-                    .foregroundStyle(.secondary)
-            }
-            HStack {
-                if row.record.isSafeModeSuppressed {
-                    Button("Reset Safe Mode") { Task { await model.resetSafeMode(row) } }
-                        .accessibilityLabel("Reset safe mode for \(row.displayName)")
+                .width(min: 160, ideal: 220)
+                TableColumn("Version") { (row: RendererSettingsRow) in
+                    Text(row.record.version.rawValue)
+                        .monospacedDigit()
                 }
-                Spacer()
-                Button("Remove", role: .destructive) { removalCandidate = row }
-                    .disabled(model.isBusy)
+                .width(min: 80, ideal: 90)
+                TableColumn("Renders") { (row: RendererSettingsRow) in
+                    Text(row.registrations.isEmpty ? "—" : row.registrations.joined(separator: ", "))
+                        .foregroundStyle(.secondary)
+                }
+                .width(min: 120, ideal: 160)
+                // The status is the row's own diagnostic in short form: the
+                // icon carries the state, and the full sentence renders in the
+                // detail below the table.
+                TableColumn("Status") { (row: RendererSettingsRow) in
+                    Label(row.status.label, systemImage: row.status.systemImage)
+                        .foregroundStyle(row.status.tint)
+                        .help(row.status.explanation)
+                }
+                .width(min: 110, ideal: 130)
+            }
+            .frame(height: Metrics.tableHeight)
+            .accessibilityIdentifier("renderer-package-table")
+            .accessibilityLabel("Renderer packages installed on this Mac")
+            .overlay {
+                if model.rows.isEmpty {
+                    ContentUnavailableView(
+                        "No renderer packages are installed on this Mac.",
+                        systemImage: "square.stack.3d.up.slash",
+                        description: Text("Use Add to import a local renderer package folder."))
+                }
+            }
+
+            packageActionBar
+
+            if model.isBusy {
+                ProgressView("Updating renderer packages…")
+                    .controlSize(.small)
+                    .accessibilityLabel("Updating renderer packages")
+                    .accessibilityAddTraits(.updatesFrequently)
+            }
+
+            if let row = selectedRow {
+                packageDetail(row)
+            }
+
+            // Outcomes no installed row owns: a rejected import, or a removal
+            // whose row has already left the table.
+            if let notice = model.paneNotice {
+                noticeLabel(notice)
             }
         }
-        .padding(.vertical, 4)
+    }
+
+    /// The add/remove bar beneath the table, in the macOS table idiom: Add
+    /// creates a package, the destructive action applies to the selected row,
+    /// and registry refresh sits opposite them.
+    private var packageActionBar: some View {
+        HStack(spacing: Metrics.actionBarSpacing) {
+            Button("Add Package…", systemImage: "plus") {
+                showingPicker = true
+            }
+            .disabled(model.isBusy)
+            .accessibilityIdentifier("renderer-package-add-button")
+            .accessibilityLabel("Add a renderer package")
+            .help("Add a local renderer package folder. Files and archives are not supported.")
+
+            Button("Remove", systemImage: "minus", role: .destructive) {
+                removalCandidate = selectedRow
+            }
+            .disabled(model.isBusy || selectedRow == nil)
+            .accessibilityIdentifier("renderer-package-remove-button")
+            .accessibilityLabel("Remove the selected renderer package")
+
+            Spacer()
+
+            Button("Refresh Registry", systemImage: "arrow.clockwise") {
+                Task { await model.refresh() }
+            }
+            .disabled(model.isBusy)
+            .accessibilityLabel("Refresh the renderer registry")
+        }
+        .controlSize(.small)
+    }
+
+    /// The selected package's diagnostics, kept with the package they describe:
+    /// the machine index's own status sentence first, then the latest outcome
+    /// scoped to this package, then the one recovery this pane may perform.
+    @ViewBuilder
+    private func packageDetail(_ row: RendererSettingsRow) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.detailSpacing) {
+            Label(row.status.explanation, systemImage: row.status.systemImage)
+                .font(.body)
+                .foregroundStyle(row.status.tint)
+                .accessibilityLabel("\(row.displayName) \(row.record.version.rawValue). \(row.status.label). \(row.status.explanation)")
+
+            LabeledContent("Package", value: row.record.packageID.rawValue)
+                .font(.callout)
+            if row.registrations.isEmpty == false {
+                LabeledContent("Registrations", value: row.registrations.joined(separator: ", "))
+                    .font(.callout)
+            }
+
+            if let notice = model.notice(for: row) {
+                noticeLabel(notice)
+            }
+
+            if row.record.isSafeModeSuppressed {
+                Button("Reset Safe Mode") { Task { await model.resetSafeMode(row) } }
+                    .controlSize(.small)
+                    .disabled(model.isBusy)
+                    .accessibilityLabel("Reset safe mode for \(row.displayName)")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Diagnostics for \(row.displayName) \(row.record.version.rawValue)")
     }
 
     @ViewBuilder
+    private func noticeLabel(_ notice: RendererSettingsNotice) -> some View {
+        Label(
+            notice.message,
+            systemImage: notice.severity == .failure ? "exclamationmark.triangle" : "checkmark.circle")
+            .font(.callout)
+            .foregroundStyle(notice.severity == .failure ? AnyShapeStyle(Color.red) : AnyShapeStyle(HierarchicalShapeStyle.secondary))
+            .textSelection(.enabled)
+    }
+
+    // MARK: - Source renderer preferences
+
+    /// Two pop-ups instead of a list of one-shot buttons: pick the source, then
+    /// pick the version it is pinned to. "Automatic" is a real choice here — it
+    /// clears the preference rather than pinning a sentinel.
+    @ViewBuilder
     private func sourceVersionControls(model: RendererSettingsModel) -> some View {
         if let source = model.wiki?.sources.first(where: { $0.id == selectedSourceID }) ?? model.wiki?.sources.first {
-            Picker("Source for version selection", selection: Binding(
+            Picker("Source", selection: Binding(
                 get: {
                     guard let selectedSourceID,
                           model.wiki?.sources.contains(where: { $0.id == selectedSourceID }) == true else {
@@ -318,26 +601,52 @@ struct RendererSettingsView: View {
                     Text(source.effectiveName).tag(Optional(source.id))
                 }
             }
-            ForEach(model.rows.filter { $0.record.state == .validated }) { row in
-                ForEach(model.descriptors(for: row), id: \.reference) { descriptor in
-                    let preference = model.wiki?.rendererSourcePreference(for: source.id)
-                    let isSelected = isExactPreference(preference, matching: descriptor.reference)
-                    Button {
-                        model.selectVersion(descriptor, for: source.id)
-                    } label: {
-                        HStack {
-                            Text("Use \(descriptor.displayName) \(descriptor.reference.version.rawValue) for \(source.effectiveName)")
-                            if isSelected {
-                                Image(systemName: "checkmark")
-                                    .accessibilityHidden(true)
-                            }
-                        }
-                    }
-                    .accessibilityLabel("\(descriptor.displayName), version \(descriptor.reference.version.rawValue), for \(source.effectiveName)")
-                    .accessibilityValue(isSelected ? "Selected renderer version" : "Not selected")
+            .accessibilityLabel("Source for renderer version selection")
+
+            Picker("Renderer", selection: rendererBinding(for: source, model: model)) {
+                Text("Automatic").tag(RendererReference?.none)
+                ForEach(model.selectableDescriptors, id: \.reference) { descriptor in
+                    Text("\(descriptor.displayName) \(descriptor.reference.version.rawValue)")
+                        .tag(Optional(descriptor.reference))
                 }
             }
+            .accessibilityLabel("Selected renderer version for \(source.effectiveName)")
+            .accessibilityValue(pinnedRendererDescription(for: source, model: model))
         }
+    }
+
+    private func rendererBinding(
+        for source: SourceSummary,
+        model: RendererSettingsModel
+    ) -> Binding<RendererReference?> {
+        Binding(
+            get: {
+                guard case let .exact(reference) = model.wiki?.rendererSourcePreference(for: source.id) else {
+                    return nil
+                }
+                return reference
+            },
+            set: { reference in
+                guard let reference,
+                      let descriptor = model.selectableDescriptors.first(where: { $0.reference == reference })
+                else {
+                    model.clearVersionSelection(for: source.id)
+                    return
+                }
+                model.selectVersion(descriptor, for: source.id)
+            })
+    }
+
+    private func pinnedRendererDescription(for source: SourceSummary, model: RendererSettingsModel) -> String {
+        guard case let .exact(reference) = model.wiki?.rendererSourcePreference(for: source.id),
+              let descriptor = model.selectableDescriptors.first(where: { $0.reference == reference })
+        else { return "Automatic" }
+        return "\(descriptor.displayName) \(reference.version.rawValue)"
+    }
+
+    private func selectFirstPackageIfNeeded() {
+        guard model.rows.contains(where: { $0.id == selectedPackageID }) == false else { return }
+        selectedPackageID = model.rows.first?.id
     }
 
     private func announceAccessibility(_ message: String) {
@@ -345,14 +654,6 @@ struct RendererSettingsView: View {
             element: NSApp as Any,
             notification: .announcementRequested,
             userInfo: [.announcement: message])
-    }
-
-    private func isExactPreference(
-        _ preference: RendererPreferenceReference?,
-        matching reference: RendererReference
-    ) -> Bool {
-        guard case let .exact(selectedReference) = preference else { return false }
-        return selectedReference == reference
     }
 }
 #endif

--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -281,7 +281,7 @@ final class RendererSettingsModel {
         wiki.removeRendererSourcePreference(sourceID: source)
         notice = RendererSettingsNotice(
             severity: .success,
-            message: "This source now uses the automatically resolved renderer.",
+            message: "Cleared the renderer for this source. It opens as Source until you choose one.",
             scope: .pane)
     }
 
@@ -402,6 +402,10 @@ struct RendererSettingsView: View {
                 }
             } header: {
                 Text("Source Renderer Preferences")
+            } footer: {
+                Text("Choose which installed renderer opens one source in this wiki. A source with no renderer opens as Source. This pins an exact version, so a source keeps the renderer you chose after a newer version is installed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .formStyle(.grouped)
@@ -606,8 +610,10 @@ struct RendererSettingsView: View {
     // MARK: - Source renderer preferences
 
     /// Two pop-ups instead of a list of one-shot buttons: pick the source, then
-    /// pick the version it is pinned to. "Automatic" is a real choice here — it
-    /// clears the preference rather than pinning a sentinel.
+    /// pick the renderer it is pinned to. `None` is a real choice here — it
+    /// clears the preference rather than pinning a sentinel. Clearing does not
+    /// hand the choice back to the matcher: `RendererResolution.preferred`
+    /// returns nil without a stored preference, so the source opens as Source.
     @ViewBuilder
     private func sourceVersionControls(model: RendererSettingsModel) -> some View {
         if let source = model.wiki?.sources.first(where: { $0.id == selectedSourceID }) ?? model.wiki?.sources.first {
@@ -627,7 +633,7 @@ struct RendererSettingsView: View {
             .accessibilityLabel("Source for renderer version selection")
 
             Picker("Renderer", selection: rendererBinding(for: source, model: model)) {
-                Text("Automatic").tag(RendererReference?.none)
+                Text("None (show Source)").tag(RendererReference?.none)
                 ForEach(model.selectableDescriptors, id: \.reference) { descriptor in
                     Text("\(descriptor.displayName) \(descriptor.reference.version.rawValue)")
                         .tag(Optional(descriptor.reference))
@@ -663,7 +669,7 @@ struct RendererSettingsView: View {
     private func pinnedRendererDescription(for source: SourceSummary, model: RendererSettingsModel) -> String {
         guard case let .exact(reference) = model.wiki?.rendererSourcePreference(for: source.id),
               let descriptor = model.selectableDescriptors.first(where: { $0.reference == reference })
-        else { return "Automatic" }
+        else { return "None, opens as Source" }
         return "\(descriptor.displayName) \(reference.version.rawValue)"
     }
 

--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -316,12 +316,35 @@ final class RendererSettingsModel {
     }
 }
 
+/// The package table's height, in one place because the table has no intrinsic
+/// content size: SwiftUI cannot ask an `NSTableView`-backed `Table` how tall its
+/// rows are, so settings has to compute it.
+///
+/// The height follows the row count between a floor and a ceiling. A short list
+/// leaves no dead space under its rows, and a long one scrolls inside the
+/// table's own scroll area rather than growing the Settings window.
+enum RendererPackageTableMetrics {
+    /// One `Table` row at the regular control size, and the header above the
+    /// rows. Both are measured from the live pane's accessibility geometry.
+    static let rowHeight: CGFloat = 24
+    static let headerHeight: CGFloat = 28
+    /// A one-row table reads as a stray strip next to the action bar, so two
+    /// rows is the floor even when only one package is installed.
+    static let minimumVisibleRows = 2
+    static let maximumVisibleRows = 8
+    /// The empty state is a `ContentUnavailableView` with an image, a title,
+    /// and a description. It needs more room than the row floor gives.
+    static let emptyHeight: CGFloat = 148
+
+    static func height(forRowCount count: Int) -> CGFloat {
+        guard count > 0 else { return emptyHeight }
+        let visibleRows = min(max(count, minimumVisibleRows), maximumVisibleRows)
+        return headerHeight + CGFloat(visibleRows) * rowHeight
+    }
+}
+
 struct RendererSettingsView: View {
     private enum Metrics {
-        /// Four columns (Package 160+, Version 80+, Renders 120+, Status 110+)
-        /// need room for roughly five rows before the table scrolls internally,
-        /// so the Settings window never grows with the package count.
-        static let tableHeight: CGFloat = 168
         static let detailSpacing: CGFloat = 6
         static let sectionSpacing: CGFloat = 10
         static let actionBarSpacing: CGFloat = 6
@@ -472,7 +495,7 @@ struct RendererSettingsView: View {
                 }
                 .width(min: 110, ideal: 130)
             }
-            .frame(height: Metrics.tableHeight)
+            .frame(height: RendererPackageTableMetrics.height(forRowCount: model.rows.count))
             .accessibilityIdentifier("renderer-package-table")
             .accessibilityLabel("Renderer packages installed on this Mac")
             .overlay {

--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -119,18 +119,18 @@ struct RendererSettingsNotice: Hashable {
     let scope: RendererSettingsNoticeScope
 }
 
-/// Settings-facing adapter for machine package management and source-specific
-/// preferences. It deliberately owns no renderer-resolution state: the machine
-/// index and WikiStoreModel remain authoritative, while InstalledRendererHost
-/// refreshes only future registry snapshots. Existing panes retain their pinned
-/// reference.
+/// Settings-facing adapter for machine package management. It is wiki-agnostic
+/// by design: installed packages are machine-scoped, and a source's renderer
+/// preference is written where the user reads the source, not here. It owns no
+/// renderer-resolution state either — the machine index stays authoritative,
+/// and InstalledRendererHost refreshes only future registry snapshots, so
+/// existing panes retain their pinned reference.
 @MainActor
 @Observable
 final class RendererSettingsModel {
     static let installFailureMessage = "The renderer package could not be validated or installed."
 
     let host: InstalledRendererHost
-    private(set) var wiki: WikiStoreModel?
 
     private(set) var rows: [RendererSettingsRow] = []
     private(set) var isBusy = false
@@ -149,18 +149,8 @@ final class RendererSettingsModel {
         return notice.message
     }
 
-    init(host: InstalledRendererHost, wiki: WikiStoreModel?) {
+    init(host: InstalledRendererHost) {
         self.host = host
-        self.wiki = wiki
-        rebuildRows()
-    }
-
-    /// Settings is app-scoped, while source preferences are session-scoped.
-    /// Refresh the adapter whenever the active session changes so a long-lived
-    /// Settings scene never writes through a stale store.
-    func updateWiki(_ wiki: WikiStoreModel?) {
-        guard self.wiki !== wiki else { return }
-        self.wiki = wiki
         rebuildRows()
     }
 
@@ -248,55 +238,6 @@ final class RendererSettingsModel {
         notice = RendererSettingsNotice(severity: .failure, message: error, scope: .pane)
     }
 
-    /// Version selection is an exact preference on a source. This keeps
-    /// rollback scoped to the user's source choice rather than mutating the
-    /// machine registry or replacing an active pane pin.
-    func selectVersion(_ descriptor: RendererDescriptor, for source: SourceID) {
-        guard let wiki else {
-            notice = RendererSettingsNotice(
-                severity: .failure,
-                message: "Open a wiki before selecting a renderer version.",
-                scope: .pane)
-            return
-        }
-        wiki.setRendererSourcePreference(
-            sourceID: source,
-            preference: .exact(descriptor.reference))
-        notice = RendererSettingsNotice(
-            severity: .success,
-            message: "Selected \(descriptor.displayName) \(descriptor.reference.version.rawValue) for this source.",
-            scope: .pane)
-    }
-
-    /// Clearing the preference returns the source to automatic resolution. It
-    /// is a distinct operation from pinning, not a pin to a sentinel version.
-    func clearVersionSelection(for source: SourceID) {
-        guard let wiki else {
-            notice = RendererSettingsNotice(
-                severity: .failure,
-                message: "Open a wiki before selecting a renderer version.",
-                scope: .pane)
-            return
-        }
-        wiki.removeRendererSourcePreference(sourceID: source)
-        notice = RendererSettingsNotice(
-            severity: .success,
-            message: "Cleared the renderer for this source. It opens as Source until you choose one.",
-            scope: .pane)
-    }
-
-    func descriptors(for row: RendererSettingsRow) -> [RendererDescriptor] {
-        host.machineIndex?.records
-            .first(where: { $0.packageID == row.record.packageID && $0.version == row.record.version })?
-            .validatedDescriptors ?? []
-    }
-
-    /// Every renderer a source can be pinned to. Only validated records project
-    /// descriptors, so an unavailable package cannot become a pinned choice.
-    var selectableDescriptors: [RendererDescriptor] {
-        rows.filter { $0.record.state == .validated }.flatMap { descriptors(for: $0) }
-    }
-
     /// Every package version the machine index still holds, except removal
     /// tombstones. Unavailable versions stay in the table on purpose: their
     /// status is the only place a quarantine or a validation failure is
@@ -350,19 +291,14 @@ struct RendererSettingsView: View {
         static let actionBarSpacing: CGFloat = 6
     }
 
-    private let wiki: WikiStoreModel?
-    private let wikiID: WikiID?
     @State private var model: RendererSettingsModel
     @State private var showingPackageHelp = false
     @State private var showingPicker = false
     @State private var removalCandidate: RendererSettingsRow?
     @State private var selectedPackageID: RendererSettingsRow.ID?
-    @State private var selectedSourceID: SourceID?
 
-    init(host: InstalledRendererHost, wiki: WikiStoreModel?, wikiID: WikiID?) {
-        self.wiki = wiki
-        self.wikiID = wikiID
-        _model = State(initialValue: RendererSettingsModel(host: host, wiki: wiki))
+    init(host: InstalledRendererHost) {
+        _model = State(initialValue: RendererSettingsModel(host: host))
     }
 
     private var selectedRow: RendererSettingsRow? {
@@ -388,31 +324,10 @@ struct RendererSettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            Section {
-                if let wiki = model.wiki {
-                    if wiki.sources.isEmpty {
-                        Text("Add a source to choose an exact renderer version.")
-                            .foregroundStyle(.secondary)
-                    } else {
-                        sourceVersionControls(model: model)
-                    }
-                } else {
-                    Text("Open a wiki to choose an exact renderer version for a source.")
-                        .foregroundStyle(.secondary)
-                }
-            } header: {
-                Text("Source Renderer Preferences")
-            } footer: {
-                Text("Choose which installed renderer opens one source in this wiki. A source with no renderer opens as Source. This pins an exact version, so a source keeps the renderer you chose after a newer version is installed.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
         }
         .formStyle(.grouped)
         .padding()
-        .task(id: wikiID) {
-            model.updateWiki(wiki)
-            selectedSourceID = wiki?.sources.first?.id
+        .task {
             await model.refresh()
             selectFirstPackageIfNeeded()
         }
@@ -605,72 +520,6 @@ struct RendererSettingsView: View {
             .font(.callout)
             .foregroundStyle(notice.severity == .failure ? AnyShapeStyle(Color.red) : AnyShapeStyle(HierarchicalShapeStyle.secondary))
             .textSelection(.enabled)
-    }
-
-    // MARK: - Source renderer preferences
-
-    /// Two pop-ups instead of a list of one-shot buttons: pick the source, then
-    /// pick the renderer it is pinned to. `None` is a real choice here — it
-    /// clears the preference rather than pinning a sentinel. Clearing does not
-    /// hand the choice back to the matcher: `RendererResolution.preferred`
-    /// returns nil without a stored preference, so the source opens as Source.
-    @ViewBuilder
-    private func sourceVersionControls(model: RendererSettingsModel) -> some View {
-        if let source = model.wiki?.sources.first(where: { $0.id == selectedSourceID }) ?? model.wiki?.sources.first {
-            Picker("Source", selection: Binding(
-                get: {
-                    guard let selectedSourceID,
-                          model.wiki?.sources.contains(where: { $0.id == selectedSourceID }) == true else {
-                        return model.wiki?.sources.first?.id
-                    }
-                    return selectedSourceID
-                },
-                set: { selectedSourceID = $0 })) {
-                ForEach(model.wiki?.sources ?? []) { source in
-                    Text(source.effectiveName).tag(Optional(source.id))
-                }
-            }
-            .accessibilityLabel("Source for renderer version selection")
-
-            Picker("Renderer", selection: rendererBinding(for: source, model: model)) {
-                Text("None (show Source)").tag(RendererReference?.none)
-                ForEach(model.selectableDescriptors, id: \.reference) { descriptor in
-                    Text("\(descriptor.displayName) \(descriptor.reference.version.rawValue)")
-                        .tag(Optional(descriptor.reference))
-                }
-            }
-            .accessibilityLabel("Selected renderer version for \(source.effectiveName)")
-            .accessibilityValue(pinnedRendererDescription(for: source, model: model))
-        }
-    }
-
-    private func rendererBinding(
-        for source: SourceSummary,
-        model: RendererSettingsModel
-    ) -> Binding<RendererReference?> {
-        Binding(
-            get: {
-                guard case let .exact(reference) = model.wiki?.rendererSourcePreference(for: source.id) else {
-                    return nil
-                }
-                return reference
-            },
-            set: { reference in
-                guard let reference,
-                      let descriptor = model.selectableDescriptors.first(where: { $0.reference == reference })
-                else {
-                    model.clearVersionSelection(for: source.id)
-                    return
-                }
-                model.selectVersion(descriptor, for: source.id)
-            })
-    }
-
-    private func pinnedRendererDescription(for source: SourceSummary, model: RendererSettingsModel) -> String {
-        guard case let .exact(reference) = model.wiki?.rendererSourcePreference(for: source.id),
-              let descriptor = model.selectableDescriptors.first(where: { $0.reference == reference })
-        else { return "None, opens as Source" }
-        return "\(descriptor.displayName) \(reference.version.rawValue)"
     }
 
     private func selectFirstPackageIfNeeded() {

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -948,10 +948,7 @@ struct WikiFSApp: App {
                 AppearanceSettingsView()
                     .tag(SettingsTab.appearance)
                     .tabItem { Label("Appearance", systemImage: "paintbrush") }
-                RendererSettingsView(
-                    host: installedRendererHost,
-                    wiki: settingsWikiStore,
-                    wikiID: registry.activeWikiID)
+                RendererSettingsView(host: installedRendererHost)
                     .tag(SettingsTab.renderers)
                     .tabItem { Label("Renderers", systemImage: "square.stack.3d.up") }
             }
@@ -989,14 +986,6 @@ struct WikiFSApp: App {
             get: { SettingsTab(rawValue: settingsSelectedTabRaw) ?? .zotero },
             set: { settingsSelectedTabRaw = $0.rawValue }
         )
-    }
-
-    /// Settings is app-scoped, so it uses the current frontmost session when
-    /// one exists. A missing session keeps machine installation available while
-    /// correctly disabling wiki-scoped controls.
-    private var settingsWikiStore: WikiStoreModel? {
-        guard let wikiID = registry.activeWikiID else { return nil }
-        return sessionManager.sessions[wikiID]?.store
     }
 
     /// The `ColorScheme?` to apply via `.preferredColorScheme` on every scene.

--- a/Tests/WikiFSAppTests/RendererSettingsHelpTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsHelpTests.swift
@@ -103,7 +103,6 @@ struct RendererSettingsHelpHostedTests {
         #expect(settingsSource.contains("Refresh Registry"))
         #expect(settingsSource.contains("Reset Safe Mode"))
         #expect(settingsSource.contains("Remove"))
-        #expect(settingsSource.contains("Source Renderer Preferences"))
     }
 
     private func repositoryRoot() -> URL {

--- a/Tests/WikiFSAppTests/RendererSettingsHelpTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsHelpTests.swift
@@ -99,7 +99,7 @@ struct RendererSettingsHelpHostedTests {
             contentsOf: repositoryRoot().appending(path: "Sources/WikiFS/Settings/RendererSettingsView.swift"),
             encoding: .utf8)
         #expect(settingsSource.contains("RendererPackageHelpControl(isPresented: $showingPackageHelp)"))
-        #expect(settingsSource.contains("Advanced Local Renderer Package Import"))
+        #expect(settingsSource.contains("Add Package…"))
         #expect(settingsSource.contains("Refresh Registry"))
         #expect(settingsSource.contains("Reset Safe Mode"))
         #expect(settingsSource.contains("Remove"))

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -30,7 +30,7 @@ struct RendererSettingsManagementViewTests {
         // Packages are a selectable table with a fixed height, so the pane
         // scrolls internally instead of growing the Settings window.
         #expect(source.contains("Table(model.rows, selection: $selectedPackageID)"))
-        #expect(source.contains(".frame(height: Metrics.tableHeight)"))
+        #expect(source.contains(".frame(height: RendererPackageTableMetrics.height(forRowCount: model.rows.count))"))
         // Add is a first-class control under the table, not a disclosure.
         #expect(source.contains("Button(\"Add Package…\", systemImage: \"plus\")"))
         #expect(source.contains("renderer-package-add-button"))
@@ -152,6 +152,28 @@ struct RendererSettingsManagementViewTests {
 
         #expect(host.view.fittingSize.width > 0)
         #expect(host.view.fittingSize.height > 0)
+    }
+
+    @Test("the table fits its rows between a floor and a ceiling")
+    func tableHeightFollowsRowCountWithinBounds() {
+        let metrics = RendererPackageTableMetrics.self
+
+        // No rows: the empty state needs more room than the row floor gives.
+        #expect(metrics.height(forRowCount: 0) == metrics.emptyHeight)
+
+        // Below the floor, a stray one-row strip is padded to two rows.
+        let floor = metrics.headerHeight + CGFloat(metrics.minimumVisibleRows) * metrics.rowHeight
+        #expect(metrics.height(forRowCount: 1) == floor)
+        #expect(metrics.height(forRowCount: metrics.minimumVisibleRows) == floor)
+
+        // Between the bounds the table fits its rows exactly, so a short list
+        // leaves no dead space.
+        #expect(metrics.height(forRowCount: 4) == metrics.headerHeight + 4 * metrics.rowHeight)
+
+        // Past the ceiling the height stops growing and the table scrolls.
+        let ceiling = metrics.headerHeight + CGFloat(metrics.maximumVisibleRows) * metrics.rowHeight
+        #expect(metrics.height(forRowCount: metrics.maximumVisibleRows) == ceiling)
+        #expect(metrics.height(forRowCount: 200) == ceiling)
     }
 
     @Test("status resolution keeps unavailable, safe mode, and rollback distinct")

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -1,5 +1,7 @@
 #if os(macOS)
+import AppKit
 import Foundation
+import SwiftUI
 import Testing
 import WikiFSCore
 import WikiFSEngine
@@ -25,11 +27,19 @@ struct RendererSettingsManagementViewTests {
 
         #expect(source.contains("Installed on This Mac"))
         #expect(source.contains("No renderer packages are installed on this Mac."))
-        #expect(source.contains("Advanced Local Renderer Package Import"))
+        // Packages are a selectable table with a fixed height, so the pane
+        // scrolls internally instead of growing the Settings window.
+        #expect(source.contains("Table(model.rows, selection: $selectedPackageID)"))
+        #expect(source.contains(".frame(height: Metrics.tableHeight)"))
+        // Add is a first-class control under the table, not a disclosure.
+        #expect(source.contains("Button(\"Add Package…\", systemImage: \"plus\")"))
+        #expect(source.contains("renderer-package-add-button"))
+        #expect(source.contains("renderer-package-remove-button"))
+        #expect(!source.contains("Advanced Local Renderer Package Import"))
+        #expect(!source.contains("DisclosureGroup"))
         #expect(source.contains("RendererSettingsPackagePicker.localImportSourceMessage"))
         #expect(source.contains("RendererSettingsPackagePicker.localImportStorageMessage"))
         #expect(source.contains("RendererSettingsPackagePicker.localImportAfterMessage"))
-        #expect(source.contains("RendererSettingsPackagePicker.importButtonTitle"))
         #expect(source.contains("RendererSettingsPackagePicker.v1FormatMessage"))
         #expect(source.contains("The renderer package could not be validated or installed."))
         #expect(!appSource.contains(".task { await installedRendererHost.bootstrapBundledRendererPackages() }"))
@@ -39,7 +49,11 @@ struct RendererSettingsManagementViewTests {
         #expect(!source.contains("Application Support"))
         #expect(!source.contains("App Group"))
         #expect(source.contains("Source data and wiki preferences were preserved"))
-        #expect(source.contains(".filter { $0.state == .validated }"))
+        // Removal tombstones stay hidden, but a quarantined or unvalidated
+        // record keeps its row: its status is the only place the failure is
+        // explained. Only validated records may be pinned to a source.
+        #expect(source.contains(".filter { $0.state != .removed }"))
+        #expect(source.contains(".filter { $0.record.state == .validated }"))
         #expect(source.contains(".task(id: wikiID)"))
         #expect(source.contains("model.updateWiki(wiki)"))
         #expect(source.contains("rendererSourcePreference(for: source.id)"))
@@ -117,6 +131,136 @@ struct RendererSettingsManagementViewTests {
         model.updateWiki(secondWiki)
 
         #expect(model.wiki === secondWiki)
+    }
+
+    // MARK: - Inline per-package diagnostics
+
+    @Test("the pane hosts its table and empty state in a macOS window")
+    @MainActor
+    func panelHostsTableAndEmptyState() {
+        let view = RendererSettingsView(
+            host: InstalledRendererHost(services: UnavailableRendererServices()),
+            wiki: nil,
+            wikiID: nil)
+        let host = NSHostingController(rootView: view)
+        let window = NSWindow(contentViewController: host)
+        window.setContentSize(NSSize(width: 640, height: 560))
+        window.makeKeyAndOrderFront(nil)
+        defer { window.close() }
+
+        host.view.layoutSubtreeIfNeeded()
+
+        #expect(host.view.fittingSize.width > 0)
+        #expect(host.view.fittingSize.height > 0)
+    }
+
+    @Test("status resolution keeps unavailable, safe mode, and rollback distinct")
+    func statusResolutionFollowsRecordPrecedence() throws {
+        let quarantined = try Self.makeRecord(state: .quarantined, diagnostic: .packageQuarantined)
+        #expect(RendererPackageStatus.resolve(quarantined) == .unavailable(.packageQuarantined))
+
+        let unvalidated = try Self.makeRecord(state: .unvalidated)
+        #expect(RendererPackageStatus.resolve(unvalidated) == .unavailable(nil))
+
+        let validated = try Self.makeRecord(state: .validated, descriptors: [try Self.makeDescriptor()])
+        #expect(RendererPackageStatus.resolve(validated) == .available)
+
+        // Safe mode outranks the lifecycle state: the version is validated but
+        // suppressed, and only the suppression is actionable.
+        let suppressed = try Self.makeRecord(
+            state: .validated,
+            isSafeModeSuppressed: true,
+            descriptors: [try Self.makeDescriptor()])
+        #expect(RendererPackageStatus.resolve(suppressed) == .safeModeSuppressed)
+
+        let superseded = try Self.makeRecord(state: .superseded, descriptors: [try Self.makeDescriptor()])
+        #expect(RendererPackageStatus.resolve(superseded) == .superseded)
+    }
+
+    @Test("every status explains itself so a row never shows a bare state word")
+    func everyStatusCarriesAnExplanation() {
+        let statuses: [RendererPackageStatus] = [
+            .available,
+            .superseded,
+            .safeModeSuppressed,
+            .unavailable(nil)
+        ] + RendererPackageInstallDiagnostic.allCases.map { RendererPackageStatus.unavailable($0) }
+
+        for status in statuses {
+            #expect(status.label.isEmpty == false)
+            #expect(status.explanation.isEmpty == false)
+            #expect(status.systemImage.isEmpty == false)
+        }
+    }
+
+    @Test("an import that produced no row reports on the pane, not on a package")
+    func installFailureIsPaneScoped() async {
+        let model = RendererSettingsModel(
+            host: InstalledRendererHost(services: UnavailableRendererServices()),
+            wiki: nil)
+
+        await model.install(directory: URL.temporaryDirectory.appending(path: "missing-renderer-package"))
+
+        #expect(model.paneNotice?.severity == .failure)
+        #expect(model.paneNotice?.message == RendererSettingsModel.installFailureMessage)
+        #expect(model.diagnostic == nil)
+    }
+
+    @Test("one notice at a time: a refresh clears the outcome it replaced")
+    func refreshClearsThePreviousNotice() async {
+        let model = RendererSettingsModel(
+            host: InstalledRendererHost(services: UnavailableRendererServices()),
+            wiki: nil)
+        model.report(error: "Selection was rejected.")
+        #expect(model.lastError == "Selection was rejected.")
+
+        await model.refresh()
+
+        #expect(model.lastError == nil)
+        #expect(model.notice == nil)
+    }
+
+    private static func makeRecord(
+        state: RendererPackageInstallState,
+        diagnostic: RendererPackageInstallDiagnostic? = nil,
+        isSafeModeSuppressed: Bool = false,
+        descriptors: [RendererDescriptor] = []
+    ) throws -> RendererPackageInstallRecord {
+        let timestamp = RFC3339Timestamp(date: Date(timeIntervalSince1970: 1_700_000_000))
+        return try RendererPackageInstallRecord(
+            packageID: try RendererPackageID(validating: "org.example.settings"),
+            version: try RendererPackageVersion(validating: "1.0.0"),
+            expectedPackageHash: try RendererSHA256Digest(bytes: Array(repeating: 7, count: 32)),
+            state: state,
+            reservedAt: timestamp,
+            updatedAt: timestamp,
+            diagnostic: diagnostic,
+            isSafeModeSuppressed: isSafeModeSuppressed,
+            validatedDescriptors: descriptors)
+    }
+
+    private static func makeDescriptor() throws -> RendererDescriptor {
+        let entryPath = try RendererRelativePath(validating: "index.html")
+        return try RendererDescriptor(
+            reference: RendererReference(
+                packageID: try RendererPackageID(validating: "org.example.settings"),
+                version: try RendererPackageVersion(validating: "1.0.0"),
+                registrationID: try RendererRegistrationID(validating: "canvas")),
+            displayName: "Example Canvas",
+            implementation: .webPackage(RendererWebEntryPoint(path: entryPath)),
+            matchers: [.artifactKind(.source)],
+            presentations: [.web],
+            approvedAssets: [
+                RendererAsset(
+                    path: entryPath,
+                    digest: try RendererSHA256Digest(bytes: Array(repeating: 2, count: 32)))
+            ],
+            capabilities: [.inputRead],
+            sizeLimits: try RendererSizeLimits(maximumInputByteCount: 1, maximumDecodedByteCount: 1),
+            linkPolicy: .none,
+            accessibility: RendererAccessibility(supportsVoiceOver: true, supportsKeyboardNavigation: true),
+            compatibility: try RendererCompatibility(minimumProtocolRevision: 1, maximumProtocolRevision: 1),
+            priority: 0)
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -51,13 +51,17 @@ struct RendererSettingsManagementViewTests {
         #expect(source.contains("Source data and wiki preferences were preserved"))
         // Removal tombstones stay hidden, but a quarantined or unvalidated
         // record keeps its row: its status is the only place the failure is
-        // explained. Only validated records may be pinned to a source.
+        // explained.
         #expect(source.contains(".filter { $0.state != .removed }"))
-        #expect(source.contains(".filter { $0.record.state == .validated }"))
-        #expect(source.contains(".task(id: wikiID)"))
-        #expect(source.contains("model.updateWiki(wiki)"))
-        #expect(source.contains("rendererSourcePreference(for: source.id)"))
-        #expect(source.contains("Selected renderer version"))
+        // The pane is machine-scoped: installed packages are shared by every
+        // wiki, and a source's renderer preference is written where the user
+        // reads the source, not in Settings.
+        #expect(source.contains("init(host: InstalledRendererHost)"))
+        #expect(!source.contains("Source Renderer Preferences"))
+        #expect(!source.contains("WikiStoreModel"))
+        #expect(!source.contains("rendererSourcePreference"))
+        #expect(!source.contains("setRendererSourcePreference"))
+        #expect(!source.contains("removeRendererSourcePreference"))
         #expect(source.contains("Updating renderer packages"))
         #expect(source.contains("announcementRequested"))
         #expect(source.contains("Files and archives are not supported."))
@@ -74,8 +78,7 @@ struct RendererSettingsManagementViewTests {
     @Test("settings model reports install failure and clears busy state")
     func settingsModelReportsInstallFailure() async {
         let model = RendererSettingsModel(
-            host: InstalledRendererHost(services: UnavailableRendererServices()),
-            wiki: nil)
+            host: InstalledRendererHost(services: UnavailableRendererServices()))
 
         await model.install(directory: URL.temporaryDirectory.appending(path: "missing-renderer-package"))
 
@@ -100,7 +103,7 @@ struct RendererSettingsManagementViewTests {
                 registrationID: BundledRendererPackages.excalidrawRegistrationID))
             .assemble()
         let host = InstalledRendererHost(services: handle.services)
-        let model = RendererSettingsModel(host: host, wiki: nil)
+        let model = RendererSettingsModel(host: host)
         let packageURL = try #require(BundledRendererPackages.excalidrawResourceURL())
 
         await model.install(directory: packageURL)
@@ -112,36 +115,11 @@ struct RendererSettingsManagementViewTests {
         try await handle.dispose()
     }
 
-    @Test("settings model follows the current wiki store")
-    func settingsModelTracksCurrentWikiStore() throws {
-        let firstURL = URL.temporaryDirectory.appending(path: "renderer-settings-first-\\(UUID().uuidString).sqlite")
-        let secondURL = URL.temporaryDirectory.appending(path: "renderer-settings-second-\\(UUID().uuidString).sqlite")
-        defer {
-            for url in [firstURL, secondURL] {
-                do { try FileManager.default.removeItem(at: url) }
-                catch { Issue.record("Renderer settings model fixture cleanup failed.") }
-            }
-        }
-
-        let firstWiki = WikiStoreModel(store: try GRDBWikiStore(databaseURL: firstURL))
-        let secondWiki = WikiStoreModel(store: try GRDBWikiStore(databaseURL: secondURL))
-        let host = InstalledRendererHost(services: UnavailableRendererServices())
-        let model = RendererSettingsModel(host: host, wiki: firstWiki)
-
-        model.updateWiki(secondWiki)
-
-        #expect(model.wiki === secondWiki)
-    }
-
-    // MARK: - Inline per-package diagnostics
-
     @Test("the pane hosts its table and empty state in a macOS window")
     @MainActor
     func panelHostsTableAndEmptyState() {
         let view = RendererSettingsView(
-            host: InstalledRendererHost(services: UnavailableRendererServices()),
-            wiki: nil,
-            wikiID: nil)
+            host: InstalledRendererHost(services: UnavailableRendererServices()))
         let host = NSHostingController(rootView: view)
         let window = NSWindow(contentViewController: host)
         window.setContentSize(NSSize(width: 640, height: 560))
@@ -218,8 +196,7 @@ struct RendererSettingsManagementViewTests {
     @Test("an import that produced no row reports on the pane, not on a package")
     func installFailureIsPaneScoped() async {
         let model = RendererSettingsModel(
-            host: InstalledRendererHost(services: UnavailableRendererServices()),
-            wiki: nil)
+            host: InstalledRendererHost(services: UnavailableRendererServices()))
 
         await model.install(directory: URL.temporaryDirectory.appending(path: "missing-renderer-package"))
 
@@ -231,8 +208,7 @@ struct RendererSettingsManagementViewTests {
     @Test("one notice at a time: a refresh clears the outcome it replaced")
     func refreshClearsThePreviousNotice() async {
         let model = RendererSettingsModel(
-            host: InstalledRendererHost(services: UnavailableRendererServices()),
-            wiki: nil)
+            host: InstalledRendererHost(services: UnavailableRendererServices()))
         model.report(error: "Selection was rejected.")
         #expect(model.lastError == "Selection was rejected.")
 

--- a/progress/2026-08-31T200000Z-renderer-settings-package-table.md
+++ b/progress/2026-08-31T200000Z-renderer-settings-package-table.md
@@ -17,8 +17,13 @@ the bottom of the pane, far from the package they described.
 The pane now has three parts:
 
 * **A package table.** `Table` with four columns (Package, Version, Renders,
-  Status) and a fixed height. The table scrolls internally, so the package count
-  cannot stretch the window. This follows `ExtractionSettingsView.extractorRouteTable`.
+  Status). This follows `ExtractionSettingsView.extractorRouteTable`.
+  `RendererPackageTableMetrics.height(forRowCount:)` gives the height, because a
+  `Table` has no intrinsic content size. The height follows the row count
+  between a floor of two rows and a ceiling of eight. A short list leaves no
+  space below its rows, and a long list scrolls in the table's own scroll area.
+  The window height does not change with the package count. The row height and
+  the header height come from the accessibility geometry of the live pane.
 
 * **Inline diagnostics.** `RendererPackageStatus` resolves the three separate
   record fields — lifecycle state, safe-mode suppression, and the closed install
@@ -55,5 +60,8 @@ Two other changes follow from inline diagnostics:
 * A new hosted test puts `RendererSettingsView` in an `NSWindow` and checks that
   the table and the empty state lay out.
 * The full suite did not run locally. CI runs it.
-* The change was not seen in the running app. The app on this machine runs an
-  older build.
+* The pane was seen in the running app and captured. The accessibility tree
+  confirmed that the table has its own scroll area, and gave the row height
+  (24 pt) and the header height (28 pt) that the metrics use.
+* The content-driven height was not seen in the running app. It needs a new
+  install and a restart.

--- a/progress/2026-08-31T200000Z-renderer-settings-package-table.md
+++ b/progress/2026-08-31T200000Z-renderer-settings-package-table.md
@@ -1,0 +1,59 @@
+---
+timestamp: 2026-08-31T200000Z
+title: Renderer settings package table with inline diagnostics
+branch: feature/renderer-settings-package-table
+status: complete
+---
+
+# Renderer settings package table with inline diagnostics
+
+## Progress
+
+The Renderer settings pane showed installed packages as a list of tall cards. The
+list grew the Settings window, it did not align the version or the status, and it
+hid the import control in a disclosure group. Diagnostics went to two sections at
+the bottom of the pane, far from the package they described.
+
+The pane now has three parts:
+
+* **A package table.** `Table` with four columns (Package, Version, Renders,
+  Status) and a fixed height. The table scrolls internally, so the package count
+  cannot stretch the window. This follows `ExtractionSettingsView.extractorRouteTable`.
+
+* **Inline diagnostics.** `RendererPackageStatus` resolves the three separate
+  record fields — lifecycle state, safe-mode suppression, and the closed install
+  diagnostic — into one status. Safe mode outranks the lifecycle state, because
+  only the suppression is actionable. The Status column shows the short label and
+  the icon. The detail under the table shows the full sentence for the selected
+  package. `RendererSettingsNotice` replaces the two global strings
+  `diagnostic` and `lastError`: it holds one outcome with a severity and a scope,
+  so an install or a safe-mode reset renders with the package it changed. An
+  outcome that no row owns, such as a rejected import, stays on the pane.
+  `diagnostic` and `lastError` remain as computed properties of that notice.
+
+* **An Add button.** `Add Package…` and a destructive `Remove` sit below the
+  table, with `Refresh Registry` opposite them. The disclosure group is gone.
+  The import contract copy moved to the section footer, where it is always
+  visible.
+
+Two other changes follow from inline diagnostics:
+
+* The table keeps every record except a removal tombstone. Before, it kept only
+  validated records, so a quarantined or a rejected package was invisible and the
+  user got no reason. Only validated records still project descriptors, so an
+  unavailable package cannot become a pinned source preference.
+
+* Source renderer preferences use two pop-ups instead of one button for each
+  installed descriptor. `Automatic` is a real choice: it calls
+  `removeRendererSourcePreference` instead of pinning a sentinel version.
+
+## Verification
+
+* `make build` — passes.
+* `WIKIFS_APP_TESTS=1 swift test --filter 'RendererSettingsManagementViewTests|RendererSettingsHelpTests|RendererSettingsPackagePickerTests'` — 13 tests pass.
+* `swift test --filter RendererSettings` — 16 tests in 5 suites pass.
+* A new hosted test puts `RendererSettingsView` in an `NSWindow` and checks that
+  the table and the empty state lay out.
+* The full suite did not run locally. CI runs it.
+* The change was not seen in the running app. The app on this machine runs an
+  older build.

--- a/progress/2026-08-31T200000Z-renderer-settings-package-table.md
+++ b/progress/2026-08-31T200000Z-renderer-settings-package-table.md
@@ -48,9 +48,16 @@ Two other changes follow from inline diagnostics:
   user got no reason. Only validated records still project descriptors, so an
   unavailable package cannot become a pinned source preference.
 
-* Source renderer preferences use two pop-ups instead of one button for each
-  installed descriptor. `Automatic` is a real choice: it calls
-  `removeRendererSourcePreference` instead of pinning a sentinel version.
+* The Source Renderer Preferences section is gone, and the pane is now
+  wiki-agnostic: `RendererSettingsView(host:)` takes no `WikiStoreModel` and no
+  `WikiID`. Installed packages are machine-scoped, so Settings no longer needs a
+  session. The section wrote an exact renderer pin for one source. The reading
+  UI already writes that pin when the user activates a renderer pane
+  (`SourceDetailView.persistRendererPreference`), and its Source/rendered
+  toggle changes presentation. What the section alone could do was roll a
+  source back to an older installed version of a package, and clear a pin.
+  `removeRendererSourcePreference` now has no caller in the app. The store API
+  stays.
 
 ## Verification
 


### PR DESCRIPTION
## Why

The Renderer settings pane was confusing. It listed installed packages as tall
cards that grew the Settings window, it hid the import control in a disclosure
group, and it reported every outcome in two sections at the bottom of the pane,
far from the package each outcome described.

## What changed

**A package table.** `Table` with four columns: Package, Version, Renders, and
Status. This follows `ExtractionSettingsView.extractorRouteTable`.
`RendererPackageTableMetrics.height(forRowCount:)` gives the height, because a
`Table` has no intrinsic content size. The height follows the row count between
a floor of two rows and a ceiling of eight. A short list leaves no space below
its rows, and a long list scrolls in the table's own scroll area. The window
height does not change with the package count. The row height (24 pt) and the
header height (28 pt) come from the accessibility geometry of the live pane.

**Inline diagnostics.** `RendererPackageStatus` resolves three separate record
fields — the lifecycle state, the safe-mode suppression, and the closed install
diagnostic — into one status for each package. Safe mode outranks the lifecycle
state, because only the suppression is actionable. The Status column shows the
short label and the icon. The detail below the table shows the full sentence for
the selected package.

`RendererSettingsNotice` replaces the two global strings `diagnostic` and
`lastError`. It holds one outcome with a severity and a scope, so an install or
a safe-mode reset renders with the package it changed. An outcome that no row
owns, such as a rejected import, stays on the pane. `diagnostic` and `lastError`
remain as computed properties of that notice, so an error cannot outlive the
success that replaced it.

**An Add button.** `Add Package…` and a destructive `Remove` are below the
table, with `Refresh Registry` opposite them. The disclosure group is gone. The
import contract copy moved to the section footer, where it is always visible.

**Every record except a removal tombstone keeps a row.** Before, the table kept
only validated records, so a quarantined or a rejected package was invisible and
the user got no reason for it. Inline diagnostics need those rows: a validated
record almost always has no diagnostic.

**The Source Renderer Preferences section is gone.** It pinned an exact renderer
version for one source in the open wiki. The reading UI already writes that pin
when the user activates a renderer pane
(`SourceDetailView.persistRendererPreference`), and its Source/rendered toggle
covers a return to Source. The section alone could roll a source back to an
older installed version of a package, which needs two versions of one package
installed and no UI supplies one. `removeRendererSourcePreference` now has no
caller in the app; the store API stays.

This makes the pane wiki-agnostic, which is what it always was in substance:
installed packages are machine-scoped and every wiki on the Mac shares them.
`RendererSettingsView(host:)` takes no `WikiStoreModel` and no `WikiID`, the
model drops its store reference and its preference writers, and
`WikiFSApp.settingsWikiStore` goes with them.

## Verification

- `make build` passes.
- SwiftLint `--strict` reports 0 violations in 640 files.
- `WIKIFS_APP_TESTS=1 swift test --filter 'RendererSettingsManagementViewTests|RendererSettingsHelpTests|RendererSettingsPackagePickerTests'` — 14 tests pass.
- `swift test --filter RendererSettings` — 16 tests in 5 suites pass.
- New tests cover the status precedence, the notice scope, the one-notice rule,
  and the table height at the empty case, the floor, an exact fit, and the
  ceiling clamp.
- A hosted test puts `RendererSettingsView` in an `NSWindow` and checks that the
  table and the empty state lay out.
- The first two commits were seen in the running app and captured. The later
  commits were not: they need a new install and a restart.
- The full suite did not run locally. CI runs it.

## Review notes

Three source-text contract assertions locked the old layout and were replaced
with assertions for the new structure: the disclosure title,
`importButtonTitle` in the view file (the picker tests still assert it), and
`.filter { $0.state == .validated }`. Check these if those strings were
load-bearing for a reason the code does not state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U4SShVtLajqZUkwQYEWe5