### PR TITLE
Fix live daemon chat coordinator publication

### DIFF
--- a/Sources/WikiFS/Chats/ChatDaemonCoordinatorHolder.swift
+++ b/Sources/WikiFS/Chats/ChatDaemonCoordinatorHolder.swift
@@ -1,0 +1,22 @@
+#if os(macOS)
+import Observation
+import WikiFSCore
+
+/// Stable publication point for the app-wide daemon chat coordinator.
+///
+/// `WikiFSApp` is a value type whose initialization instance is not the mounted
+/// scene value. Transport callbacks retain this holder instead of capturing the
+/// transient app value, so successful daemon admission invalidates every scene
+/// that reads `coordinator`.
+@MainActor
+@Observable
+final class ChatDaemonCoordinatorHolder {
+    private(set) var coordinator: ChatDaemonCoordinator?
+
+    func replace(with replacement: ChatDaemonCoordinator?) {
+        coordinator?.stop()
+        coordinator = replacement
+        DebugLog.store("WikiFSApp: chat daemon coordinator \(replacement == nil ? "cleared" : "published")")
+    }
+}
+#endif

--- a/Sources/WikiFS/Queue/DaemonTransportAppCoordinator.swift
+++ b/Sources/WikiFS/Queue/DaemonTransportAppCoordinator.swift
@@ -39,13 +39,6 @@ final class DaemonTransportAppCoordinator {
         self.observeEvent = observeEvent
     }
 
-    func installChatReplacement(
-        _ replacement: @escaping @MainActor (ChatDaemonCoordinator?) -> Void
-    ) {
-        guard lifecycle == .idle else { return }
-        replaceChatCoordinator = replacement
-    }
-
     func startIfNeeded() {
         guard lifecycle == .idle else { return }
         lifecycle = .started

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -97,12 +97,10 @@ struct WikiFSApp: App {
     /// Owns the open-windows list for the standard Window menu (issue #567).
     @State private var windowTracker: WindowListTracker
 
-    /// App-wide chat daemon coordinator (Phase C4). Owns the per-chat
-    /// `RemoteChatSession` registry + wraps the 6 chat XPC commands. `nil`
-    /// when the daemon is unavailable — chat surfaces then render an
-    /// reconnecting state while transport starts or recovers. Chat has no local
-    /// fallback because the daemon owns chat.
-    @State private var chatDaemonCoordinator: ChatDaemonCoordinator?
+    /// App-wide chat daemon coordinator (Phase C4). The holder has stable
+    /// reference identity so the transport callback can update the mounted
+    /// scene even though `WikiFSApp` itself is a transient value.
+    @State private var chatDaemonHolder: ChatDaemonCoordinatorHolder
 
     /// Presentation-only adapter for typed daemon transport events.
     @State private var healthMonitor: DaemonHealthMonitor
@@ -233,11 +231,15 @@ struct WikiFSApp: App {
 
         let transportMonitor = DaemonHealthMonitor(services: transportOwner.services)
         _healthMonitor = State(initialValue: transportMonitor)
+        let chatDaemonHolder = ChatDaemonCoordinatorHolder()
+        _chatDaemonHolder = State(initialValue: chatDaemonHolder)
         daemonTransportCoordinator = DaemonTransportAppCoordinator(
             services: transportOwner.services,
             bridge: transportBridge,
             queueController: runtimeController,
-            replaceChatCoordinator: { _ in },
+            replaceChatCoordinator: { [chatDaemonHolder] coordinator in
+                chatDaemonHolder.replace(with: coordinator)
+            },
             observeEvent: { [weak transportMonitor] event in
                 transportMonitor?.consume(event)
             })
@@ -356,6 +358,7 @@ struct WikiFSApp: App {
         // so the `.task` copies that remain are harmless redundant fallbacks,
         // not the primary path. Add new one-time launch work HERE, not to an
         // individual window's `.task`.
+        appDelegate.chatDaemonHolder = chatDaemonHolder
         appDelegate.bootstrap = { [self] in
             startStatusItem()
             applyAppKitAppearance()
@@ -497,7 +500,7 @@ struct WikiFSApp: App {
             }
             // Phase C4: chat runs on the daemon — check the coordinator's
             // aggregate rather than a per-wiki chat launcher.
-            if chatDaemonCoordinator?.anyChatGenerating == true {
+            if chatDaemonHolder.coordinator?.anyChatGenerating == true {
                 return "A chat session"
             }
             return nil
@@ -565,18 +568,8 @@ struct WikiFSApp: App {
 
     @MainActor
     private func connectToDaemon() {
-        daemonTransportCoordinator.installChatReplacement { coordinator in
-            replaceChatDaemonCoordinator(coordinator)
-        }
         healthMonitor.start()
         daemonTransportCoordinator.startIfNeeded()
-    }
-
-    @MainActor
-    private func replaceChatDaemonCoordinator(_ coordinator: ChatDaemonCoordinator?) {
-        chatDaemonCoordinator?.stop()
-        chatDaemonCoordinator = coordinator
-        appDelegate.chatDaemonCoordinator = coordinator
     }
 
     var body: some Scene {
@@ -600,7 +593,7 @@ struct WikiFSApp: App {
             .appEnvironment(
                 tracker: activityTracker,
                 openActivityWindow: { [weak openWindowBridge] queue in openWindowBridge?.openActivityWindow?(queue) },
-                chatDaemon: chatDaemonCoordinator,
+                chatDaemon: chatDaemonHolder.coordinator,
                 healthMonitor: healthMonitor)
             .preferredColorScheme(appearanceColorScheme)
             .sheet(isPresented: $showingOptionalRuntimeSetup) {
@@ -696,7 +689,7 @@ struct WikiFSApp: App {
             .appEnvironment(
                 tracker: activityTracker,
                 openActivityWindow: { [weak openWindowBridge] queue in openWindowBridge?.openActivityWindow?(queue) },
-                chatDaemon: chatDaemonCoordinator,
+                chatDaemon: chatDaemonHolder.coordinator,
                 healthMonitor: healthMonitor)
             .preferredColorScheme(appearanceColorScheme)
             .onAppear {
@@ -1015,7 +1008,7 @@ struct WikiFSApp: App {
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
     @MainActor weak var sessionManager: SessionManager?
-    @MainActor weak var chatDaemonCoordinator: ChatDaemonCoordinator?
+    @MainActor weak var chatDaemonHolder: ChatDaemonCoordinatorHolder?
     /// STRONG on purpose: this is the only long-lived owner of the status-item
     /// controller. A weak reference here deallocates the controller the moment
     /// `startStatusItem()` returns, which removes the NSStatusItem from the
@@ -1148,7 +1141,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidBecomeActive(_ notification: Notification) {
         MainActor.assumeIsolated {
-            chatDaemonCoordinator?.applicationDidBecomeActive()
+            chatDaemonHolder?.coordinator?.applicationDidBecomeActive()
         }
     }
 

--- a/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/ChatDaemonCoordinatorTests.swift
@@ -461,6 +461,26 @@ struct ChatDaemonCoordinatorTests {
         #expect(session.selectedModelId(forProvider: ProviderID(rawValue: "claude-acp")) == ModelID(rawValue: "activation-model"))
     }
 
+    @Test func stableHolderPublishesTransportReplacement() {
+        let holder = ChatDaemonCoordinatorHolder()
+        let coordinator = makeCoordinator()
+        let observation = ObservationCounter()
+
+        withObservationTracking {
+            _ = holder.coordinator
+        } onChange: {
+            observation.increment()
+        }
+
+        #expect(holder.coordinator == nil)
+        holder.replace(with: coordinator)
+        #expect(observation.count == 1)
+        #expect(holder.coordinator === coordinator)
+
+        holder.replace(with: nil)
+        #expect(holder.coordinator == nil)
+    }
+
     private func providerConfigDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("provider-reload-\(UUID().uuidString)", isDirectory: true)
@@ -560,6 +580,19 @@ struct ChatDaemonCoordinatorTests {
             await Task.yield()
         }
         Issue.record("Condition was not met before timeout.")
+    }
+}
+
+private final class ObservationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int {
+        lock.withLock { value }
+    }
+
+    func increment() {
+        lock.withLock { value += 1 }
     }
 }
 


### PR DESCRIPTION
## Summary

- Store the daemon chat coordinator in a stable observable holder.
- Publish transport replacements through that holder from app initialization.
- Remove the late replacement callback installation.
- Add a regression test for storage and Observation invalidation.

## Root cause

Runtime logs showed that `wikid` was alive and had one active chat session. The app also changed from `disconnected` to `reconnecting` to `connected`. It installed `XPCQueueEngineProxy` successfully.

The transport coordinator started with a no-op chat replacement callback. A later callback captured a transient `WikiFSApp` value and wrote its optional `@State`. The mounted scenes did not receive the live coordinator, so their environment value stayed nil.

## Fix

`ChatDaemonCoordinatorHolder` gives the transport callback stable reference identity. Both window scenes observe `holder.coordinator` and publish it through the SwiftUI environment. The holder also stops the old coordinator before each replacement.

The publication seam now logs whether it published or cleared the chat coordinator.

## Verification

- `make build` passed and produced a signed app bundle.
- `WIKIFS_APP_TESTS=1 swift test --filter stableHolderPublishesTransportReplacement` passed with one test.
- One `make test` run passed all 4,185 tests.
- A second full run had one unrelated extractor timeout. The failing test passed on immediate isolated rerun in 1.32 seconds.
- Swift language-server diagnostics found no issues in the changed files.
- The pre-commit hook linted 644 Swift files with zero violations.
