### PR TITLE
Fix inline source renderer mounting

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1234,10 +1234,11 @@ final class WikiReaderWebView: WKWebView {
       window.sdwInjectRendererEmbed = function(placeholderID, expansionID, kind, src, title, height, sandboxJSON){
         var card = document.getElementById(placeholderID);
         if(!card){ return 'no-card'; }
-        var expansion = card.querySelector('.sdw-renderer-card__expansion');
-        if(!expansion){ return 'no-expansion'; }
+        var embedHost = card.querySelector('.sdw-renderer-card__expansion');
+        if(!embedHost && card.classList.contains('sdw-inline-renderer')){ embedHost = card; }
+        if(!embedHost){ return 'no-embed-host'; }
         // Remove only this placeholder's prior surface (scoped collapse).
-        var prior = expansion.querySelector('.sdw-renderer-embed');
+        var prior = embedHost.querySelector('.sdw-renderer-embed');
         if(prior){ prior.remove(); }
         var element;
         if(kind === 'audio'){
@@ -1273,7 +1274,7 @@ final class WikiReaderWebView: WKWebView {
         element.className = 'sdw-renderer-embed';
         element.id = expansionID + '-embed';
         element.setAttribute('aria-label', title);
-        expansion.appendChild(element);
+        embedHost.appendChild(element);
         window.__sdwRendererEmbedLoads[placeholderID] = 'appended';
         return 'injected';
       };
@@ -1282,9 +1283,10 @@ final class WikiReaderWebView: WKWebView {
       window.sdwRemoveRendererEmbed = function(placeholderID){
         var card = document.getElementById(placeholderID);
         if(!card){ return 'no-card'; }
-        var expansion = card.querySelector('.sdw-renderer-card__expansion');
-        if(!expansion){ return 'no-expansion'; }
-        var prior = expansion.querySelector('.sdw-renderer-embed');
+        var embedHost = card.querySelector('.sdw-renderer-card__expansion');
+        if(!embedHost && card.classList.contains('sdw-inline-renderer')){ embedHost = card; }
+        if(!embedHost){ return 'no-embed-host'; }
+        var prior = embedHost.querySelector('.sdw-renderer-embed');
         if(prior){ prior.remove(); return 'removed'; }
         return 'none';
       };

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -1237,9 +1237,6 @@ final class WikiReaderWebView: WKWebView {
         var embedHost = card.querySelector('.sdw-renderer-card__expansion');
         if(!embedHost && card.classList.contains('sdw-inline-renderer')){ embedHost = card; }
         if(!embedHost){ return 'no-embed-host'; }
-        // Remove only this placeholder's prior surface (scoped collapse).
-        var prior = embedHost.querySelector('.sdw-renderer-embed');
-        if(prior){ prior.remove(); }
         var element;
         if(kind === 'audio'){
           element = document.createElement('audio');
@@ -1274,6 +1271,12 @@ final class WikiReaderWebView: WKWebView {
         element.className = 'sdw-renderer-embed';
         element.id = expansionID + '-embed';
         element.setAttribute('aria-label', title);
+        // Replace only after the new surface is fully validated. A malformed
+        // reinjection must keep the working surface and its fallback state.
+        var prior = embedHost.querySelector('.sdw-renderer-embed');
+        if(prior){ prior.remove(); }
+        var inlineFallback = card.querySelector('.sdw-inline-renderer__fallback');
+        if(inlineFallback){ inlineFallback.hidden = true; inlineFallback.setAttribute('aria-hidden', 'true'); }
         embedHost.appendChild(element);
         window.__sdwRendererEmbedLoads[placeholderID] = 'appended';
         return 'injected';
@@ -1287,7 +1290,12 @@ final class WikiReaderWebView: WKWebView {
         if(!embedHost && card.classList.contains('sdw-inline-renderer')){ embedHost = card; }
         if(!embedHost){ return 'no-embed-host'; }
         var prior = embedHost.querySelector('.sdw-renderer-embed');
-        if(prior){ prior.remove(); return 'removed'; }
+        if(prior){
+          prior.remove();
+          var inlineFallback = card.querySelector('.sdw-inline-renderer__fallback');
+          if(inlineFallback){ inlineFallback.hidden = false; inlineFallback.setAttribute('aria-hidden', 'false'); }
+          return 'removed';
+        }
         return 'none';
       };
 

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -795,6 +795,8 @@ struct MarkdownHTMLRendererTests {
         #expect(script.contains("action:card.dataset.rendererExpanded==='true'?'collapse':'activate'"))
         #expect(WikiReaderWebView.embedBootstrapJS.contains("card.classList.contains('sdw-inline-renderer')"))
         #expect(WikiReaderWebView.embedBootstrapJS.contains("embedHost.appendChild(element)"))
+        #expect(WikiReaderWebView.embedBootstrapJS.contains("inlineFallback.hidden = true"))
+        #expect(WikiReaderWebView.embedBootstrapJS.contains("inlineFallback.hidden = false"))
         #expect(script.contains("sdw-renderer-card__collapse") == false)
         #expect(script.contains("__sdwRendererAttachmentPresentCollapse") == false)
     }

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -793,6 +793,8 @@ struct MarkdownHTMLRendererTests {
         #expect(script.contains("event.target.closest('.sdw-renderer-card__row')"))
         #expect(script.contains("event.target.closest('[data-renderer-action=\"open-window\"]')"))
         #expect(script.contains("action:card.dataset.rendererExpanded==='true'?'collapse':'activate'"))
+        #expect(WikiReaderWebView.embedBootstrapJS.contains("card.classList.contains('sdw-inline-renderer')"))
+        #expect(WikiReaderWebView.embedBootstrapJS.contains("embedHost.appendChild(element)"))
         #expect(script.contains("sdw-renderer-card__collapse") == false)
         #expect(script.contains("__sdwRendererAttachmentPresentCollapse") == false)
     }

--- a/Tests/WikiFSAppTests/RendererHostedSubframeHarnessTests.swift
+++ b/Tests/WikiFSAppTests/RendererHostedSubframeHarnessTests.swift
@@ -360,6 +360,35 @@ struct RendererHostedSubframeHarnessTests {
             timeout: .seconds(2))
     }
 
+    @Test("inline renderer host accepts and removes a DOM package embed")
+    func inlineRendererHostAcceptsAndRemovesDOMPackageEmbed() async throws {
+        let harness = try await RendererHostedWebKitHarness.permissive()
+        defer { harness.close() }
+        try await harness.loadHTML("""
+        <!doctype html><html><body>
+        <span class="sdw-inline-renderer" id="source-include" data-renderer-admitted="true">
+          <span class="sdw-inline-renderer__fallback">source fallback</span>
+        </span>
+        <script>\(WikiReaderWebView.embedBootstrapJS)</script>
+        </body></html>
+        """)
+
+        try await harness.executeJavaScript(
+            "window.sdwInjectRendererEmbed('source-include', 'source-include-expansion', 'iframe', 'about:blank', 'Excalidraw', 480, '[\"allow-scripts\"]')",
+            expectedValue: RendererDOMEmbedInjection.injectionAcknowledgement,
+            description: "inline renderer package-frame injection")
+        try await harness.waitForJavaScriptTrue(
+            "String(document.querySelector('#source-include > iframe.sdw-renderer-embed') !== null)",
+            description: "package frame mounted inside inline renderer host")
+        try await harness.executeJavaScript(
+            "window.sdwRemoveRendererEmbed('source-include')",
+            expectedValue: "removed",
+            description: "inline renderer package-frame removal")
+        try await harness.waitForJavaScriptTrue(
+            "String(document.querySelector('#source-include > iframe.sdw-renderer-embed') === null)",
+            description: "package frame removed from inline renderer host")
+    }
+
     @Test("lifecycle adapter invokes scoped invalidation")
     func lifecycleAdapterInvokesScopedInvalidation() async throws {
         let harness = try await RendererHostedWebKitHarness.permissive()

--- a/Tests/WikiFSAppTests/RendererHostedSubframeHarnessTests.swift
+++ b/Tests/WikiFSAppTests/RendererHostedSubframeHarnessTests.swift
@@ -380,6 +380,16 @@ struct RendererHostedSubframeHarnessTests {
         try await harness.waitForJavaScriptTrue(
             "String(document.querySelector('#source-include > iframe.sdw-renderer-embed') !== null)",
             description: "package frame mounted inside inline renderer host")
+        try await harness.waitForJavaScriptTrue(
+            "String(document.querySelector('#source-include > .sdw-inline-renderer__fallback').hidden === true)",
+            description: "source include fallback hidden after package-frame injection")
+        try await harness.executeJavaScript(
+            "window.sdwInjectRendererEmbed('source-include', 'replacement', 'iframe', 'about:blank', 'Excalidraw', 480, 'malformed')",
+            expectedValue: "bad-sandbox",
+            description: "malformed inline renderer reinjection")
+        try await harness.waitForJavaScriptTrue(
+            "String(document.querySelector('#source-include-expansion-embed') !== null && document.querySelector('#source-include > .sdw-inline-renderer__fallback').hidden === true)",
+            description: "failed reinjection preserves the working frame and fallback state")
         try await harness.executeJavaScript(
             "window.sdwRemoveRendererEmbed('source-include')",
             expectedValue: "removed",
@@ -387,6 +397,9 @@ struct RendererHostedSubframeHarnessTests {
         try await harness.waitForJavaScriptTrue(
             "String(document.querySelector('#source-include > iframe.sdw-renderer-embed') === null)",
             description: "package frame removed from inline renderer host")
+        try await harness.waitForJavaScriptTrue(
+            "String(document.querySelector('#source-include > .sdw-inline-renderer__fallback').hidden === false)",
+            description: "source include fallback restored after package-frame removal")
     }
 
     @Test("lifecycle adapter invokes scoped invalidation")


### PR DESCRIPTION
The reader found admitted source includes, but its DOM injection code only accepted disclosure-card expansion regions. Inline source renderer elements therefore returned no expansion and entered a retry loop. This change uses the inline renderer element as the package embed host when no disclosure expansion exists. Injection and scoped removal now use the same host rule. Regression coverage executes injection and removal in hosted WebKit and checks the bootstrap contract. Verification: make build passed. make test passed 4,187 tests in 455 suites. The targeted Excalidraw source projection, bootstrap contract, hosted inline injection, and hosted Excalidraw package tests passed. Swift diagnostics and pre-commit lint passed. A broader opt-in hosted harness run still has unrelated existing custom-scheme and focus timing failures, but the new regression passed in that run.