### PR TITLE
fix(menu): prevent View menu dismissal during hover

### DIFF
--- a/Sources/WikiFS/Window/WindowMenuCommands.swift
+++ b/Sources/WikiFS/Window/WindowMenuCommands.swift
@@ -36,12 +36,14 @@ final class WindowListTracker {
         guard !didStart else { return }
         didStart = true
         let center = NotificationCenter.default
-        // Recompute whenever a window appears, focuses, hides, or closes —
-        // the open-windows list must stay in sync without a manual refresh.
+        // Recompute when a window appears, focuses, or closes. Do not observe
+        // occlusion changes here: AppKit can emit those while the menu bar is
+        // tracking (for example when the pointer enters View), and publishing
+        // an @Observable change then makes SwiftUI rebuild the command tree
+        // under the pointer, dismissing the menu (#1201).
         let names: [Notification.Name] = [
             NSWindow.didBecomeKeyNotification,
             NSWindow.didBecomeMainNotification,
-            NSWindow.didChangeOcclusionStateNotification,
             NSWindow.willCloseNotification,
             NSApplication.didBecomeActiveNotification
         ]


### PR DESCRIPTION
## Summary

- Prevent the View menu from dismissing while the pointer moves across the menu bar.
- Stop observing window occlusion changes in the SwiftUI-backed window command tracker.

## Cause

AppKit can emit `didChangeOcclusionState` while the menu bar is tracking. The observer published an `@Observable` update, which rebuilt the SwiftUI command hierarchy under the pointer and dismissed the menu.

## Validation

- `make build`
- `make test` — 4,187 tests across 455 suites
- Pre-commit lint checks passed
