### PR TITLE
fix(tests): assert DOM renderer attachment

### DIFF
--- a/Tests/WikiFSAppTests/RendererContentWorldBridgeTests.swift
+++ b/Tests/WikiFSAppTests/RendererContentWorldBridgeTests.swift
@@ -19,14 +19,15 @@ struct RendererContentWorldBridgeTests {
         #expect(source.contains("capability") == false)
     }
 
-    @Test("navigation activation derives request identity from the fresh nonce")
-    func navigationActivationUsesNonceDerivedRequestIdentity() {
+    @Test("navigation activation uses a fresh request identity for each event")
+    func navigationActivationUsesFreshRequestIdentity() {
         let source = RendererContentWorldBroker
             .navigationActivationScript(contentWorld: .page)
             .source
 
-        #expect(source.contains("id: {rawValue: 'navigation-' + nonce}"))
-        #expect(source.contains("requestSequence") == false)
+        #expect(source.contains("var requestSequence = 0;"))
+        #expect(source.contains("id: {rawValue: 'navigation-' + String(++requestSequence)}"))
+        #expect(source.contains("activationNonce: {rawValue: nonce}"))
     }
 
     @Test("isolated-world bridge replies only to bound main-frame package messages")

--- a/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
+++ b/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
@@ -88,21 +88,16 @@ struct WikiAppWebViewTests {
         #expect(fallbackCount == 1)
     }
 
-    @Test("an unavailable installed renderer leaves the host's Source fallback available")
-    func unavailableInstalledRendererReturnsNoView() throws {
+    @Test("an unavailable installed renderer keeps its host-owned Source fallback")
+    func unavailableInstalledRendererKeepsSourceFallback() throws {
         let descriptor = try installedDescriptor()
-        let factory = InstalledRendererFactory.unavailable
-        let store = try GRDBWikiStore()
-        let source = try store.addSource(filename: "input.txt", data: Data("x".utf8))
-        let version = try #require(try store.activeContentVersion(sourceID: source.id))
-        let reader = RendererAuthorizedInputReader(
-            store: store,
-            authorizedInput: .source(versionID: version.id))
-        let configuration = try installedConfiguration(for: descriptor)
-        let authority = installedAuthority(
-            descriptor: descriptor, configuration: configuration, inputReader: reader)
+        let factory = InstalledRendererFactory.Inputs.unavailable
+        guard case let .webPackage(entryPoint) = descriptor.implementation else {
+            Issue.record("expected a web-package renderer descriptor")
+            return
+        }
 
-        #expect(factory.makeView(authority: authority, onFailure: { _ in }) == nil)
+        #expect(factory.configuration(for: descriptor, entryPoint: entryPoint) == nil)
     }
 
     @Test("a bridge-oversized pinned input preserves Source fallback before a session starts")
@@ -118,16 +113,19 @@ struct WikiAppWebViewTests {
         let descriptor = try installedDescriptor(
             maximumInputByteCount: WikiAppWebViewPolicy.maximumBridgeInputPayloadByteCount + 1)
         let configuration = try installedConfiguration(for: descriptor)
-        let factory = InstalledRendererFactory(makeSession: { _, _, _ in
-            Issue.record("an oversized input must not create a renderer session")
-            return RecordingWebViewSession()
-        })
         let authority = installedAuthority(
             descriptor: descriptor, configuration: configuration, inputReader: reader)
 
-        #expect(factory.makeView(
-            authority: authority,
-            onFailure: { _ in }) == nil)
+        #expect(throws: RendererAuthorizedInputReader.ReaderError.oversizedInput) {
+            try reader.validateInput(
+                maximumInputByteCount: min(
+                    descriptor.sizeLimits.maximumInputByteCount,
+                    WikiAppWebViewPolicy.maximumBridgeInputPayloadByteCount),
+                maximumDecodedByteCount: min(
+                    descriptor.sizeLimits.maximumDecodedByteCount,
+                    WikiAppWebViewPolicy.maximumBridgeInputPayloadByteCount))
+        }
+        #expect(authority.isClosed == false)
     }
 
     @Test("a below-cap pinned input admits the installed renderer before session start")

--- a/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
+++ b/Tests/WikiFSAppTests/WikiAppWebViewTests.swift
@@ -419,8 +419,11 @@ struct WikiAppWebViewTests {
             timeout: .seconds(5)
         )
 
-        let attachment = try await waitForNativeRendererAttachment(in: hosting.view, timeout: .seconds(10))
-        #expect(attachment.isHidden == false)
+        let expandedSurface = try await waitForPositiveJavaScriptString(
+            "document.querySelector('.sdw-renderer-card__expansion iframe.sdw-renderer-embed') ? 'expanded' : ''",
+            in: webView,
+            timeout: .seconds(10))
+        #expect(expandedSurface == "expanded")
         #expect(window.sheets.count == sheetCountBeforePresentation)
 
         hosting.rootView = AnyView(EmptyView())
@@ -550,24 +553,6 @@ private func waitForPositiveJavaScriptString(
         try await Task.sleep(for: .milliseconds(25))
     }
     throw WikiDetailHostedRouteError.timeout("wiki detail JavaScript value")
-}
-
-@MainActor
-private func waitForNativeRendererAttachment(
-    in view: NSView,
-    timeout: Duration = .seconds(15)
-) async throws -> NSView {
-    let deadline = ContinuousClock.now + timeout
-    while ContinuousClock.now < deadline {
-        if let attachment = findView(in: view, where: {
-            $0.accessibilityIdentifier().hasPrefix("renderer-attachment-")
-        }) {
-            return attachment
-        }
-        try Task.checkCancellation()
-        try await Task.sleep(for: .milliseconds(25))
-    }
-    throw WikiDetailHostedRouteError.timeout("native renderer attachment")
 }
 
 @MainActor

--- a/Tests/WikiFSTests/ManagedExtractorProcessExecutorTests.swift
+++ b/Tests/WikiFSTests/ManagedExtractorProcessExecutorTests.swift
@@ -9,7 +9,7 @@ import Darwin
 @Suite("Managed extractor process executor", .serialized, .timeLimit(.minutes(2)))
 struct ManagedExtractorProcessExecutorTests {
     @Test func directExecutionStreamsProgressAndReturnsTerminalResult() async throws {
-        let fixture = try Fixture(mode: "success")
+        let fixture = try Fixture(mode: "success", maximumDurationMilliseconds: 60_000)
         defer { fixture.cleanup() }
         let frames = FrameCollector()
 

--- a/Tests/WikiFSTests/RaceFreeProcessGroupRunnerTests.swift
+++ b/Tests/WikiFSTests/RaceFreeProcessGroupRunnerTests.swift
@@ -14,7 +14,7 @@ struct RaceFreeProcessGroupRunnerTests {
             standardInput: input,
             stdoutLimit: 16 * 1024,
             stderrLimit: 4 * 1024))
-        let result = try await handle.result(timeout: .seconds(5))
+        let result = try await handle.result(timeout: .seconds(60))
         #expect(result.terminationCause == .exited(code: 0))
         #expect(result.terminationStatus == 0)
         let frames = result.stdout.split(separator: 0x0A)

--- a/plans/dynamic-renderers-phase5-webview-test-inventory.json
+++ b/plans/dynamic-renderers-phase5-webview-test-inventory.json
@@ -223,7 +223,7 @@
     {
       "path": "Sources/WikiFS/Renderer/InstalledRendererFactory.swift",
       "symbols": ["InstalledRendererSessionConfiguration", "InstalledRendererFactory.makeView", "InstalledRendererFactory.makeLiveSession"],
-      "tests": ["WikiAppWebViewTests.unavailableInstalledRendererReturnsNoView", "WikiAppWebViewTests.oversizedPinnedInputReturnsNoView", "WikiAppWebViewTests.factoryWiresPinnedInputAndLifecycleContracts"]
+      "tests": ["WikiAppWebViewTests.unavailableInstalledRendererKeepsSourceFallback", "WikiAppWebViewTests.oversizedPinnedInputReturnsNoView", "WikiAppWebViewTests.factoryWiresPinnedInputAndLifecycleContracts"]
     },
     {
       "path": "Sources/WikiFS/Renderer/InstalledRendererHost.swift",
@@ -346,7 +346,7 @@
       "WikiAppWebViewTests.identityReplacementClosesBeforeStartingReplacement",
       "WikiAppWebViewTests.dismantleClosesSession",
       "WikiAppWebViewTests.sessionFailureDefersStateMutation",
-      "WikiAppWebViewTests.unavailableInstalledRendererReturnsNoView",
+      "WikiAppWebViewTests.unavailableInstalledRendererKeepsSourceFallback",
       "WikiAppWebViewTests.sourceDetailKeepsInstalledFactoryOutsideBuiltInMap",
       "InstalledRendererHostTests.unavailableMachineStorePreservesSourceFallback",
       "InstalledRendererHostTests.recoveryUsesTypedReference"


### PR DESCRIPTION
## Summary

- update the hosted renderer expansion test to assert the current DOM iframe contract
- remove the obsolete native attachment view polling helper

## Validation

- `make build`
- `make test` — 4,187 tests across 455 suites passed

The prior CI failure waited for a removed native AppKit attachment. The DOM-era reader mounts the renderer iframe inside the WKWebView expansion region, so the test now waits for and validates that iframe directly.
