### PR TITLE
fix(editor): clear stale markdown warning on page switch

### DIFF
--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -1395,9 +1395,15 @@ public final class WikiStoreModel {
 
     private func loadDrafts(for newValue: WikiSelection?) {
         loadedSelection = newValue
-        // A page switch invalidates the prior page's fence warning so a stale
-        // banner doesn't bleed onto an unrelated page (it's recomputed on save).
+        // A page switch invalidates the prior page's lint warnings so a stale
+        // banner doesn't bleed onto an unrelated page (they're recomputed on
+        // save). The markdown lint is computed on a background Task, so also
+        // cancel the in-flight lint — otherwise page A's findings can land
+        // after the switch and write the stale banner onto page B.
         fenceSaveWarning = nil
+        markdownSaveWarning = nil
+        markdownWarningTask?.cancel()
+        markdownWarningTask = nil
         var restoredFromPendingDraft = false
         switch newValue {
         case .newChat, .bookmark, .chat:

--- a/Tests/WikiFSTests/MarkdownEditorWarningTests.swift
+++ b/Tests/WikiFSTests/MarkdownEditorWarningTests.swift
@@ -121,6 +121,28 @@ struct MarkdownEditorWarningTests {
         #expect(model.markdownSaveWarning == nil)
     }
 
+    @Test func pageSwitchClearsStaleWarning() async throws {
+        let store = try StoreBackend.current.makeStore(databaseURL: tempURL())
+        let model = WikiStoreModel(store: store)
+        model.markdownLinter = try repoLinter()
+        model.newPage(title: "Messy")
+        model.draftBody = "#No space after hash"
+        model.save()
+        // The markdown warning is computed on a background Task — poll briefly.
+        try await pollFor { model.markdownSaveWarning != nil }
+        #expect(model.markdownSaveWarning?.contains("MD018") == true)
+        // Selecting another page reloads drafts, which must clear the stale
+        // banner — mirroring the mermaid/fence warning behaviour. It must NOT
+        // reappear: page B is clean, so nothing re-lints, and a cancelled
+        // in-flight lint can't write page A's findings onto page B.
+        model.newPage(title: "Clean")
+        #expect(model.markdownSaveWarning == nil)
+        // Give any cancelled-but-started lint a chance to land and confirm it
+        // doesn't resurrect the stale banner on the new page.
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(model.markdownSaveWarning == nil)
+    }
+
     @Test func noCrashWhenLinterUnavailable() throws {
         // The unbundled path: nil linter → no warning, no crash.
         let store = try StoreBackend.current.makeStore(databaseURL: tempURL())


### PR DESCRIPTION
## What

Fixes #1187: the markdown save-warning banner (with its Fix button) persisted across page switches, showing the *previous* page's lint findings on the page now on screen.

`WikiStoreModel.loadDrafts(for:)` resets `fenceSaveWarning` on a selection change so a stale banner doesn't bleed onto an unrelated page, but `markdownSaveWarning` was added later and was never included in that reset — nothing else ever cleared it, so it survived every navigation.

## Root cause

Two related leaks in the same spot:

1. **Stale banner (the reported bug).** No `markdownSaveWarning = nil` in `loadDrafts(for:)`. The orange banner kept page A's findings and an actionable Fix button while the user was on page B.
2. **Late-landing lint.** `markdownWarningTask` was also not cancelled in `loadDrafts(for:)`. `updateMarkdownWarning` runs the lint on a background `Task`, so a lint kicked off on page A could complete *after* the user switched to page B and write A's findings into the banner shown on B.

## Fix

Clear `markdownSaveWarning` and cancel the in-flight `markdownWarningTask` in `loadDrafts(for:)`, right next to the existing `fenceSaveWarning = nil` — exactly the suggested fix in the issue.

## Test

New regression test `MarkdownEditorWarningTests.pageSwitchClearsStaleWarning`: save a page that trips MD018, verify the warning appears, switch to a second (clean) page, and assert `markdownSaveWarning == nil` — including a short settle window so a cancelled-but-started lint can't resurrect the stale banner. Mirrors the existing `FenceEditorWarningTests.pageSwitchClearsStaleWarning`.

Verified the test fails on the unpatched code (stale MD018 finding survives the switch) and passes with the fix.

## Validation

- `make test` — full suite: 4130 tests, 445 suites, all pass.
- Pre-commit hooks: swiftformat lint 0 violations (640 files), no new bare `try?`.

## Notes

The Fix button was mostly harmless in the stale state (it re-lints fresh body and returns early when nothing changes), but it was still an actionable control attached to a warning about a different page, and pressing it on a dirty-but-unrelated draft triggered a `save()` the user did not ask for. This removes that surface entirely.
