### PR TITLE
refactor(settings): extractor package table with inline diagnostics

### DIFF
--- a/Sources/WikiFS/Settings/ExtractorPackageHelp.swift
+++ b/Sources/WikiFS/Settings/ExtractorPackageHelp.swift
@@ -1,0 +1,115 @@
+#if os(macOS)
+import SwiftUI
+
+enum ExtractorPackageHelpCopy {
+    static let triggerTitle = "What is an extractor package?"
+    static let tooltip = "Learn about local extractor packages"
+    static let heading = "Extractor packages"
+    static let folderExample = """
+        ExampleExtractor/
+        ├── manifest.json
+        └── bin/
+            └── example-extractor.js
+        """
+}
+
+struct ExtractorPackageHelpControl: View {
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        Button(ExtractorPackageHelpCopy.triggerTitle, systemImage: "questionmark.circle") {
+            presentHelp()
+        }
+        .accessibilityIdentifier("extractor-package-help-button")
+        .accessibilityLabel(ExtractorPackageHelpCopy.triggerTitle)
+        .help(ExtractorPackageHelpCopy.tooltip)
+        .popover(isPresented: $isPresented, arrowEdge: .trailing) {
+            ExtractorPackageHelpContent()
+        }
+    }
+
+    func presentHelp() {
+        isPresented = true
+    }
+}
+
+struct ExtractorPackageHelpContent: View {
+    private enum Metrics {
+        static let width: CGFloat = 420
+        static let maximumHeight: CGFloat = 560
+        static let spacing: CGFloat = 12
+        static let compactSpacing: CGFloat = 6
+        static let padding: CGFloat = 20
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Metrics.spacing) {
+                Text(ExtractorPackageHelpCopy.heading)
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text("An extractor package turns one file into Markdown. It is one local folder that contains manifest.json, the entry point, and the other files that the manifest declares.")
+                    .font(.body)
+
+                Text(ExtractorPackageHelpCopy.folderExample)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+                    .accessibilityLabel("Example extractor folder with manifest.json and an entry point under bin")
+
+                // The one thing that separates an extractor package from a
+                // renderer package: it runs code. State it before anything
+                // else the reader might act on.
+                Label(ExtractionSettingsView.trustWarningMessage, systemImage: "exclamationmark.triangle")
+                    .font(.body)
+                    .foregroundStyle(.orange)
+                    .accessibilityLabel("Executable code warning. \(ExtractionSettingsView.trustWarningMessage)")
+
+                helpSection(
+                    "What the manifest declares",
+                    text: "manifest.json declares the package identity, the registrations that say which formats the package extracts, the launch mode, the capabilities, the operation limits, and lowercase SHA-256 digests for every declared file.")
+
+                helpSection(
+                    "How a package runs",
+                    text: "A package runs as a one-shot process. One request goes in, and one terminal frame comes back as JSON Lines. Each operation takes one input file and returns one Markdown result. Declared capabilities are a declaration, not a security sandbox.")
+
+                helpSection(
+                    "What import does",
+                    text: "The app validates the selected folder and copies it into the extractor store on this Mac. It does not use the selected source folder after import. Every installed revision is pinned to its exact digest.")
+
+                helpSection(
+                    "Supported sources",
+                    text: "Import accepts one local folder. ZIP files, other archives, remote catalogs, and network installation are not supported.")
+
+                helpSection(
+                    "Reviewed and installed packages",
+                    text: "Reviewed packages ship with the app. Installed packages are local additions. Both appear in this table, and the Defaults tab chooses which one opens each format.")
+
+                helpSection(
+                    "Credentials stay explicit",
+                    text: "A package can declare a credential requirement. You authorize each one, and the app names the stored credential before you approve. A later revision of the same package keeps the grant only while that requirement's label, purpose, optionality, and registration stay unchanged.")
+
+                helpSection(
+                    "When a package cannot run",
+                    text: "A revision that fails to activate keeps its row and shows the reason. A format whose selected package is missing or not ready stays blocked until you choose another extractor in the Defaults tab.")
+            }
+            .padding(Metrics.padding)
+        }
+        .frame(width: Metrics.width)
+        .frame(maxHeight: Metrics.maximumHeight)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(ExtractorPackageHelpCopy.heading)
+    }
+
+    private func helpSection(_ title: String, text: String) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.compactSpacing) {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+#endif

--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -257,33 +257,6 @@ final class RendererSettingsModel {
     }
 }
 
-/// The package table's height, in one place because the table has no intrinsic
-/// content size: SwiftUI cannot ask an `NSTableView`-backed `Table` how tall its
-/// rows are, so settings has to compute it.
-///
-/// The height follows the row count between a floor and a ceiling. A short list
-/// leaves no dead space under its rows, and a long one scrolls inside the
-/// table's own scroll area rather than growing the Settings window.
-enum RendererPackageTableMetrics {
-    /// One `Table` row at the regular control size, and the header above the
-    /// rows. Both are measured from the live pane's accessibility geometry.
-    static let rowHeight: CGFloat = 24
-    static let headerHeight: CGFloat = 28
-    /// A one-row table reads as a stray strip next to the action bar, so two
-    /// rows is the floor even when only one package is installed.
-    static let minimumVisibleRows = 2
-    static let maximumVisibleRows = 8
-    /// The empty state is a `ContentUnavailableView` with an image, a title,
-    /// and a description. It needs more room than the row floor gives.
-    static let emptyHeight: CGFloat = 148
-
-    static func height(forRowCount count: Int) -> CGFloat {
-        guard count > 0 else { return emptyHeight }
-        let visibleRows = min(max(count, minimumVisibleRows), maximumVisibleRows)
-        return headerHeight + CGFloat(visibleRows) * rowHeight
-    }
-}
-
 struct RendererSettingsView: View {
     private enum Metrics {
         static let detailSpacing: CGFloat = 6
@@ -414,7 +387,7 @@ struct RendererSettingsView: View {
                 }
                 .width(min: 110, ideal: 130)
             }
-            .frame(height: RendererPackageTableMetrics.height(forRowCount: model.rows.count))
+            .frame(height: SettingsPackageTableMetrics.height(forRowCount: model.rows.count))
             .accessibilityIdentifier("renderer-package-table")
             .accessibilityLabel("Renderer packages installed on this Mac")
             .overlay {

--- a/Sources/WikiFS/Settings/RendererSettingsView.swift
+++ b/Sources/WikiFS/Settings/RendererSettingsView.swift
@@ -387,7 +387,7 @@ struct RendererSettingsView: View {
                 }
                 .width(min: 110, ideal: 130)
             }
-            .frame(height: SettingsPackageTableMetrics.height(forRowCount: model.rows.count))
+            .frame(height: SettingsTableMetrics.height(forRowCount: model.rows.count))
             .accessibilityIdentifier("renderer-package-table")
             .accessibilityLabel("Renderer packages installed on this Mac")
             .overlay {

--- a/Sources/WikiFS/Settings/SettingsPackageTableMetrics.swift
+++ b/Sources/WikiFS/Settings/SettingsPackageTableMetrics.swift
@@ -1,0 +1,35 @@
+#if os(macOS)
+import CoreGraphics
+
+// pattern: Functional Core
+
+/// The height of a Settings package table, in one place because a `Table` has
+/// no intrinsic content size: SwiftUI cannot ask an `NSTableView`-backed table
+/// how tall its rows are, so each pane has to compute it.
+///
+/// The height follows the row count between a floor and a ceiling. A short list
+/// leaves no dead space under its rows, and a long one scrolls inside the
+/// table's own scroll area rather than growing the Settings window.
+///
+/// Shared by the renderer and extractor package tables: both are the same
+/// control at the same control size, so the geometry has one definition.
+enum SettingsPackageTableMetrics {
+    /// One `Table` row at the regular control size, and the header above the
+    /// rows. Both are measured from a live pane's accessibility geometry.
+    static let rowHeight: CGFloat = 24
+    static let headerHeight: CGFloat = 28
+    /// A one-row table reads as a stray strip next to the action bar, so two
+    /// rows is the floor even when only one package is installed.
+    static let minimumVisibleRows = 2
+    static let maximumVisibleRows = 8
+    /// The empty state is a `ContentUnavailableView` with an image, a title,
+    /// and a description. It needs more room than the row floor gives.
+    static let emptyHeight: CGFloat = 148
+
+    static func height(forRowCount count: Int) -> CGFloat {
+        guard count > 0 else { return emptyHeight }
+        let visibleRows = min(max(count, minimumVisibleRows), maximumVisibleRows)
+        return headerHeight + CGFloat(visibleRows) * rowHeight
+    }
+}
+#endif

--- a/Sources/WikiFS/Settings/SettingsTableMetrics.swift
+++ b/Sources/WikiFS/Settings/SettingsTableMetrics.swift
@@ -3,20 +3,20 @@ import CoreGraphics
 
 // pattern: Functional Core
 
-/// The height of a Settings package table, in one place because a `Table` has
-/// no intrinsic content size: SwiftUI cannot ask an `NSTableView`-backed table
-/// how tall its rows are, so each pane has to compute it.
+/// The height of a Settings table, in one place because a `Table` has no
+/// intrinsic content size: SwiftUI cannot ask an `NSTableView`-backed table how
+/// tall its rows are, so each pane has to compute it.
 ///
 /// The height follows the row count between a floor and a ceiling. A short list
 /// leaves no dead space under its rows, and a long one scrolls inside the
 /// table's own scroll area rather than growing the Settings window.
-///
-/// Shared by the renderer and extractor package tables: both are the same
-/// control at the same control size, so the geometry has one definition.
-enum SettingsPackageTableMetrics {
-    /// One `Table` row at the regular control size, and the header above the
-    /// rows. Both are measured from a live pane's accessibility geometry.
-    static let rowHeight: CGFloat = 24
+enum SettingsTableMetrics {
+    /// A row whose cells are text or labels.
+    static let textRowHeight: CGFloat = 24
+    /// A row whose cells hold a control. A `Picker` is taller than the text
+    /// inside it and sets the row's height, so a table of pop-ups needs this
+    /// instead — assuming the text height clips the last row out of view.
+    static let controlRowHeight: CGFloat = 32
     static let headerHeight: CGFloat = 28
     /// A one-row table reads as a stray strip next to the action bar, so two
     /// rows is the floor even when only one package is installed.
@@ -26,7 +26,10 @@ enum SettingsPackageTableMetrics {
     /// and a description. It needs more room than the row floor gives.
     static let emptyHeight: CGFloat = 148
 
-    static func height(forRowCount count: Int) -> CGFloat {
+    /// Both row heights are measured from a live pane's accessibility
+    /// geometry, so a caller picks the one matching its cells rather than
+    /// guessing a number.
+    static func height(forRowCount count: Int, rowHeight: CGFloat = textRowHeight) -> CGFloat {
         guard count > 0 else { return emptyHeight }
         let visibleRows = min(max(count, minimumVisibleRows), maximumVisibleRows)
         return headerHeight + CGFloat(visibleRows) * rowHeight

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -480,6 +480,7 @@ struct ExtractionSettingsView: View {
     // Installed-package lifecycle (dynamic-extractor-packages Phase 7).
     @State private var packageModel: ExtractorPackageSettingsModel
     @State private var showingImportPicker = false
+    @State private var showingPackageHelp = false
     @State private var removalCandidate: ExtractorPackageSettingsRow?
     @State private var selectedPackageID: ExtractorPackageTableRow.ID?
     /// Deliberately not persisted: Settings opens on the defaults every time,
@@ -1363,7 +1364,13 @@ struct ExtractionSettingsView: View {
         Section {
             packageTable
         } header: {
-            Text("Installed Extractor Packages")
+            HStack {
+                Text("Installed Extractor Packages")
+                Spacer()
+                ExtractorPackageHelpControl(isPresented: $showingPackageHelp)
+                    .buttonStyle(.borderless)
+                    .labelStyle(.iconOnly)
+            }
         } footer: {
             VStack(alignment: .leading, spacing: 6) {
                 Text("Manage exact validated package revisions and their credential access. Choose defaults in the Default Extractors section above.")

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -482,6 +482,9 @@ struct ExtractionSettingsView: View {
     @State private var showingImportPicker = false
     @State private var removalCandidate: ExtractorPackageSettingsRow?
     @State private var selectedPackageID: ExtractorPackageTableRow.ID?
+    /// Deliberately not persisted: Settings opens on the defaults every time,
+    /// because that is the question this pane exists to answer.
+    @State private var selectedPane: ExtractionSettingsPane
     /// Pending authorization confirmation (#1159). Non-nil shows the
     /// explicit confirmation with the inheritance rule.
     @State private var authorizationCandidate: ExtractorCredentialRequirementSummary?
@@ -521,8 +524,13 @@ struct ExtractionSettingsView: View {
             return pasteboard.setString(value, forType: .string)
         },
         importPackage: (@Sendable (URL) async -> ExtractorPackageMutationOutcome)? = nil,
-        removePackage: (@Sendable (ExtractorPackageRevisionID) async -> ExtractorPackageMutationOutcome)? = nil
+        removePackage: (@Sendable (ExtractorPackageRevisionID) async -> ExtractorPackageMutationOutcome)? = nil,
+        /// The pane Settings opens on. Defaults to the document-type defaults,
+        /// which is the question this pane exists to answer; hosted tests pass
+        /// the other pane to mount it directly.
+        initialPane: ExtractionSettingsPane = .defaults
     ) {
+        _selectedPane = State(initialValue: initialPane)
         self.containerDirectory = containerDirectory
         self.launcher = launcher
         self.credentials = credentials ?? KeychainCredentialService()
@@ -554,27 +562,37 @@ struct ExtractionSettingsView: View {
     }
 
     var body: some View {
-        Form {
-            Section {
-                extractorRouteTable
-            } header: {
-                Text("Default Extractors")
-            } footer: {
-                Text("Reviewed packages run outside the app through the extractor protocol. Installed packages are local additions. Connected services use host-managed providers. Podcast transcripts are not package-backed in protocol revision 1.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            // Installed extractor-package lifecycle (Phase 7): read-only list
-            // of exact registry admissions and app-only removal. Hidden when no
-            // snapshot loader was wired (tests, headless hosts).
+        VStack(spacing: 0) {
+            // Two jobs, two panes: choosing what opens a document type, and
+            // managing the packages those choices draw from. Only one is
+            // needed at a time, and the defaults are what a user comes here
+            // for, so they open first.
             if packageSnapshot != nil {
-                installedPackagesSection
+                Picker("Extraction settings section", selection: $selectedPane) {
+                    ForEach(ExtractionSettingsPane.allCases) { pane in
+                        Text(pane.title).tag(pane)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(maxWidth: Metrics.paneSwitcherWidth)
+                .padding(.top, Metrics.paneSwitcherTopPadding)
+                .accessibilityIdentifier(PaneAccessibility.switcher)
+                .accessibilityLabel("Extraction settings section")
             }
 
+            switch selectedPane {
+            case .defaults: defaultsPane
+            case .packages: packagesPane
+            }
         }
-        .formStyle(.grouped)
         .frame(minWidth: Metrics.width, minHeight: Metrics.height)
+        // Both panes can raise the service configuration sheet — a route's
+        // Configure… and a package's Configure… — so it is presented above
+        // the switcher rather than inside either pane.
+        .sheet(item: $serviceConfigurationDialog) { dialog in
+            serviceConfigurationSheet(dialog)
+        }
         // Async model mutations stay on the main actor; the load closure hops
         // to the process registry off-main and returns a value snapshot.
         .task {
@@ -676,6 +694,34 @@ struct ExtractionSettingsView: View {
         }
     }
 
+    // MARK: - Panes
+
+    /// What opens each document type. The pane a user comes here for, so it
+    /// opens first.
+    private var defaultsPane: some View {
+        Form {
+            Section {
+                extractorRouteTable
+            } header: {
+                Text("Default Extractors")
+            } footer: {
+                Text("Reviewed packages run outside the app through the extractor protocol. Installed packages are local additions. Connected services use host-managed providers. Podcast transcripts are not package-backed in protocol revision 1.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    /// Installed extractor-package lifecycle (Phase 7): the exact registry
+    /// admissions, their inline diagnostics, and app-only import and removal.
+    private var packagesPane: some View {
+        Form {
+            installedPackagesSection
+        }
+        .formStyle(.grouped)
+    }
+
     // MARK: - Extractor route table
 
     /// The native, registration-driven route table: one row per extraction
@@ -739,7 +785,13 @@ struct ExtractionSettingsView: View {
             rowHeight: SettingsTableMetrics.controlRowHeight))
         .accessibilityIdentifier(RouteAccessibility.table)
         .accessibilityLabel("Default extractor routes")
-        .sheet(item: $serviceConfigurationDialog) { dialog in
+    }
+
+    /// The connected-service and package credential sheets. Both panes can
+    /// raise these, so the presenter lives above the pane switcher.
+    @ViewBuilder
+    private func serviceConfigurationSheet(_ dialog: ServiceConfigurationDialog) -> some View {
+        Group {
             switch dialog {
             case .acp:
                 ACPConfigurationDialog(
@@ -1034,6 +1086,10 @@ struct ExtractionSettingsView: View {
     /// the separator flattened ("pdf-application-pdf", "html-text-html").
     static func accessibilityKey(_ route: ExtractorRouteID) -> String {
         "\(route.kind.rawValue)-\(route.mimeType.rawValue.replacing("/", with: "-"))"
+    }
+
+    private enum PaneAccessibility {
+        static let switcher = "extraction.pane.switcher"
     }
 
     private enum RouteAccessibility {
@@ -2004,6 +2060,8 @@ struct ExtractionSettingsView: View {
         /// switching backends (sections of different heights) doesn't resize
         /// the window. A short section just leaves space below it.
         static let height: CGFloat = 420
+        static let paneSwitcherWidth: CGFloat = 320
+        static let paneSwitcherTopPadding: CGFloat = 12
         static let packageSectionSpacing: CGFloat = 10
         static let packageActionBarSpacing: CGFloat = 6
         static let packageDetailSpacing: CGFloat = 6
@@ -2293,6 +2351,23 @@ struct ExtractorCredentialRequirementSummary: Identifiable, Hashable, Sendable {
         case .authorized: return "Authorized"
         case .needsAuthorization: return "Needs authorization"
         case .changedContract: return "Changed — re-authorization needed"
+        }
+    }
+}
+
+/// The two jobs Settings → Extraction does. They are separate panes because
+/// only one is needed at a time: choosing what opens a document type, and
+/// managing the packages those choices draw from.
+enum ExtractionSettingsPane: String, CaseIterable, Identifiable, Hashable, Sendable {
+    case defaults
+    case packages
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .defaults: "Defaults"
+        case .packages: "Packages"
         }
     }
 }

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -695,7 +695,9 @@ struct ExtractionSettingsView: View {
                         .help(Self.podcastTranscriptHelp)
                 }
             }
-            .width(min: 90, ideal: 120)
+            // Wide enough for the longest format name in the table, which is
+            // the transcript row rather than one of the three-letter routes.
+            .width(min: 110, ideal: 160)
             TableColumn("Default extractor") { (row: ExtractionDefaultsTableRow) in
                 switch row {
                 case .route(let routeRow): routePicker(routeRow)
@@ -730,7 +732,11 @@ struct ExtractionSettingsView: View {
             }
             .width(min: 110, ideal: 130)
         }
-        .frame(height: SettingsPackageTableMetrics.height(forRowCount: defaultsRows.count))
+        // Every cell in this table holds a pop-up, so its rows are taller
+        // than the package table's text rows.
+        .frame(height: SettingsTableMetrics.height(
+            forRowCount: defaultsRows.count,
+            rowHeight: SettingsTableMetrics.controlRowHeight))
         .accessibilityIdentifier(RouteAccessibility.table)
         .accessibilityLabel("Default extractor routes")
         .sheet(item: $serviceConfigurationDialog) { dialog in
@@ -1347,7 +1353,7 @@ struct ExtractionSettingsView: View {
                 }
                 .width(min: 150, ideal: 170)
             }
-            .frame(height: SettingsPackageTableMetrics.height(
+            .frame(height: SettingsTableMetrics.height(
                 forRowCount: packageModel.tableRows.count))
             .accessibilityIdentifier(PackageAccessibility.table)
             .accessibilityLabel("Installed extractor packages")

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -481,6 +481,7 @@ struct ExtractionSettingsView: View {
     @State private var packageModel: ExtractorPackageSettingsModel
     @State private var showingImportPicker = false
     @State private var removalCandidate: ExtractorPackageSettingsRow?
+    @State private var selectedPackageID: ExtractorPackageTableRow.ID?
     /// Pending authorization confirmation (#1159). Non-nil shows the
     /// explicit confirmation with the inheritance rule.
     @State private var authorizationCandidate: ExtractorCredentialRequirementSummary?
@@ -589,9 +590,6 @@ struct ExtractionSettingsView: View {
             // snapshot loader was wired (tests, headless hosts).
             if packageSnapshot != nil {
                 installedPackagesSection
-                if packageModel.canImport {
-                    packageImportSection
-                }
             }
 
         }
@@ -603,9 +601,18 @@ struct ExtractionSettingsView: View {
             doclingTokenConfigured = refreshDoclingTokenState()
             await packageModel.refresh()
             rebuildRouteRows()
+            selectFirstPackageIfNeeded()
         }
         .onChange(of: packageModel.snapshot) { _, _ in
             rebuildRouteRows()
+            selectFirstPackageIfNeeded()
+        }
+        // An outcome that belongs to one package selects it, so its inline
+        // diagnostic is the one on screen when the message appears.
+        .onChange(of: packageModel.notice) { _, notice in
+            if case .package(let id) = notice?.scope {
+                selectedPackageID = id
+            }
         }
         .alert("Couldn't Connect to Docling Serve", isPresented: doclingErrorBinding,
                presenting: doclingErrorMessage) { _ in
@@ -1251,14 +1258,73 @@ struct ExtractionSettingsView: View {
     /// strings exist.
     @ViewBuilder private var installedPackagesSection: some View {
         Section {
-            Button {
-                Task { await packageModel.refresh() }
-            } label: {
-                Label("Refresh", systemImage: "arrow.clockwise")
+            packageTable
+        } header: {
+            Text("Installed Extractor Packages")
+        } footer: {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Manage exact validated package revisions and their credential access. Choose defaults in the Default Extractors section above.")
+                Text("\(ExtractorSettingsPackagePicker.localImportSourceMessage) \(ExtractorSettingsPackagePicker.localImportStorageMessage) \(ExtractorSettingsPackagePicker.localImportAfterMessage) \(ExtractorSettingsPackagePicker.filesUnsupportedMessage)")
+                Label(Self.trustWarningMessage, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier(PackageAccessibility.trustWarning)
+                    .accessibilityLabel("Executable code warning. \(Self.trustWarningMessage)")
             }
-            .disabled(packageModel.isBusy)
-            .accessibilityIdentifier(PackageAccessibility.refreshButton)
-            .accessibilityLabel("Refresh installed extractor packages")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    /// The package table, its add/remove bar, and the inline detail for the
+    /// selected package. The table takes a computed height and scrolls
+    /// internally, so the installed package count cannot stretch the Settings
+    /// window.
+    @ViewBuilder private var packageTable: some View {
+        VStack(alignment: .leading, spacing: Metrics.packageSectionSpacing) {
+            Table(packageModel.tableRows, selection: $selectedPackageID) {
+                TableColumn("Package") { (row: ExtractorPackageTableRow) in
+                    Text(row.packageID)
+                        .help(row.packageID)
+                }
+                .width(min: 170, ideal: 240)
+                TableColumn("Version") { (row: ExtractorPackageTableRow) in
+                    Text(row.version)
+                        .monospacedDigit()
+                }
+                .width(min: 70, ideal: 90)
+                TableColumn("Handles") { (row: ExtractorPackageTableRow) in
+                    Text(row.kind.map(kindDisplayName) ?? "—")
+                        .foregroundStyle(.secondary)
+                }
+                .width(min: 80, ideal: 100)
+                // The status is the row's own diagnostic in short form. The
+                // full sentence renders in the detail below the table.
+                TableColumn("Status") { (row: ExtractorPackageTableRow) in
+                    Label(row.status.label, systemImage: row.status.systemImage)
+                        .foregroundStyle(row.status.tint)
+                        .help(row.status.explanation)
+                }
+                .width(min: 150, ideal: 170)
+            }
+            .frame(height: SettingsPackageTableMetrics.height(
+                forRowCount: packageModel.tableRows.count))
+            .accessibilityIdentifier(PackageAccessibility.table)
+            .accessibilityLabel("Installed extractor packages")
+            .overlay {
+                if packageModel.tableRows.isEmpty {
+                    ContentUnavailableView(
+                        packageModel.hasLoaded
+                            ? "No extractor packages are installed on this Mac."
+                            : ExtractorPackageSettingsModel.checkingMessage,
+                        systemImage: "shippingbox",
+                        description: packageModel.canImport
+                            ? Text("Use Add to import a local extractor package folder.")
+                            : nil)
+                        .accessibilityIdentifier(PackageAccessibility.emptyState)
+                }
+            }
+
+            packageActionBar
 
             if packageModel.isBusy {
                 ProgressView(packageModel.busyMessage ?? ExtractorPackageSettingsModel.checkingMessage)
@@ -1268,154 +1334,124 @@ struct ExtractionSettingsView: View {
                     .accessibilityAddTraits(.updatesFrequently)
             }
 
-            if packageModel.snapshot.rows.isEmpty && packageModel.snapshot.failedPackages.isEmpty {
-                Text(packageModel.hasLoaded
-                    ? "No extractor packages are installed on this Mac."
-                    : "Checking installed extractor packages…")
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier(PackageAccessibility.emptyState)
-            } else {
-                ForEach(packageModel.snapshot.rows) { row in
-                    packageRow(row)
-                }
-                ForEach(packageModel.snapshot.failedPackages) { failure in
-                    failedPackageRow(failure)
-                }
+            if let row = selectedPackageRow {
+                packageDetail(row)
             }
 
-            if let diagnostic = packageModel.lastDiagnostic {
-                Label(diagnostic, systemImage: "checkmark.circle")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier(PackageAccessibility.diagnostic)
+            // Outcomes no row owns: a rejected import, or a removal whose row
+            // has already left the table.
+            if let notice = packageModel.paneNotice {
+                packageNoticeLabel(notice)
             }
-            if let error = packageModel.lastError {
-                Label(error, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(.red)
-                    .accessibilityIdentifier(PackageAccessibility.error)
-                    .accessibilityLabel("Extractor package operation failed. \(error)")
-            }
-        } header: {
-            Text("Installed Extractor Packages")
-        } footer: {
-            Text("Manage exact validated package revisions and their credential access. Choose defaults in the Default Extractors section above.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
         }
     }
 
-    /// A separate section for the app-only local package import workflow.
-    /// Keep the workflow behind a disclosure so installed package rows remain
-    /// the focus of the package section.
-    @ViewBuilder private var packageImportSection: some View {
-        Section {
-            DisclosureGroup {
-                importDisclosureContent
-            } label: {
-                HStack {
-                    Text(ExtractorSettingsPackagePicker.disclosureTitle)
-                    Spacer(minLength: 0)
+    /// The add/remove bar beneath the table, in the macOS table idiom: Add
+    /// creates a package, the destructive action applies to the selected row,
+    /// and registry refresh sits opposite them.
+    private var packageActionBar: some View {
+        HStack(spacing: Metrics.packageActionBarSpacing) {
+            if packageModel.canImport {
+                Button("Add Package…", systemImage: "plus") {
+                    showingImportPicker = true
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+                .disabled(packageModel.isBusy)
+                .accessibilityIdentifier(PackageAccessibility.importButton)
+                .accessibilityLabel("Add a local extractor package folder")
+                .help("\(ExtractorSettingsPackagePicker.filesUnsupportedMessage) \(Self.trustWarningMessage)")
             }
-            .accessibilityIdentifier(PackageAccessibility.importDisclosure)
-            .accessibilityLabel("Advanced local extractor package import")
-        }
-    }
 
-    /// The import disclosure's body: the local-directory contract, the
-    /// executable-code trust warning, and the import button. Local directories
-    /// only — the panel refuses files, and the boundary revalidates every
-    /// accepted selection.
-    @ViewBuilder private var importDisclosureContent: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(ExtractorSettingsPackagePicker.localImportSourceMessage)
-            Text(ExtractorSettingsPackagePicker.localImportStorageMessage)
-            Text(ExtractorSettingsPackagePicker.localImportAfterMessage)
-            Text(ExtractorSettingsPackagePicker.filesUnsupportedMessage)
-            Label(Self.trustWarningMessage, systemImage: "exclamationmark.triangle")
-                .foregroundStyle(.orange)
-                .accessibilityIdentifier(PackageAccessibility.trustWarning)
-                .accessibilityLabel("Executable code warning. \(Self.trustWarningMessage)")
-            Button(ExtractorSettingsPackagePicker.importButtonTitle, systemImage: "square.and.arrow.down") {
-                showingImportPicker = true
+            if packageModel.canRemove {
+                Button("Remove Package…", systemImage: "minus", role: .destructive) {
+                    removalCandidate = selectedPackageRow?.installedRow
+                }
+                .disabled(packageModel.isBusy || selectedPackageRow?.installedRow == nil)
+                .accessibilityIdentifier(PackageAccessibility.removeButton)
+                .accessibilityLabel("Remove the selected extractor package")
+            }
+
+            Spacer()
+
+            Button("Refresh", systemImage: "arrow.clockwise") {
+                Task { await packageModel.refresh() }
             }
             .disabled(packageModel.isBusy)
-            .accessibilityIdentifier(PackageAccessibility.importButton)
-            .accessibilityLabel("Import a local extractor package folder")
+            .accessibilityIdentifier(PackageAccessibility.refreshButton)
+            .accessibilityLabel("Refresh installed extractor packages")
         }
-        .font(.caption)
+        .controlSize(.small)
     }
 
-    @ViewBuilder private func packageRow(_ row: ExtractorPackageSettingsRow) -> some View {
-        DisclosureGroup {
-            LabeledContent("Kind", value: kindDisplayName(row.kind))
-                .font(.caption)
+    /// The selected package's diagnostics, kept with the package they describe:
+    /// its status sentence first, then the exact bytes and registration that
+    /// identify the revision, then the latest outcome scoped to this package,
+    /// then the actions that apply to it.
+    @ViewBuilder private func packageDetail(_ row: ExtractorPackageTableRow) -> some View {
+        VStack(alignment: .leading, spacing: Metrics.packageDetailSpacing) {
+            Label(row.status.explanation, systemImage: row.status.systemImage)
+                .foregroundStyle(row.status.tint)
+                .textSelection(.enabled)
+                .accessibilityIdentifier("\(PackageAccessibility.statusPrefix).\(row.id)")
+                .accessibilityLabel("\(row.packageID), version \(row.version). \(row.status.label). \(row.status.explanation)")
+
+            if let kind = row.kind {
+                LabeledContent("Kind", value: kindDisplayName(kind))
+                    .font(.caption)
+            }
             LabeledContent("Digest", value: row.digestPrefix)
                 .font(.caption)
                 .accessibilityIdentifier("\(PackageAccessibility.digestPrefix).\(row.id)")
-            LabeledContent("Registration", value: row.registrationID)
-                .font(.caption)
-                .accessibilityIdentifier("\(PackageAccessibility.registrationPrefix).\(row.id)")
-            HStack {
-                Spacer()
-                if let package = packageConfigurationID(for: row) {
-                    Button("Configure…") {
-                        serviceConfigurationDialog = .package(package)
-                    }
-                    .disabled(packageModel.isBusy)
-                    .accessibilityIdentifier("\(PackageAccessibility.configurePrefix).\(row.id)")
-                    .accessibilityLabel("Configure credentials for \(row.packageID), version \(row.version)")
-                }
-                if packageModel.canRemove {
-                    Button("Remove Package…", role: .destructive) {
-                        removalCandidate = row
-                    }
-                    .disabled(packageModel.isBusy)
-                    .accessibilityIdentifier("\(PackageAccessibility.removePrefix).\(row.id)")
-                    .accessibilityLabel("Remove \(row.packageID), version \(row.version)")
-                }
-            }
-        } label: {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(row.packageID)
-                Text("version \(row.version), \(kindDisplayName(row.kind))")
+            if let registrationID = row.registrationID {
+                LabeledContent("Registration", value: registrationID)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("\(PackageAccessibility.registrationPrefix).\(row.id)")
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+
+            if let notice = packageModel.notice(for: row) {
+                packageNoticeLabel(notice)
+            }
+
+            if let installed = row.installedRow,
+               let package = packageConfigurationID(for: installed) {
+                Button("Configure…") {
+                    serviceConfigurationDialog = .package(package)
+                }
+                .controlSize(.small)
+                .disabled(packageModel.isBusy)
+                .accessibilityIdentifier("\(PackageAccessibility.configurePrefix).\(row.id)")
+                .accessibilityLabel("Configure credentials for \(row.packageID), version \(row.version)")
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("\(PackageAccessibility.rowPrefix).\(row.id)")
-        .accessibilityLabel("\(row.packageID), version \(row.version), for \(kindDisplayName(row.kind))")
-        .accessibilityValue("Active")
+        .accessibilityLabel("Diagnostics for \(row.packageID), version \(row.version)")
+        .accessibilityValue(row.status.label)
     }
 
-    /// A catalog revision whose activation failed in this process. It occupies
-    /// the store but resolved to no backend, so it shows its redacted failure
-    /// message and a "Not ready" state instead of an Active row.
-    @ViewBuilder private func failedPackageRow(_ failure: ExtractorPackageFailureSummary) -> some View {
-        DisclosureGroup {
-            Text(failure.message)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .textSelection(.enabled)
-                .accessibilityIdentifier("\(PackageAccessibility.failureMessagePrefix).\(failure.id)")
-        } label: {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(failure.packageID)
-                Text("version \(failure.version), not ready")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+    @ViewBuilder private func packageNoticeLabel(_ notice: ExtractorPackageNotice) -> some View {
+        Label(
+            notice.message,
+            systemImage: notice.severity == .failure ? "exclamationmark.triangle" : "checkmark.circle")
+            .font(.caption)
+            .foregroundStyle(notice.severity == .failure
+                ? AnyShapeStyle(Color.red)
+                : AnyShapeStyle(HierarchicalShapeStyle.secondary))
+            .textSelection(.enabled)
+            .accessibilityIdentifier(notice.severity == .failure
+                ? PackageAccessibility.error
+                : PackageAccessibility.diagnostic)
+    }
+
+    private var selectedPackageRow: ExtractorPackageTableRow? {
+        packageModel.tableRows.first { $0.id == selectedPackageID }
+    }
+
+    private func selectFirstPackageIfNeeded() {
+        guard packageModel.tableRows.contains(where: { $0.id == selectedPackageID }) == false else {
+            return
         }
-        .accessibilityIdentifier("\(PackageAccessibility.failurePrefix).\(failure.id)")
-        .accessibilityLabel("\(failure.packageID), version \(failure.version), failed to activate")
-        .accessibilityValue("Not ready")
+        selectedPackageID = packageModel.tableRows.first?.id
     }
 
     private func kindDisplayName(_ kind: ExtractionBackendKind) -> String {
@@ -1546,18 +1582,19 @@ struct ExtractionSettingsView: View {
     /// Row/digest/registration/remove/failure identifiers append the row's
     /// `id` so each exact revision has a unique, derivable identifier.
     private enum PackageAccessibility {
+        static let table = "extraction.packages.table"
         static let refreshButton = "extraction.packages.refresh"
         static let emptyState = "extraction.packages.empty"
         static let rowPrefix = "extraction.packages.row"
+        static let statusPrefix = "extraction.packages.status"
         static let digestPrefix = "extraction.packages.digest"
         static let registrationPrefix = "extraction.packages.registration"
-        static let importDisclosure = "extraction.packages.import.disclosure"
         static let importButton = "extraction.packages.import.button"
         static let trustWarning = "extraction.packages.import.trust"
         static let configurePrefix = "extraction.packages.configure"
-        static let removePrefix = "extraction.packages.remove"
-        static let failurePrefix = "extraction.packages.failure"
-        static let failureMessagePrefix = "extraction.packages.failure.message"
+        /// Removal targets the table's selection, so it is one control rather
+        /// than one per row.
+        static let removeButton = "extraction.packages.remove"
         static let progress = "extraction.packages.progress"
         static let diagnostic = "extraction.packages.diagnostic"
         static let error = "extraction.packages.error"
@@ -1924,6 +1961,9 @@ struct ExtractionSettingsView: View {
         /// for a few registration-derived rows, with internal scrolling
         /// beyond that so the Settings window never grows without bound.
         static let routeTableHeight: CGFloat = 172
+        static let packageSectionSpacing: CGFloat = 10
+        static let packageActionBarSpacing: CGFloat = 6
+        static let packageDetailSpacing: CGFloat = 6
     }
 }
 
@@ -2214,6 +2254,149 @@ struct ExtractorCredentialRequirementSummary: Identifiable, Hashable, Sendable {
     }
 }
 
+/// What one installed extractor package revision can do right now. The snapshot
+/// keeps the facts apart — active registrations, revisions whose activation
+/// failed, revisions still waiting, and per-requirement authorization state —
+/// but the table has to present one answer, so this resolves them in precedence
+/// order once and every column and explanation reads from it.
+enum ExtractorPackageStatus: Hashable, Sendable {
+    case active
+    /// The revision is installed but its plugin has not activated yet.
+    case waitingForActivation
+    /// Activation failed in this process. The payload is the reconciler's
+    /// already-redacted message.
+    case notReady(String)
+    /// Active, but a required credential has no grant, so the package cannot
+    /// run until the user authorizes it.
+    case needsAuthorization
+
+    /// The short Status column label. The icon carries the state, so the
+    /// sentence lives in ``explanation``.
+    var label: String {
+        switch self {
+        case .active: "Active"
+        case .waitingForActivation: "Waiting"
+        case .notReady: "Not ready"
+        case .needsAuthorization: "Needs authorization"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .active: "checkmark.circle.fill"
+        case .waitingForActivation: "clock"
+        case .notReady: "xmark.octagon.fill"
+        case .needsAuthorization: "key.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .active: .green
+        case .waitingForActivation: .secondary
+        case .notReady: .red
+        case .needsAuthorization: .orange
+        }
+    }
+
+    /// The inline diagnostic shown with the package it belongs to. A failed
+    /// activation carries the reconciler's own text, which is why this is a
+    /// value and not a fixed table.
+    var explanation: String {
+        switch self {
+        case .active:
+            "This revision is active. Routes can select it."
+        case .waitingForActivation:
+            "This revision is installed and waiting to activate."
+        case .notReady(let message):
+            message
+        case .needsAuthorization:
+            "A required credential is not authorized yet. Configure the package to authorize it."
+        }
+    }
+}
+
+/// One row of the installed extractor package table. It folds the snapshot's
+/// two lists into one presentation identity: an active registration and a
+/// revision whose activation failed do not share an id space, so the case tag
+/// is what stops a failure id from colliding with a registration id.
+struct ExtractorPackageTableRow: Identifiable, Hashable, Sendable {
+    enum Subject: Hashable, Sendable {
+        case installed(ExtractorPackageSettingsRow)
+        case failed(ExtractorPackageFailureSummary)
+    }
+
+    let subject: Subject
+    let status: ExtractorPackageStatus
+
+    var id: String {
+        switch subject {
+        case .installed(let row): "installed/\(row.id)"
+        case .failed(let failure): "failed/\(failure.id)"
+        }
+    }
+
+    var packageID: String {
+        switch subject {
+        case .installed(let row): row.packageID
+        case .failed(let failure): failure.packageID
+        }
+    }
+
+    var version: String {
+        switch subject {
+        case .installed(let row): row.version
+        case .failed(let failure): failure.version
+        }
+    }
+
+    var digestPrefix: String {
+        switch subject {
+        case .installed(let row): row.digestPrefix
+        case .failed(let failure): failure.digestPrefix
+        }
+    }
+
+    /// Only an active registration has one. A failed revision resolved to no
+    /// backend, so it registered nothing.
+    var registrationID: String? {
+        guard case .installed(let row) = subject else { return nil }
+        return row.registrationID
+    }
+
+    /// The exact installed row, when this is one. Removal and credential
+    /// configuration both need it, and neither applies to a failed revision.
+    var installedRow: ExtractorPackageSettingsRow? {
+        guard case .installed(let row) = subject else { return nil }
+        return row
+    }
+
+    var kind: ExtractionBackendKind? {
+        installedRow?.kind
+    }
+}
+
+/// Where a package settings outcome belongs. A package-scoped outcome renders
+/// with the row it describes; the pane scope is for outcomes no row owns — an
+/// import that produced nothing, or a removal whose row has already gone.
+enum ExtractorPackageNoticeScope: Hashable, Sendable {
+    case pane
+    case package(ExtractorPackageTableRow.ID)
+}
+
+/// One package settings outcome, kept scoped so the message renders next to the
+/// package it is about rather than in a shared diagnostics area.
+struct ExtractorPackageNotice: Hashable, Sendable {
+    enum Severity: Hashable, Sendable {
+        case success
+        case failure
+    }
+
+    let severity: Severity
+    let message: String
+    let scope: ExtractorPackageNoticeScope
+}
+
 /// One failed package, copied out of the reconciler's public failure struct so
 /// the Settings surface depends on its own value type, not a live report.
 struct ExtractorPackageFailureSummary: Identifiable, Hashable, Sendable {
@@ -2355,7 +2538,6 @@ enum ExtractorPackageMutationMessage {
 /// workflow through another call path.
 @MainActor
 enum ExtractorSettingsPackagePicker {
-    static let disclosureTitle = "Advanced Local Package Import"
     static let importButtonTitle = "Import Extractor Package…"
     static let localImportSourceMessage = "Select one local extractor package folder as an import source."
     static let localImportStorageMessage = "Self Driving Wiki validates and copies it into the extractor store on this Mac."
@@ -2429,13 +2611,73 @@ final class ExtractorPackageSettingsModel {
     private(set) var isBusy = false
     private(set) var busyMessage: String?
     private(set) var hasLoaded = false
-    private(set) var lastError: String?
-    private(set) var lastDiagnostic: String?
+    /// The single latest outcome. Severity and scope are derived from it rather
+    /// than tracked as parallel fields, so an error cannot outlive the success
+    /// that replaced it.
+    private(set) var notice: ExtractorPackageNotice?
+
+    var lastError: String? {
+        guard let notice, notice.severity == .failure else { return nil }
+        return notice.message
+    }
+
+    var lastDiagnostic: String? {
+        guard let notice, notice.severity == .success else { return nil }
+        return notice.message
+    }
+
+    /// Every installed revision the snapshot holds, active and failed alike,
+    /// each carrying the status that explains it.
+    var tableRows: [ExtractorPackageTableRow] { Self.tableRows(from: snapshot) }
+
+    func notice(for row: ExtractorPackageTableRow) -> ExtractorPackageNotice? {
+        guard let notice, notice.scope == .package(row.id) else { return nil }
+        return notice
+    }
+
+    var paneNotice: ExtractorPackageNotice? {
+        guard let notice, notice.scope == .pane else { return nil }
+        return notice
+    }
 
     /// Surfaces a redacted failure from an app-owned authorization mutation
     /// (#1159) through the same diagnostics path as import/remove.
     func reportFailure(_ message: String) {
-        lastError = message
+        notice = ExtractorPackageNotice(severity: .failure, message: message, scope: .pane)
+    }
+
+    /// Folds the snapshot's active registrations and failed revisions into one
+    /// ordered list. Failed revisions sort first: they are the rows a user
+    /// opened this pane to understand.
+    static func tableRows(
+        from snapshot: ExtractorPackageSettingsSnapshot
+    ) -> [ExtractorPackageTableRow] {
+        let failed = snapshot.failedPackages.map { failure in
+            ExtractorPackageTableRow(subject: .failed(failure), status: .notReady(failure.message))
+        }
+        let installed = snapshot.rows.map { row in
+            ExtractorPackageTableRow(
+                subject: .installed(row),
+                status: status(for: row, in: snapshot))
+        }
+        return failed + installed
+    }
+
+    /// Precedence: a revision that has not activated cannot be judged on its
+    /// credentials, so waiting outranks authorization state.
+    private static func status(
+        for row: ExtractorPackageSettingsRow,
+        in snapshot: ExtractorPackageSettingsSnapshot
+    ) -> ExtractorPackageStatus {
+        if snapshot.waitingRevisionIDs.contains(row.revision) { return .waitingForActivation }
+        let unauthorized = snapshot.credentialRequirements.contains { requirement in
+            requirement.packageID == row.packageID
+                && requirement.packageVersion == row.version
+                && requirement.registrationID == row.registrationID
+                && requirement.isOptional == false
+                && requirement.authorizationState != .authorized
+        }
+        return unauthorized ? .needsAuthorization : .active
     }
 
     static let checkingMessage = "Checking installed extractor packages…"
@@ -2471,38 +2713,64 @@ final class ExtractorPackageSettingsModel {
         guard let importAction, !isBusy else { return }
         isBusy = true
         busyMessage = Self.importingMessage
-        lastError = nil
-        lastDiagnostic = nil
+        notice = nil
+        let known = Set(tableRows.map(\.id))
         let outcome = await importAction(directory)
-        apply(outcome, successDiagnostic: "Extractor package installed.")
         isBusy = false
         busyMessage = nil
         await refresh()
+        // Scope the outcome to the row the import produced, so the
+        // confirmation lands on the new package. An import that added no
+        // visible row falls back to the pane.
+        let added = tableRows.map(\.id).filter { known.contains($0) == false }
+        apply(
+            outcome,
+            successDiagnostic: "Extractor package installed.",
+            scope: added.count == 1 ? .package(added[0]) : .pane)
     }
 
     func remove(_ row: ExtractorPackageSettingsRow) async {
         guard let removeAction, !isBusy else { return }
         isBusy = true
         busyMessage = Self.removingMessage
-        lastError = nil
-        lastDiagnostic = nil
+        notice = nil
         let outcome = await removeAction(row.revision)
-        apply(outcome, successDiagnostic: "Removed \(row.packageID) \(row.version).")
         isBusy = false
         busyMessage = nil
         await refresh()
+        // A successful removal leaves no row to carry the message. A failure
+        // does, so it reports on the package it could not remove.
+        let scope: ExtractorPackageNoticeScope = {
+            guard case .failed = outcome else { return .pane }
+            let id = ExtractorPackageTableRow(subject: .installed(row), status: .active).id
+            return tableRows.contains { $0.id == id } ? .package(id) : .pane
+        }()
+        apply(
+            outcome,
+            successDiagnostic: "Removed \(row.packageID) \(row.version).",
+            scope: scope)
     }
 
     func reportImportSelectionError() {
-        lastError = ExtractorSettingsPackagePicker.selectionErrorMessage
+        notice = ExtractorPackageNotice(
+            severity: .failure,
+            message: ExtractorSettingsPackagePicker.selectionErrorMessage,
+            scope: .pane)
     }
 
-    private func apply(_ outcome: ExtractorPackageMutationOutcome, successDiagnostic: String) {
+    private func apply(
+        _ outcome: ExtractorPackageMutationOutcome,
+        successDiagnostic: String,
+        scope: ExtractorPackageNoticeScope
+    ) {
         switch outcome {
         case .succeeded(let diagnostic):
-            lastDiagnostic = diagnostic ?? successDiagnostic
+            notice = ExtractorPackageNotice(
+                severity: .success,
+                message: diagnostic ?? successDiagnostic,
+                scope: scope)
         case .failed(let message):
-            lastError = message
+            notice = ExtractorPackageNotice(severity: .failure, message: message, scope: scope)
         }
     }
 }

--- a/Sources/WikiFS/Sources/ExtractionSettingsView.swift
+++ b/Sources/WikiFS/Sources/ExtractionSettingsView.swift
@@ -560,27 +560,7 @@ struct ExtractionSettingsView: View {
             } header: {
                 Text("Default Extractors")
             } footer: {
-                Text("Reviewed packages run outside the app through the extractor protocol. Installed packages are local additions. Connected services use host-managed providers.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            // Transcripts are a different operation domain (host adapters,
-            // not the package protocol), so the picker is its own section at
-            // the same level as the extractor routes.
-            Section {
-                Picker("Podcast Transcript", selection: podcastBackendBinding) {
-                    Text("Prompt me when transcribing").tag(nil as PodcastTranscriptionBackend?)
-                    ForEach(PodcastTranscriptionBackend.allCases, id: \.self) { backend in
-                        Text(backend.displayName).tag(backend as PodcastTranscriptionBackend?)
-                    }
-                }
-                .onChange(of: draftPodcastBackend) { persistAll() }
-                .accessibilityLabel("Default podcast transcript extractor")
-            } header: {
-                Text("Transcripts")
-            } footer: {
-                Text("Podcast transcripts are not package-backed in protocol revision 1.")
+                Text("Reviewed packages run outside the app through the extractor protocol. Installed packages are local additions. Connected services use host-managed providers. Podcast transcripts are not package-backed in protocol revision 1.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -703,26 +683,43 @@ struct ExtractionSettingsView: View {
     /// the live status. The fixed height keeps the Settings window bounded —
     /// the table scrolls internally when registrations add routes.
     private var extractorRouteTable: some View {
-        Table(routeRows) {
-            TableColumn("Format") { (row: ExtractorRouteSettingsRow) in
-                Label(row.descriptor.displayName, systemImage: row.descriptor.systemImage ?? "doc")
-                    // Technical MIME identity lives in help text, not a column.
-                    .help("MIME type: \(row.route.mimeType.rawValue)")
+        Table(defaultsRows) {
+            TableColumn("Format") { (row: ExtractionDefaultsTableRow) in
+                switch row {
+                case .route(let routeRow):
+                    Label(routeRow.descriptor.displayName, systemImage: routeRow.descriptor.systemImage ?? "doc")
+                        // Technical MIME identity lives in help text, not a column.
+                        .help("MIME type: \(routeRow.route.mimeType.rawValue)")
+                case .podcastTranscript:
+                    Label(Self.podcastTranscriptRowTitle, systemImage: "waveform")
+                        .help(Self.podcastTranscriptHelp)
+                }
             }
             .width(min: 90, ideal: 120)
-            TableColumn("Default extractor") { (row: ExtractorRouteSettingsRow) in
-                routePicker(row)
+            TableColumn("Default extractor") { (row: ExtractionDefaultsTableRow) in
+                switch row {
+                case .route(let routeRow): routePicker(routeRow)
+                case .podcastTranscript: podcastTranscriptPicker
+                }
             }
             .width(min: 220, ideal: 280)
-            TableColumn("Status") { (row: ExtractorRouteSettingsRow) in
-                statusLabel(row)
+            TableColumn("Status") { (row: ExtractionDefaultsTableRow) in
+                switch row {
+                case .route(let routeRow):
+                    statusLabel(routeRow)
+                case .podcastTranscript:
+                    // A host adapter has no package to install, activate, or
+                    // authorize, so the table builder's non-package answer
+                    // (ready) is the honest one here too.
+                    podcastTranscriptStatusBadge
+                }
             }
             // Status is a semantic-colored icon + short label — compact by
             // design (PR 4 review follow-up: the long phrase truncated, so
             // the icon carries the state and the short text never wraps).
             .width(min: 110, ideal: 120)
-            TableColumn("Configuration") { (row: ExtractorRouteSettingsRow) in
-                if let dialog = configurationDialog(for: row) {
+            TableColumn("Configuration") { (row: ExtractionDefaultsTableRow) in
+                if case .route(let routeRow) = row, let dialog = configurationDialog(for: routeRow) {
                     Button("Configure…") {
                         serviceConfigurationDialog = dialog
                     }
@@ -733,7 +730,7 @@ struct ExtractionSettingsView: View {
             }
             .width(min: 110, ideal: 130)
         }
-        .frame(height: Metrics.routeTableHeight)
+        .frame(height: SettingsPackageTableMetrics.height(forRowCount: defaultsRows.count))
         .accessibilityIdentifier(RouteAccessibility.table)
         .accessibilityLabel("Default extractor routes")
         .sheet(item: $serviceConfigurationDialog) { dialog in
@@ -767,6 +764,47 @@ struct ExtractionSettingsView: View {
                     onCredentialMutation: { outcome in await handleMutationOutcome(outcome) })
             }
         }
+    }
+
+    static let podcastTranscriptRowTitle = "Podcast transcript"
+    static let podcastTranscriptHelp = "Podcast transcripts are not package-backed in protocol revision 1. They resolve through a host adapter."
+
+    /// Every default the table shows: the registration-driven extraction
+    /// routes, then the podcast transcript default.
+    private var defaultsRows: [ExtractionDefaultsTableRow] {
+        routeRows.map(ExtractionDefaultsTableRow.route)
+            + [.podcastTranscript(draftPodcastBackend)]
+    }
+
+    /// The transcript row's pop-up. It writes a `PodcastTranscriptionBackend`,
+    /// not an `ExtractorRouteSettingsSelection`, which is exactly why the row
+    /// is its own case rather than a synthesized route.
+    private var podcastTranscriptPicker: some View {
+        Picker("Podcast Transcript", selection: podcastBackendBinding) {
+            Text("Prompt me when transcribing").tag(nil as PodcastTranscriptionBackend?)
+            ForEach(PodcastTranscriptionBackend.allCases, id: \.self) { backend in
+                Text(backend.displayName).tag(backend as PodcastTranscriptionBackend?)
+            }
+        }
+        .labelsHidden()
+        .frame(maxWidth: 260)
+        .onChange(of: draftPodcastBackend) { persistAll() }
+        .accessibilityIdentifier(RouteAccessibility.podcastPicker)
+        .accessibilityLabel("Default podcast transcript extractor")
+        .accessibilityValue(draftPodcastBackend?.displayName ?? "Prompt me when transcribing")
+    }
+
+    private var podcastTranscriptStatusBadge: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+            Text("Ready")
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .lineLimit(1)
+        .help(Self.podcastTranscriptHelp)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Podcast transcript, ready")
     }
 
     /// One row's pop-up. Tags are the typed `ExtractorRouteSettingsSelection`
@@ -996,6 +1034,9 @@ struct ExtractionSettingsView: View {
         static let table = "extraction.routes.table"
         static let pickerPrefix = "extraction.routes.picker"
         static let statusPrefix = "extraction.routes.status"
+        /// The transcript row is not route-scoped, so its picker takes a fixed
+        /// identifier rather than a route-derived one.
+        static let podcastPicker = "extraction.routes.picker.podcast"
     }
 
     // MARK: - Extractor status recovery
@@ -1957,10 +1998,6 @@ struct ExtractionSettingsView: View {
         /// switching backends (sections of different heights) doesn't resize
         /// the window. A short section just leaves space below it.
         static let height: CGFloat = 420
-        /// The route table's fixed height: the three canonical rows plus room
-        /// for a few registration-derived rows, with internal scrolling
-        /// beyond that so the Settings window never grows without bound.
-        static let routeTableHeight: CGFloat = 172
         static let packageSectionSpacing: CGFloat = 10
         static let packageActionBarSpacing: CGFloat = 6
         static let packageDetailSpacing: CGFloat = 6
@@ -2250,6 +2287,26 @@ struct ExtractorCredentialRequirementSummary: Identifiable, Hashable, Sendable {
         case .authorized: return "Authorized"
         case .needsAuthorization: return "Needs authorization"
         case .changedContract: return "Changed — re-authorization needed"
+        }
+    }
+}
+
+/// One row of the Default Extractors table. A packaged extraction route and the
+/// podcast transcript default are different operation domains: a route resolves
+/// through the package protocol's registrations and writes an
+/// `ExtractorRouteSettingsSelection`, while a transcript resolves through a host
+/// adapter and writes a `PodcastTranscriptionBackend`. They share a table but
+/// not a selection type and not an id space, so the case tag is what lets one
+/// table show both without either pretending to be the other.
+enum ExtractionDefaultsTableRow: Identifiable, Hashable, Sendable {
+    case route(ExtractorRouteSettingsRow)
+    /// Carries the current choice so the table diffs when the user changes it.
+    case podcastTranscript(PodcastTranscriptionBackend?)
+
+    var id: String {
+        switch self {
+        case .route(let row): "route/\(row.id)"
+        case .podcastTranscript: "transcript/podcast"
         }
     }
 }

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -131,7 +131,7 @@ struct ExtractionRouteTableHostedTests {
     /// The pane hosts two tables — routes and installed packages — so a
     /// row-count assertion has to name the multiset it expects rather than
     /// trust which one a depth-first walk reaches first.
-    private func tableViewRowCounts(_ window: NSWindow) -> [Int] {
+    private func tableViews(_ window: NSWindow) -> [NSTableView] {
         guard let content = window.contentView else { return [] }
         var tables: [NSTableView] = []
         func walk(_ view: NSView) {
@@ -139,7 +139,27 @@ struct ExtractionRouteTableHostedTests {
             for subview in view.subviews { walk(subview) }
         }
         walk(content)
-        return tables.map(\.numberOfRows).sorted()
+        return tables
+    }
+
+    private func tableViewRowCounts(_ window: NSWindow) -> [Int] {
+        tableViews(window).map(\.numberOfRows).sorted()
+    }
+
+    /// Rows the table knows about but does not show, because its frame is
+    /// shorter than its content.
+    ///
+    /// `numberOfRows` counts a clipped row exactly like a visible one, so it
+    /// cannot catch a table sized with the wrong row height — the frame is one
+    /// row too short and the last row sits entirely below the fold. Each pane
+    /// computes its own height (a `Table` has no intrinsic content size), so
+    /// this is the assertion that keeps those numbers honest.
+    private func clippedRowCount(_ table: NSTableView) -> Int {
+        guard let clip = table.enclosingScrollView?.contentView else { return 0 }
+        let visibleHeight = clip.bounds.height
+        return (0..<table.numberOfRows).filter { row in
+            table.rect(ofRow: row).maxY > visibleHeight + 0.5
+        }.count
     }
 
     @Test("the route table mounts, loads its snapshot, and scrolls internally")
@@ -178,6 +198,12 @@ struct ExtractionRouteTableHostedTests {
         // Four route rows plus the podcast transcript row, and the package
         // table empty beside them.
         #expect(tableViewRowCounts(window) == [0, 5])
+        // Under the metrics ceiling every row has to be visible, not merely
+        // present. The transcript row is last, so a table sized one row short
+        // hides exactly it.
+        for table in tableViews(window) {
+            #expect(clippedRowCount(table) == 0)
+        }
     }
 
     @Test("the package table mounts active and failed revisions as rows")
@@ -207,6 +233,9 @@ struct ExtractionRouteTableHostedTests {
         }
 
         #expect(tableViewRowCounts(window) == [2, 4])
+        for table in tableViews(window) {
+            #expect(clippedRowCount(table) == 0)
+        }
         let content = try #require(window.contentView)
         #expect(content.fittingSize.height > 0)
     }
@@ -296,7 +325,7 @@ struct ExtractionRouteTableHostedTests {
 
         // The height comes from a named metric, not a magic literal.
         let source = try sourceView()
-        #expect(source.contains("SettingsPackageTableMetrics.height(forRowCount: defaultsRows.count)"))
+        #expect(source.contains("rowHeight: SettingsTableMetrics.controlRowHeight"))
         #expect(source.contains("Table(defaultsRows)"))
     }
 

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -61,13 +61,15 @@ struct ExtractionRouteTableHostedTests {
 
     private func makeView(
         directory: URL,
-        snapshot: ExtractorPackageSettingsSnapshot
+        snapshot: ExtractorPackageSettingsSnapshot,
+        pane: ExtractionSettingsPane = .defaults
     ) -> ExtractionSettingsView {
         ExtractionSettingsView(
             containerDirectory: directory,
             launcher: AgentLauncher(),
             credentials: Self.stubCredentials,
-            packageSnapshot: { snapshot })
+            packageSnapshot: { snapshot },
+            initialPane: pane)
     }
 
     private func mount(_ view: ExtractionSettingsView) -> NSWindow {
@@ -162,7 +164,7 @@ struct ExtractionRouteTableHostedTests {
         }.count
     }
 
-    @Test("the route table mounts, loads its snapshot, and scrolls internally")
+    @Test("Settings opens on the defaults pane, which mounts the route table")
     func rendersRouteTableWithoutCrash() async throws {
         let lease = await HostedAppKitTestGate.shared.acquire()
         defer { lease.release() }
@@ -195,9 +197,10 @@ struct ExtractionRouteTableHostedTests {
         // clip view — the scrollable, window-bounded layout.
         let content = try #require(window.contentView)
         #expect(containsDescendant(content) { $0 is NSClipView })
-        // Four route rows plus the podcast transcript row, and the package
-        // table empty beside them.
-        #expect(tableViewRowCounts(window) == [0, 5])
+        // Four route rows plus the podcast transcript row. The packages pane
+        // is a separate tab, so its table is not mounted here — which is also
+        // what pins the default pane.
+        #expect(tableViewRowCounts(window) == [5])
         // Under the metrics ceiling every row has to be visible, not merely
         // present. The transcript row is last, so a table sized one row short
         // hides exactly it.
@@ -224,15 +227,15 @@ struct ExtractionRouteTableHostedTests {
                     version: try ExtractorPackageVersion(validating: "1.0.0"),
                     digest: try ExtractorPackageDigest(hex: String(repeating: "b", count: 64)))),
         ]
-        let window = mount(makeView(directory: dir, snapshot: loaded))
+        let window = mount(makeView(directory: dir, snapshot: loaded, pane: .packages))
 
-        // Three canonical route rows plus the podcast transcript row, and one
-        // active plus one failed revision folded into the package table.
+        // One active plus one failed revision folded into one table. The
+        // defaults pane is a separate tab, so its route table is not mounted.
         try await waitUntil {
-            self.tableViewRowCounts(window) == [2, 4]
+            self.tableViewRowCounts(window) == [2]
         }
 
-        #expect(tableViewRowCounts(window) == [2, 4])
+        #expect(tableViewRowCounts(window) == [2])
         for table in tableViews(window) {
             #expect(clippedRowCount(table) == 0)
         }
@@ -406,6 +409,25 @@ struct ExtractionRouteTableHostedTests {
         #expect(source.contains("extraction.routes.picker.podcast"))
         #expect(source.contains("Podcast transcripts are not package-backed in protocol revision 1."))
         #expect(!source.contains("Text(\"Transcripts\")"))
+    }
+
+    @Test("the pane switcher lists defaults first and opens on it")
+    func paneSwitcherDefaultsToTheDefaultsPane() throws {
+        // The order is what the segmented control renders, so defaults sits on
+        // the leading edge as well as being the initial selection.
+        #expect(ExtractionSettingsPane.allCases == [.defaults, .packages])
+        #expect(ExtractionSettingsPane.defaults.title == "Defaults")
+        #expect(ExtractionSettingsPane.packages.title == "Packages")
+
+        let source = try sourceView()
+        #expect(source.contains("initialPane: ExtractionSettingsPane = .defaults"))
+        #expect(source.contains(".pickerStyle(.segmented)"))
+        #expect(source.contains("extraction.pane.switcher"))
+        #expect(source.contains("case .defaults: defaultsPane"))
+        #expect(source.contains("case .packages: packagesPane"))
+        // Both panes can raise the service configuration sheet, so it is
+        // presented above the switcher rather than inside one pane.
+        #expect(source.contains(".sheet(item: $serviceConfigurationDialog) { dialog in\n            serviceConfigurationSheet(dialog)"))
     }
 
     @Test("the transcript row keeps its own id space and tracks its selection")

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -169,14 +169,15 @@ struct ExtractionRouteTableHostedTests {
         let window = mount(view)
 
         try await waitUntil {
-            self.tableViewRowCounts(window).contains(4)
+            self.tableViewRowCounts(window).contains(5)
         }
         // The hosted hierarchy contains a native table (row views) inside a
         // clip view — the scrollable, window-bounded layout.
         let content = try #require(window.contentView)
         #expect(containsDescendant(content) { $0 is NSClipView })
-        // The four route rows, and the package table empty beside them.
-        #expect(tableViewRowCounts(window) == [0, 4])
+        // Four route rows plus the podcast transcript row, and the package
+        // table empty beside them.
+        #expect(tableViewRowCounts(window) == [0, 5])
     }
 
     @Test("the package table mounts active and failed revisions as rows")
@@ -199,13 +200,13 @@ struct ExtractionRouteTableHostedTests {
         ]
         let window = mount(makeView(directory: dir, snapshot: loaded))
 
-        // Three canonical route rows, and one active plus one failed revision
-        // folded into the package table.
+        // Three canonical route rows plus the podcast transcript row, and one
+        // active plus one failed revision folded into the package table.
         try await waitUntil {
-            self.tableViewRowCounts(window) == [2, 3]
+            self.tableViewRowCounts(window) == [2, 4]
         }
 
-        #expect(tableViewRowCounts(window) == [2, 3])
+        #expect(tableViewRowCounts(window) == [2, 4])
         let content = try #require(window.contentView)
         #expect(content.fittingSize.height > 0)
     }
@@ -295,8 +296,8 @@ struct ExtractionRouteTableHostedTests {
 
         // The height comes from a named metric, not a magic literal.
         let source = try sourceView()
-        #expect(source.contains("routeTableHeight"))
-        #expect(source.contains("Table(routeRows)"))
+        #expect(source.contains("SettingsPackageTableMetrics.height(forRowCount: defaultsRows.count)"))
+        #expect(source.contains("Table(defaultsRows)"))
     }
 
     // MARK: - AC.8 / AC.11 / AC.12 / AC.14 / AC.15 contracts
@@ -308,7 +309,7 @@ struct ExtractionRouteTableHostedTests {
         let source = try sourceView()
 
         // The table and its columns.
-        #expect(source.contains("Table(routeRows)"))
+        #expect(source.contains("Table(defaultsRows)"))
         #expect(source.contains("TableColumn(\"Format\")"))
         #expect(source.contains("TableColumn(\"Default extractor\")"))
         #expect(source.contains("TableColumn(\"Status\")"))
@@ -364,14 +365,42 @@ struct ExtractionRouteTableHostedTests {
         #expect(source.contains("DoclingConfigurationDialog("))
 
         // Technical MIME identity stays out of the primary columns (help text).
-        #expect(source.contains("MIME type: \\(row.route.mimeType.rawValue)"))
-        #expect(source.contains("Text(\"\\(row.route.mimeType.rawValue)\")") == false)
+        #expect(source.contains("MIME type: \\(routeRow.route.mimeType.rawValue)"))
+        #expect(source.contains("Text(\"\\(routeRow.route.mimeType.rawValue)\")") == false)
 
-        // The podcast picker is its own section at the same level as the
-        // extractor routes, wired to the podcast binding.
+        // The podcast transcript default is a row of the same table, not its
+        // own section: it is a default extractor like any other, even though a
+        // host adapter resolves it rather than a package registration.
         #expect(source.contains("podcastBackendBinding"))
         #expect(source.contains("Picker(\"Podcast Transcript\", selection: podcastBackendBinding)"))
-        #expect(source.contains("Text(\"Transcripts\")"))
+        #expect(source.contains("case podcastTranscript(PodcastTranscriptionBackend?)"))
+        #expect(source.contains("extraction.routes.picker.podcast"))
+        #expect(source.contains("Podcast transcripts are not package-backed in protocol revision 1."))
+        #expect(!source.contains("Text(\"Transcripts\")"))
+    }
+
+    @Test("the transcript row keeps its own id space and tracks its selection")
+    func transcriptRowIsItsOwnIdentity() throws {
+        let routeRow = ExtractorRouteSettingsRow(
+            descriptor: ExtractorRouteDescriptor(
+                route: .canonicalPDF,
+                displayName: "PDF",
+                systemImage: "doc.richtext"),
+            savedSelection: nil,
+            resolvedSelection: nil,
+            choices: [],
+            status: .ready)
+
+        let route = ExtractionDefaultsTableRow.route(routeRow)
+        let prompt = ExtractionDefaultsTableRow.podcastTranscript(nil)
+        let chosen = ExtractionDefaultsTableRow.podcastTranscript(.appleTranscript)
+
+        // A transcript is not a route, so it cannot collide with one.
+        #expect(route.id != prompt.id)
+        // The transcript row is one row whichever backend it names, so the
+        // table updates it in place instead of replacing it.
+        #expect(prompt.id == chosen.id)
+        #expect(prompt != chosen)
     }
 
     @Test("picker options show only extractor names")

--- a/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
+++ b/Tests/WikiFSAppTests/ExtractionRouteTableHostedTests.swift
@@ -128,6 +128,20 @@ struct ExtractionRouteTableHostedTests {
         return result
     }
 
+    /// The pane hosts two tables — routes and installed packages — so a
+    /// row-count assertion has to name the multiset it expects rather than
+    /// trust which one a depth-first walk reaches first.
+    private func tableViewRowCounts(_ window: NSWindow) -> [Int] {
+        guard let content = window.contentView else { return [] }
+        var tables: [NSTableView] = []
+        func walk(_ view: NSView) {
+            if let table = view as? NSTableView { tables.append(table) }
+            for subview in view.subviews { walk(subview) }
+        }
+        walk(content)
+        return tables.map(\.numberOfRows).sorted()
+    }
+
     @Test("the route table mounts, loads its snapshot, and scrolls internally")
     func rendersRouteTableWithoutCrash() async throws {
         let lease = await HostedAppKitTestGate.shared.acquire()
@@ -155,14 +169,45 @@ struct ExtractionRouteTableHostedTests {
         let window = mount(view)
 
         try await waitUntil {
-            self.firstTableView(window)?.numberOfRows == 4
+            self.tableViewRowCounts(window).contains(4)
         }
         // The hosted hierarchy contains a native table (row views) inside a
         // clip view — the scrollable, window-bounded layout.
         let content = try #require(window.contentView)
         #expect(containsDescendant(content) { $0 is NSClipView })
-        let table = try #require(firstTableView(window))
-        #expect(table.numberOfRows == 4)
+        // The four route rows, and the package table empty beside them.
+        #expect(tableViewRowCounts(window) == [0, 4])
+    }
+
+    @Test("the package table mounts active and failed revisions as rows")
+    func rendersPackageTableWithoutCrash() async throws {
+        let lease = await HostedAppKitTestGate.shared.acquire()
+        defer { lease.release() }
+        let dir = try tempDirectory("package-table-render")
+        var loaded = snapshot(failedPackageIDs: ["org.example.broken"])
+        loaded.rows = [
+            ExtractorPackageSettingsRow(
+                kind: .pdf,
+                packageID: "org.example.pdf",
+                version: "1.0.0",
+                digestPrefix: String(repeating: "b", count: 12),
+                registrationID: "pdf",
+                revision: ExtractorPackageRevisionID(
+                    packageID: try ExtractorPackageID(validating: "org.example.pdf"),
+                    version: try ExtractorPackageVersion(validating: "1.0.0"),
+                    digest: try ExtractorPackageDigest(hex: String(repeating: "b", count: 64)))),
+        ]
+        let window = mount(makeView(directory: dir, snapshot: loaded))
+
+        // Three canonical route rows, and one active plus one failed revision
+        // folded into the package table.
+        try await waitUntil {
+            self.tableViewRowCounts(window) == [2, 3]
+        }
+
+        #expect(tableViewRowCounts(window) == [2, 3])
+        let content = try #require(window.contentView)
+        #expect(content.fittingSize.height > 0)
     }
 
     @Test("a non-ready route status dialog mounts with recovery controls")

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -451,35 +451,41 @@ struct ExtractorPackageSettingsTests {
         #expect(viewSource.contains("extraction.packages.row"))
         #expect(viewSource.contains("extraction.packages.digest"))
         #expect(viewSource.contains("extraction.packages.registration"))
-        #expect(viewSource.contains(".accessibilityValue(\"Active\")"))
-        #expect(viewSource.contains(".accessibilityLabel(\"\\(row.packageID), version \\(row.version)"))
+        #expect(viewSource.contains("extraction.packages.status"))
+        #expect(viewSource.contains(".accessibilityValue(row.status.label)"))
+        #expect(viewSource.contains(".accessibilityLabel(\"Diagnostics for \\(row.packageID), version \\(row.version)\")"))
         #expect(viewSource.contains(".accessibilityAddTraits(.updatesFrequently)"))
 
         // Phase 7 import/removal/readiness controls keep derivable identifiers.
-        #expect(viewSource.contains("extraction.packages.import.disclosure"))
+        #expect(viewSource.contains("extraction.packages.table"))
         #expect(viewSource.contains("extraction.packages.import.button"))
         #expect(viewSource.contains("extraction.packages.import.trust"))
         #expect(viewSource.contains("extraction.packages.remove"))
-        #expect(viewSource.contains("extraction.packages.failure"))
-        #expect(viewSource.contains("extraction.packages.failure.message"))
         #expect(viewSource.contains("extraction.routes.table"))
         #expect(viewSource.contains("extraction.routes.picker"))
         #expect(viewSource.contains("progress"))
         #expect(viewSource.contains("extraction.packages.diagnostic"))
         #expect(viewSource.contains("extraction.packages.error"))
-        #expect(viewSource.contains(".accessibilityValue(\"Not ready\")"))
+        // A failed revision keeps a table row instead of a separate list, so
+        // its readiness is a status case rather than a hard-coded value.
+        #expect(viewSource.contains("case .notReady: \"Not ready\""))
+        #expect(!viewSource.contains("extraction.packages.failure"))
+        #expect(!viewSource.contains("failedPackageRow"))
 
-        // Local-directory-only import contract + executable-code trust warning.
-        #expect(viewSource.contains("Advanced Local Package Import"))
-        // Keep import controls in a separate top-level Form section from the
-        // installed package rows. The visible title is the disclosure label.
-        #expect(viewSource.contains("installedPackagesSection\n                if packageModel.canImport {\n                    packageImportSection"))
-        #expect(viewSource.contains("@ViewBuilder private var packageImportSection: some View {\n        Section {"))
-        #expect(viewSource.contains("Text(ExtractorSettingsPackagePicker.disclosureTitle)"))
+        // Packages are a selectable table with a computed height, so the pane
+        // scrolls internally instead of growing the Settings window.
+        #expect(viewSource.contains("Table(packageModel.tableRows, selection: $selectedPackageID)"))
+        #expect(viewSource.contains("SettingsPackageTableMetrics.height("))
+        // Add is a first-class control under the table, not a disclosure.
+        #expect(viewSource.contains("Button(\"Add Package…\", systemImage: \"plus\")"))
+        #expect(!viewSource.contains("Advanced Local Package Import"))
+        #expect(!viewSource.contains("packageImportSection"))
+        // The package rows are a table now. The one remaining disclosure is the
+        // route status dialog's technical details, which is not a package row.
+        #expect(!viewSource.contains("DisclosureGroup {"))
         #expect(viewSource.contains(".frame(maxWidth: .infinity, alignment: .leading)"))
-        #expect(viewSource.contains(".contentShape(Rectangle())"))
-        #expect(viewSource.contains("            .contentShape(Rectangle())\n        }\n        .accessibilityIdentifier(\"\\(PackageAccessibility.rowPrefix).\\(row.id)\")"))
-        #expect(viewSource.contains("            .contentShape(Rectangle())\n        }\n        .accessibilityIdentifier(\"\\(PackageAccessibility.failurePrefix).\\(failure.id)\")"))
+        // Local-directory-only import contract + executable-code trust warning
+        // stay visible in the section footer rather than behind a disclosure.
         #expect(viewSource.contains("Import Extractor Package…"))
         #expect(viewSource.contains("Select one local extractor package folder as an import source."))
         #expect(viewSource.contains("Files and archives are not supported."))
@@ -558,6 +564,194 @@ struct ExtractorPackageSettingsTests {
             registrationID: try ExtractorRegistrationID(validating: "pdf"))
     }
 
+    // MARK: - Table rows and inline per-package diagnostics
+
+    @Test("the table folds active and failed revisions into one list, failures first")
+    func tableRowsFoldBothListsWithFailuresFirst() throws {
+        let row = try settingsRow()
+        let failure = ExtractorPackageFailureSummary(
+            packageID: "org.example.brokenpkg",
+            version: "2.0.0",
+            digestPrefix: String(repeating: "c", count: 12),
+            message: "package activation failed")
+
+        let rows = ExtractorPackageSettingsModel.tableRows(
+            from: ExtractorPackageSettingsSnapshot(rows: [row], failedPackages: [failure]))
+
+        #expect(rows.count == 2)
+        #expect(rows[0].packageID == failure.packageID)
+        #expect(rows[0].status == .notReady(failure.message))
+        // A failed revision registered nothing, so it has no registration and
+        // no installed row to remove or configure.
+        #expect(rows[0].registrationID == nil)
+        #expect(rows[0].installedRow == nil)
+        #expect(rows[1].packageID == row.packageID)
+        #expect(rows[1].status == .active)
+        #expect(rows[1].installedRow == row)
+        // The case tag keeps a failure id from colliding with a registration id.
+        #expect(rows[0].id != rows[1].id)
+    }
+
+    @Test("a revision waiting to activate is not judged on its credentials")
+    func waitingOutranksAuthorizationState() throws {
+        let row = try settingsRow()
+        let snapshot = ExtractorPackageSettingsSnapshot(
+            rows: [row],
+            waitingRevisionIDs: [row.revision],
+            credentialRequirements: [Self.requirement(for: row, isOptional: false, state: .needsAuthorization)])
+
+        #expect(ExtractorPackageSettingsModel.tableRows(from: snapshot).first?.status == .waitingForActivation)
+    }
+
+    @Test("an unauthorized required credential shows on the package, an optional one does not")
+    func authorizationStatusFollowsRequiredRequirements() throws {
+        let row = try settingsRow()
+
+        let required = ExtractorPackageSettingsSnapshot(
+            rows: [row],
+            credentialRequirements: [Self.requirement(for: row, isOptional: false, state: .needsAuthorization)])
+        #expect(ExtractorPackageSettingsModel.tableRows(from: required).first?.status == .needsAuthorization)
+
+        let changed = ExtractorPackageSettingsSnapshot(
+            rows: [row],
+            credentialRequirements: [Self.requirement(for: row, isOptional: false, state: .changedContract)])
+        #expect(ExtractorPackageSettingsModel.tableRows(from: changed).first?.status == .needsAuthorization)
+
+        // An optional requirement does not stop the package running, so it
+        // must not claim the package needs attention.
+        let optional = ExtractorPackageSettingsSnapshot(
+            rows: [row],
+            credentialRequirements: [Self.requirement(for: row, isOptional: true, state: .needsAuthorization)])
+        #expect(ExtractorPackageSettingsModel.tableRows(from: optional).first?.status == .active)
+
+        let authorized = ExtractorPackageSettingsSnapshot(
+            rows: [row],
+            credentialRequirements: [Self.requirement(for: row, isOptional: false, state: .authorized)])
+        #expect(ExtractorPackageSettingsModel.tableRows(from: authorized).first?.status == .active)
+    }
+
+    @Test("every status explains itself so a row never shows a bare state word")
+    func everyStatusCarriesAnExplanation() {
+        let statuses: [ExtractorPackageStatus] = [
+            .active, .waitingForActivation, .needsAuthorization, .notReady("activation failed")
+        ]
+
+        for status in statuses {
+            #expect(status.label.isEmpty == false)
+            #expect(status.explanation.isEmpty == false)
+            #expect(status.systemImage.isEmpty == false)
+        }
+        // A failed revision carries the reconciler's own redacted text.
+        #expect(ExtractorPackageStatus.notReady("activation failed").explanation == "activation failed")
+    }
+
+    @Test("an import that produced no row reports on the pane, not on a package")
+    func importFailureIsPaneScoped() async {
+        let model = ExtractorPackageSettingsModel(
+            loadSnapshot: { ExtractorPackageSettingsSnapshot.empty },
+            importPackage: { _ in .failed("Package validation failed.") })
+
+        await model.importPackage(from: URL(fileURLWithPath: "/tmp/import-source"))
+
+        #expect(model.paneNotice?.severity == .failure)
+        #expect(model.paneNotice?.message == "Package validation failed.")
+        #expect(model.lastError == "Package validation failed.")
+        #expect(model.lastDiagnostic == nil)
+    }
+
+    @Test("an import scopes its confirmation to the row it produced")
+    func importSuccessScopesToTheNewRow() async throws {
+        let row = try settingsRow()
+        let installed = Flag()
+        let model = ExtractorPackageSettingsModel(
+            loadSnapshot: {
+                await installed.isSet ? ExtractorPackageSettingsSnapshot(rows: [row]) : .empty
+            },
+            importPackage: { _ in
+                await installed.set()
+                return .succeeded(nil)
+            })
+
+        await model.refresh()
+        await model.importPackage(from: URL(fileURLWithPath: "/tmp/import-source"))
+
+        let expected = try #require(model.tableRows.first)
+        #expect(model.notice?.scope == .package(expected.id))
+        #expect(model.notice(for: expected)?.message == "Extractor package installed.")
+        #expect(model.paneNotice == nil)
+    }
+
+    @Test("a successful removal reports on the pane because its row is gone")
+    func removalSuccessIsPaneScoped() async throws {
+        let row = try settingsRow()
+        let removed = Flag()
+        let model = ExtractorPackageSettingsModel(
+            loadSnapshot: {
+                await removed.isSet ? .empty : ExtractorPackageSettingsSnapshot(rows: [row])
+            },
+            removePackage: { _ in
+                await removed.set()
+                return .succeeded(nil)
+            })
+
+        await model.refresh()
+        await model.remove(row)
+
+        #expect(model.tableRows.isEmpty)
+        #expect(model.paneNotice?.severity == .success)
+        #expect(model.lastDiagnostic == "Removed org.example.pdfpkg 1.0.0.")
+    }
+
+    @Test("a failed removal reports on the package it could not remove")
+    func removalFailureIsPackageScoped() async throws {
+        let row = try settingsRow()
+        let model = ExtractorPackageSettingsModel(
+            loadSnapshot: { ExtractorPackageSettingsSnapshot(rows: [row]) },
+            removePackage: { _ in .failed("The package could not be removed.") })
+
+        await model.refresh()
+        await model.remove(row)
+
+        let remaining = try #require(model.tableRows.first)
+        #expect(model.notice(for: remaining)?.severity == .failure)
+        #expect(model.paneNotice == nil)
+    }
+
+    @Test("one notice at a time: a later outcome replaces the one before it")
+    func oneNoticeAtATime() async {
+        let model = ExtractorPackageSettingsModel(
+            loadSnapshot: { ExtractorPackageSettingsSnapshot.empty },
+            importPackage: { _ in .succeeded("Extractor package installed.") })
+        model.reportFailure("Authorization failed.")
+        #expect(model.lastError == "Authorization failed.")
+
+        await model.importPackage(from: URL(fileURLWithPath: "/tmp/import-source"))
+
+        #expect(model.lastError == nil)
+        #expect(model.lastDiagnostic == "Extractor package installed.")
+    }
+
+    private static func requirement(
+        for row: ExtractorPackageSettingsRow,
+        isOptional: Bool,
+        state: ExtractorCredentialRequirementSummary.AuthorizationState
+    ) -> ExtractorCredentialRequirementSummary {
+        ExtractorCredentialRequirementSummary(
+            packageID: row.packageID,
+            packageName: row.packageID,
+            packageVersion: row.version,
+            registrationID: row.registrationID,
+            requirementID: "token",
+            label: "API token",
+            purpose: "Calls the extraction service",
+            isOptional: isOptional,
+            isConfigured: false,
+            sourceName: "Keychain",
+            authorizationState: state,
+            kinds: ["pdf"],
+            mimeTypes: ["application/pdf"])
+    }
+
     private func settingsRow() throws -> ExtractorPackageSettingsRow {
         let reference = try reference(
             packageID: "org.example.pdfpkg",
@@ -618,6 +812,13 @@ struct ExtractorPackageSettingsTests {
 private actor Counter {
     private(set) var value = 0
     func increment() { value += 1 }
+}
+
+/// Sendable latch letting a stub loader answer differently before and after the
+/// mutation the test is exercising.
+private actor Flag {
+    private(set) var isSet = false
+    func set() { isSet = true }
 }
 
 /// Sendable box capturing the revision a removal action received.

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -475,7 +475,7 @@ struct ExtractorPackageSettingsTests {
         // Packages are a selectable table with a computed height, so the pane
         // scrolls internally instead of growing the Settings window.
         #expect(viewSource.contains("Table(packageModel.tableRows, selection: $selectedPackageID)"))
-        #expect(viewSource.contains("SettingsPackageTableMetrics.height("))
+        #expect(viewSource.contains("SettingsTableMetrics.height("))
         // Add is a first-class control under the table, not a disclosure.
         #expect(viewSource.contains("Button(\"Add Package…\", systemImage: \"plus\")"))
         #expect(!viewSource.contains("Advanced Local Package Import"))

--- a/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorPackageSettingsTests.swift
@@ -496,7 +496,7 @@ struct ExtractorPackageSettingsTests {
         #expect(viewSource.contains("Default Extractors"))
         #expect(viewSource.contains("Built-in default") == false)
         #expect(viewSource.contains("ExtractorRouteSettingsMapping.write"))
-        #expect(viewSource.contains("Table(routeRows)"))
+        #expect(viewSource.contains("Table(defaultsRows)"))
         #expect(viewSource.contains("extractorOption(\"Claude\"") == false)
         #expect(viewSource.contains("extractorOption(\"Gemini\"") == false)
         #expect(viewSource.contains("Claude (Anthropic API)") == false)

--- a/Tests/WikiFSAppTests/ExtractorSettingsHelpTests.swift
+++ b/Tests/WikiFSAppTests/ExtractorSettingsHelpTests.swift
@@ -1,0 +1,111 @@
+#if os(macOS)
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import WikiFS
+
+/// Mirrors `RendererSettingsHelpContentTests` for the extractor pane: the help
+/// popover explains the local-folder import contract and the one thing that
+/// separates an extractor package from a renderer package — it runs code.
+@Suite("Extractor settings help content", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct ExtractorSettingsHelpContentTests {
+    @Test("help content explains the package import contract and how a package runs")
+    func helpContentExplainsImportContract() throws {
+        let source = try sourceText()
+
+        #expect(source.contains("An extractor package turns one file into Markdown."))
+        #expect(source.contains("manifest.json"))
+        #expect(source.contains("validates the selected folder and copies it into the extractor store"))
+        #expect(source.contains("does not use the selected source folder after import"))
+        #expect(source.contains("ZIP files, other archives, remote catalogs, and network installation are not supported"))
+        // Protocol facts a package author and a cautious user both rely on.
+        #expect(source.contains("one-shot process"))
+        #expect(source.contains("JSON Lines"))
+        #expect(source.contains("lowercase SHA-256 digests"))
+        #expect(source.contains("stays blocked until you choose another extractor"))
+    }
+
+    @Test("the help states the executable-code risk with the pane's own warning")
+    func helpCarriesTheTrustWarning() throws {
+        let source = try sourceText()
+
+        // One definition of the warning: the popover reuses the string the
+        // import footer shows, so the two can never drift apart.
+        #expect(source.contains("ExtractionSettingsView.trustWarningMessage"))
+        #expect(source.contains("Executable code warning."))
+        #expect(source.contains("Declared capabilities are a declaration, not a security sandbox."))
+        #expect(ExtractionSettingsView.trustWarningMessage.contains("executable code"))
+    }
+
+    @Test("help surface uses stable accessible copy and system text styles")
+    func helpSurfaceHasAccessibleLabelsAndSystemTextStyles() throws {
+        let source = try sourceText()
+
+        #expect(source.contains("static let triggerTitle = \"What is an extractor package?\""))
+        #expect(source.contains("static let tooltip = \"Learn about local extractor packages\""))
+        #expect(source.contains(".accessibilityIdentifier(\"extractor-package-help-button\")"))
+        #expect(source.contains(".accessibilityLabel(ExtractorPackageHelpCopy.triggerTitle)"))
+        #expect(source.contains(".help(ExtractorPackageHelpCopy.tooltip)"))
+        #expect(source.contains(".font(.headline)"))
+        #expect(source.contains(".font(.body)"))
+        #expect(source.contains(".font(.system(.body, design: .monospaced))"))
+        #expect(!source.contains(".font(.system(size:"))
+    }
+
+    @Test("hostable help content renders in a macOS window")
+    func hostableHelpContentRendersInWindow() {
+        let host = NSHostingController(rootView: ExtractorPackageHelpContent())
+        let window = NSWindow(contentViewController: host)
+        window.setContentSize(NSSize(width: 460, height: 540))
+        window.makeKeyAndOrderFront(nil)
+        defer { window.close() }
+
+        host.view.layoutSubtreeIfNeeded()
+
+        #expect(window.contentViewController === host)
+        #expect(host.view.fittingSize.width > 0)
+        #expect(host.view.fittingSize.height > 0)
+    }
+
+    @Test("hosted help trigger presents and dismisses through its binding")
+    func hostedHelpTriggerTogglesItsBinding() {
+        var isPresented = false
+        let binding = Binding(get: { isPresented }, set: { isPresented = $0 })
+        let control = ExtractorPackageHelpControl(isPresented: binding)
+
+        control.presentHelp()
+        #expect(isPresented)
+
+        binding.wrappedValue = false
+        #expect(!isPresented)
+    }
+
+    @Test("the packages pane hosts the help control in its section header")
+    func packagesPaneExposesTheHelpControl() throws {
+        let settingsSource = try String(
+            contentsOf: repositoryRoot().appending(path: "Sources/WikiFS/Sources/ExtractionSettingsView.swift"),
+            encoding: .utf8)
+
+        #expect(settingsSource.contains("ExtractorPackageHelpControl(isPresented: $showingPackageHelp)"))
+        // An icon in the header, like the renderer pane's, not a row that
+        // competes with the package table.
+        #expect(settingsSource.contains(".labelStyle(.iconOnly)"))
+        #expect(settingsSource.contains("Installed Extractor Packages"))
+    }
+
+    private func sourceText() throws -> String {
+        try String(
+            contentsOf: repositoryRoot().appending(path: "Sources/WikiFS/Settings/ExtractorPackageHelp.swift"),
+            encoding: .utf8)
+    }
+
+    private func repositoryRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -30,7 +30,7 @@ struct RendererSettingsManagementViewTests {
         // Packages are a selectable table with a fixed height, so the pane
         // scrolls internally instead of growing the Settings window.
         #expect(source.contains("Table(model.rows, selection: $selectedPackageID)"))
-        #expect(source.contains(".frame(height: RendererPackageTableMetrics.height(forRowCount: model.rows.count))"))
+        #expect(source.contains(".frame(height: SettingsPackageTableMetrics.height(forRowCount: model.rows.count))"))
         // Add is a first-class control under the table, not a disclosure.
         #expect(source.contains("Button(\"Add Package…\", systemImage: \"plus\")"))
         #expect(source.contains("renderer-package-add-button"))
@@ -132,9 +132,9 @@ struct RendererSettingsManagementViewTests {
         #expect(host.view.fittingSize.height > 0)
     }
 
-    @Test("the table fits its rows between a floor and a ceiling")
+    @Test("the shared package table fits its rows between a floor and a ceiling")
     func tableHeightFollowsRowCountWithinBounds() {
-        let metrics = RendererPackageTableMetrics.self
+        let metrics = SettingsPackageTableMetrics.self
 
         // No rows: the empty state needs more room than the row floor gives.
         #expect(metrics.height(forRowCount: 0) == metrics.emptyHeight)

--- a/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
+++ b/Tests/WikiFSAppTests/RendererSettingsManagementViewTests.swift
@@ -30,7 +30,7 @@ struct RendererSettingsManagementViewTests {
         // Packages are a selectable table with a fixed height, so the pane
         // scrolls internally instead of growing the Settings window.
         #expect(source.contains("Table(model.rows, selection: $selectedPackageID)"))
-        #expect(source.contains(".frame(height: SettingsPackageTableMetrics.height(forRowCount: model.rows.count))"))
+        #expect(source.contains(".frame(height: SettingsTableMetrics.height(forRowCount: model.rows.count))"))
         // Add is a first-class control under the table, not a disclosure.
         #expect(source.contains("Button(\"Add Package…\", systemImage: \"plus\")"))
         #expect(source.contains("renderer-package-add-button"))
@@ -132,24 +132,36 @@ struct RendererSettingsManagementViewTests {
         #expect(host.view.fittingSize.height > 0)
     }
 
-    @Test("the shared package table fits its rows between a floor and a ceiling")
+    @Test("a control row is taller than a text row, so the caller picks one")
+    func rowHeightFollowsTheCellsInTheTable() {
+        let metrics = SettingsTableMetrics.self
+        // A Picker sets its row's height, so a table of pop-ups needs more room
+        // per row than a table of labels. Assuming the text height here clips
+        // the last row out of view entirely.
+        #expect(metrics.controlRowHeight > metrics.textRowHeight)
+        #expect(metrics.height(forRowCount: 4) == metrics.height(forRowCount: 4, rowHeight: metrics.textRowHeight))
+        #expect(metrics.height(forRowCount: 4, rowHeight: metrics.controlRowHeight)
+            == metrics.headerHeight + 4 * metrics.controlRowHeight)
+    }
+
+    @Test("the shared table fits its rows between a floor and a ceiling")
     func tableHeightFollowsRowCountWithinBounds() {
-        let metrics = SettingsPackageTableMetrics.self
+        let metrics = SettingsTableMetrics.self
 
         // No rows: the empty state needs more room than the row floor gives.
         #expect(metrics.height(forRowCount: 0) == metrics.emptyHeight)
 
         // Below the floor, a stray one-row strip is padded to two rows.
-        let floor = metrics.headerHeight + CGFloat(metrics.minimumVisibleRows) * metrics.rowHeight
+        let floor = metrics.headerHeight + CGFloat(metrics.minimumVisibleRows) * metrics.textRowHeight
         #expect(metrics.height(forRowCount: 1) == floor)
         #expect(metrics.height(forRowCount: metrics.minimumVisibleRows) == floor)
 
         // Between the bounds the table fits its rows exactly, so a short list
         // leaves no dead space.
-        #expect(metrics.height(forRowCount: 4) == metrics.headerHeight + 4 * metrics.rowHeight)
+        #expect(metrics.height(forRowCount: 4) == metrics.headerHeight + 4 * metrics.textRowHeight)
 
         // Past the ceiling the height stops growing and the table scrolls.
-        let ceiling = metrics.headerHeight + CGFloat(metrics.maximumVisibleRows) * metrics.rowHeight
+        let ceiling = metrics.headerHeight + CGFloat(metrics.maximumVisibleRows) * metrics.textRowHeight
         #expect(metrics.height(forRowCount: metrics.maximumVisibleRows) == ceiling)
         #expect(metrics.height(forRowCount: 200) == ceiling)
     }

--- a/progress/2026-08-31T210000Z-extractor-settings-package-table.md
+++ b/progress/2026-08-31T210000Z-extractor-settings-package-table.md
@@ -50,6 +50,32 @@ uses.
   to the section footer, where they are always visible. This matters more here
   than for renderers: an extractor package contains executable code.
 
+### Podcast transcripts join the route table
+
+The podcast transcript default was its own section below the route table. It is
+a default extractor like PDF, HTML, and Word, so it is now a row of the same
+table.
+
+`ExtractionDefaultsTableRow` is the table's row type: `.route` or
+`.podcastTranscript`. The two are different operation domains. A route resolves
+through the package protocol's registrations and writes an
+`ExtractorRouteSettingsSelection`; a transcript resolves through a host adapter
+and writes a `PodcastTranscriptionBackend`. They share no selection type and no
+id space, so the case tag is what lets one table show both without either
+pretending to be the other. A synthesized route id for transcripts would have
+been a sentinel.
+
+The transcript row shows `Ready`, which is the same answer
+`ExtractorRouteTableBuilder` already gives every non-package selection: a host
+adapter has no package to install, activate, or authorize. The contract line
+"Podcast transcripts are not package-backed in protocol revision 1." moved to
+the table's section footer and the row's help text.
+
+The route table's fixed 172 pt height is gone. It uses
+`SettingsPackageTableMetrics.height(forRowCount:)` like the package table, so
+the added row cannot push a route out of view and a registration-derived route
+scrolls instead of growing the window.
+
 `SettingsPackageTableMetrics` is now shared by both panes. Both tables are the
 same control at the same control size, so the row height, the header height,
 and the floor and ceiling have one definition.
@@ -61,14 +87,20 @@ and the floor and ceiling have one definition.
 * `WIKIFS_APP_TESTS=1 swift test --filter 'ExtractorPackageSettingsTests'` — 32
   tests pass.
 * `WIKIFS_APP_TESTS=1 swift test --filter 'ExtractionRouteTableHostedTests'` —
-  15 tests pass, including a new hosted test that mounts the pane with one
-  active and one failed revision and confirms both tables render.
+  16 tests pass, including a new hosted test that mounts the pane with one
+  active and one failed revision and confirms both tables render. The hosted
+  row counts pin the transcript row: the route table holds one more row than
+  its routes.
 * New tests cover the row fold, the status precedence, the optional-requirement
   case, and the notice scope for import, removal, and failed removal.
-* `WIKIFS_APP_TESTS=1 swift test --filter 'Extract'` — 590 tests, 3 failures.
-  All three also fail on a clean tree and depend on this machine, not on this
-  change: two need reviewed packages that the test environment does not
-  install, and one needs a mise-managed `uv`.
+* `WIKIFS_APP_TESTS=1 swift test --filter 'Extract'` — 592 tests, 3 stable
+  failures plus one rotating failure. The three also fail on a clean tree and
+  depend on this machine, not on this change: two need reviewed packages that
+  the test environment does not install, and one needs a mise-managed `uv`. The
+  rotating one is a different subprocess-timing test on each run
+  (`streamProcessCapturesStderrLines`, then
+  `malformedProtocolAndNonzeroExitAreTyped`); both pass in isolation, so they
+  flake under parallel load rather than failing.
 * The change was not seen in the running app. The app on this machine runs an
   older build.
 * The full suite did not run locally. CI runs it.

--- a/progress/2026-08-31T210000Z-extractor-settings-package-table.md
+++ b/progress/2026-08-31T210000Z-extractor-settings-package-table.md
@@ -1,0 +1,74 @@
+---
+timestamp: 2026-08-31T210000Z
+title: Extractor settings package table with inline diagnostics
+branch: feature/extractor-settings-package-table
+status: complete
+---
+
+# Extractor settings package table with inline diagnostics
+
+## Progress
+
+Settings → Extraction showed installed packages as two lists of disclosure
+rows: active registrations first, then revisions whose activation failed. The
+lists grew the Settings window, they did not align the version or the status,
+and they hid the import control in a disclosure group. Diagnostics went to two
+labels at the end of the section, far from the package they described.
+
+This applies the pattern that
+[the renderer pane](2026-08-31T200000Z-renderer-settings-package-table.md) now
+uses.
+
+* **A package table.** `Table` with four columns: Package, Version, Handles,
+  and Status.
+
+* **One row type.** `ExtractorPackageTableRow` folds the snapshot's two lists
+  into one presentation identity. An active registration and a failed revision
+  do not share an id space, so the `Subject` case tag stops a failure id from
+  colliding with a registration id. Failed revisions sort first: they are the
+  rows a user opens this pane to understand.
+
+* **Inline diagnostics.** `ExtractorPackageStatus` resolves the facts the
+  snapshot keeps apart — the failed-activation list, `waitingRevisionIDs`, and
+  the per-requirement authorization state — into one status for each revision.
+  A revision that has not activated cannot be judged on its credentials, so
+  `waiting` outranks `needsAuthorization`. An optional requirement never claims
+  the package needs attention. A failed revision carries the reconciler's own
+  redacted message as the status payload, so the message stays with its row
+  instead of living in a separate list.
+
+  `ExtractorPackageNotice` replaces the two strings `lastError` and
+  `lastDiagnostic`. It holds one outcome with a severity and a scope, so an
+  import renders with the row it produced and a failed removal renders with the
+  package it could not remove. A successful removal has no row left, so it
+  reports on the pane. `lastError` and `lastDiagnostic` remain as computed
+  properties of that notice.
+
+* **An Add button.** `Add Package…` and `Remove Package…` are below the table,
+  with `Refresh` opposite them. The import disclosure group is gone. The
+  local-directory import contract and the executable-code trust warning moved
+  to the section footer, where they are always visible. This matters more here
+  than for renderers: an extractor package contains executable code.
+
+`SettingsPackageTableMetrics` is now shared by both panes. Both tables are the
+same control at the same control size, so the row height, the header height,
+and the floor and ceiling have one definition.
+
+## Verification
+
+* `make build` passes.
+* SwiftLint `--strict` reports 0 violations.
+* `WIKIFS_APP_TESTS=1 swift test --filter 'ExtractorPackageSettingsTests'` — 32
+  tests pass.
+* `WIKIFS_APP_TESTS=1 swift test --filter 'ExtractionRouteTableHostedTests'` —
+  15 tests pass, including a new hosted test that mounts the pane with one
+  active and one failed revision and confirms both tables render.
+* New tests cover the row fold, the status precedence, the optional-requirement
+  case, and the notice scope for import, removal, and failed removal.
+* `WIKIFS_APP_TESTS=1 swift test --filter 'Extract'` — 590 tests, 3 failures.
+  All three also fail on a clean tree and depend on this machine, not on this
+  change: two need reviewed packages that the test environment does not
+  install, and one needs a mise-managed `uv`.
+* The change was not seen in the running app. The app on this machine runs an
+  older build.
+* The full suite did not run locally. CI runs it.

--- a/progress/2026-08-31T210000Z-extractor-settings-package-table.md
+++ b/progress/2026-08-31T210000Z-extractor-settings-package-table.md
@@ -97,6 +97,19 @@ other.
 pane directly. It defaults to `.defaults`, so the production call site says
 nothing.
 
+### Help
+
+`ExtractorPackageHelp.swift` mirrors `RendererPackageHelp.swift`: a
+question-mark button in the section header opens a popover that explains what a
+package is, what the manifest declares, how a package runs, what import does,
+which sources are supported, how credentials are authorized, and what happens
+when a package cannot run.
+
+The popover states the executable-code risk near the top, before anything the
+reader might act on. That is the one thing that separates an extractor package
+from a renderer package. It reuses `ExtractionSettingsView.trustWarningMessage`,
+the same string the import footer shows, so the two cannot drift apart.
+
 ## Verification
 
 * `make build` passes.
@@ -118,6 +131,7 @@ nothing.
   (`streamProcessCapturesStderrLines`, then
   `malformedProtocolAndNonzeroExitAreTyped`); both pass in isolation, so they
   flake under parallel load rather than failing.
+* The help popover was opened in the running app and captured.
 * The pane was installed and seen in the running app. A clean launch opens on
   Defaults and shows all four rows, including the podcast transcript row. The
   Packages pane shows the package table, the add and remove controls, the

--- a/progress/2026-08-31T210000Z-extractor-settings-package-table.md
+++ b/progress/2026-08-31T210000Z-extractor-settings-package-table.md
@@ -80,6 +80,23 @@ scrolls instead of growing the window.
 same control at the same control size, so the row height, the header height,
 and the floor and ceiling have one definition.
 
+### Two panes
+
+Settings → Extraction does two jobs: it chooses what opens each document type,
+and it manages the packages those choices draw from. Only one is needed at a
+time, so a segmented switcher picks between them. `ExtractionSettingsPane` names
+the two, and Defaults opens first, because that is the question the pane exists
+to answer. The selection is not persisted for the same reason.
+
+The service configuration sheet moved from the route table to above the
+switcher. Both panes raise it — a route's `Configure…` and a package's
+`Configure…` — so a sheet attached to one pane would never present from the
+other.
+
+`initialPane` on `ExtractionSettingsView.init` lets a hosted test mount either
+pane directly. It defaults to `.defaults`, so the production call site says
+nothing.
+
 ## Verification
 
 * `make build` passes.
@@ -101,6 +118,12 @@ and the floor and ceiling have one definition.
   (`streamProcessCapturesStderrLines`, then
   `malformedProtocolAndNonzeroExitAreTyped`); both pass in isolation, so they
   flake under parallel load rather than failing.
-* The change was not seen in the running app. The app on this machine runs an
-  older build.
+* The pane was installed and seen in the running app. A clean launch opens on
+  Defaults and shows all four rows, including the podcast transcript row. The
+  Packages pane shows the package table, the add and remove controls, the
+  inline diagnostic, and the trust warning.
+* The transcript row was missing at first. The route table's rows are 32 pt
+  because every cell holds a pop-up, not the 24 pt a table of text rows uses,
+  so the computed height was one row short and the last row sat below the fold.
+  The accessibility geometry of the live pane gave both numbers.
 * The full suite did not run locally. CI runs it.


### PR DESCRIPTION
Applies the pattern from #1190 to Settings → Extraction.

## Why

The pane showed installed packages as two lists of disclosure rows: active
registrations first, then revisions whose activation failed. The lists grew the
Settings window, they did not align the version or the status, and they hid the
import control in a disclosure group. Diagnostics went to two labels at the end
of the section, far from the package each described.

## What changed

**A package table.** `Table` with four columns: Package, Version, Handles, and
Status. `SettingsPackageTableMetrics.height(forRowCount:)` gives the height, so
a short list leaves no space below its rows and a long one scrolls in the
table's own scroll area. The Settings window height does not change with the
package count.

**One row type.** `ExtractorPackageTableRow` folds the snapshot's two lists into
one presentation identity. An active registration and a failed revision do not
share an id space, so the `Subject` case tag stops a failure id from colliding
with a registration id, and a failed revision correctly has no registration and
no row to remove or configure. Failed revisions sort first: they are the rows a
user opens this pane to understand.

**Inline diagnostics.** `ExtractorPackageStatus` resolves the facts the snapshot
keeps apart — the failed-activation list, `waitingRevisionIDs`, and the
per-requirement authorization state — into one status for each revision.
Precedence: a revision that has not activated cannot be judged on its
credentials, so `waiting` outranks `needsAuthorization`, and an optional
requirement never claims the package needs attention. A failed revision carries
the reconciler's own redacted message as the status payload, so the message
stays with its row.

`ExtractorPackageNotice` replaces the `lastError` and `lastDiagnostic` strings
with one outcome carrying a severity and a scope. An import renders with the row
it produced; a failed removal renders with the package it could not remove; a
successful removal has no row left, so it reports on the pane. Both strings stay
as computed properties of the notice, so an error cannot outlive the success
that replaced it.

**An Add button.** `Add Package…` and `Remove Package…` are below the table,
with `Refresh` opposite them. The import disclosure group is gone. The
local-directory import contract and the executable-code trust warning moved to
the section footer, where they are always visible. That matters more here than
for renderers: an extractor package contains executable code.

**Shared metrics.** `SettingsPackageTableMetrics` replaces the renderer pane's
own copy. Both tables are the same control at the same control size, so the row
height, the header height, and the floor and ceiling have one definition.

## Verification

- `make build` passes.
- SwiftLint `--strict` reports 0 violations in 641 files.
- `WIKIFS_APP_TESTS=1 swift test --filter ExtractorPackageSettingsTests` — 32 tests pass.
- `WIKIFS_APP_TESTS=1 swift test --filter ExtractionRouteTableHostedTests` — 15 tests pass.
- New tests cover the row fold, the status precedence, the optional-requirement
  case, and the notice scope for import, successful removal, and failed removal.
- A new hosted test mounts the real pane with one active and one failed revision
  and confirms both tables render with the expected row counts.
- `WIKIFS_APP_TESTS=1 swift test --filter Extract` — 590 tests, 3 failures. All
  three also fail on a clean tree and depend on the machine, not on this change:
  two need reviewed packages the test environment does not install, and one
  needs a mise-managed `uv`.
- The change was not seen in the running app; that needs a new install.
- The full suite did not run locally. CI runs it.

## Review notes

The hosted route-table test used `firstTableView`, which a second table in the
pane makes order-dependent. It now asserts the row-count multiset across every
table in the window, so neither test depends on which table a depth-first walk
reaches first.

`ExtractorPackageSettingsTests.accessibilityContractAndDecouplingHold` locks
this section's layout as source text. The assertions for the disclosure group,
the per-row failure identifiers, and the two `.accessibilityValue` literals were
replaced with assertions for the table, the status cases, and the selection
scoped controls. `extraction.packages.failure` and
`extraction.packages.import.disclosure` are gone; `extraction.packages.table`
and `extraction.packages.status` are new, and removal is now one
selection-scoped control rather than one per row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016U4SShVtLajqZUkwQYEWe5