### PR TITLE
fix(renderers): hold the renderer pane while its session prepares

### DIFF
--- a/Sources/WikiFS/Renderer/InstalledRendererFactory.swift
+++ b/Sources/WikiFS/Renderer/InstalledRendererFactory.swift
@@ -199,8 +199,25 @@ enum RendererSessionPreparer {
 final class RendererSessionPreparationOwner {
     typealias Preparation = @MainActor (RendererSessionPreparationRequest) async throws -> RendererPreparedSessionAuthority
 
+    /// Observable lifecycle of the latest preparation request. `preparing`
+    /// lets a host hold its pane while the session builds; `failed` means the
+    /// pane definitively cannot be served (the preparation threw, or the host
+    /// could not assemble a request at all), so the host may fall back.
+    /// `idle` covers both "nothing requested" and "cancelled" — neither is a
+    /// failure. Falling back during `idle`/`preparing` is the bug this phase
+    /// exists to prevent: the fallback reverts the pane's selection, the
+    /// revert cancels the in-flight preparation, and the renderer becomes
+    /// unreachable no matter how often the user retries.
+    enum Phase: Equatable, Sendable {
+        case idle
+        case preparing
+        case prepared
+        case failed
+    }
+
     private(set) var prepared: RendererPreparedSessionAuthority?
     private(set) var identity: RendererSessionPreparationIdentity?
+    private(set) var phase: Phase = .idle
     private let preparation: Preparation
     private var generation: UInt64 = 0
     private var task: Task<Void, Never>?
@@ -211,6 +228,11 @@ final class RendererSessionPreparationOwner {
         self.preparation = preparation
     }
 
+    /// Whether the latest request is still unresolved — nothing requested
+    /// (`idle`) or in flight (`preparing`). Hosts should hold a preparing
+    /// pane while this is true and only treat `failed` as a load failure.
+    var isPending: Bool { phase == .idle || phase == .preparing }
+
     func prepare(_ request: RendererSessionPreparationRequest) {
         generation &+= 1
         let requestedGeneration = generation
@@ -219,15 +241,18 @@ final class RendererSessionPreparationOwner {
         prepared?.close()
         prepared = nil
         identity = requestedIdentity
+        phase = .preparing
         task = Task {
             do {
                 let result = try await preparation(request)
                 guard Task.isCancelled == false, generation == requestedGeneration,
                       identity == requestedIdentity else { result.close(); return }
                 prepared = result
+                phase = .prepared
             } catch {
                 guard generation == requestedGeneration, identity == requestedIdentity else { return }
                 DebugLog.reader("Renderer session preparation failed; using Source fallback: \(error)")
+                phase = .failed
             }
         }
     }
@@ -239,6 +264,20 @@ final class RendererSessionPreparationOwner {
         prepared?.close()
         prepared = nil
         identity = nil
+        phase = .idle
+    }
+
+    /// The host cannot assemble a preparation request for the selected pane
+    /// at all (missing configuration or authorized input). Unlike `cancel()`,
+    /// this is definitive: it tells the host to fall back instead of waiting.
+    func markUnavailable() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+        prepared?.close()
+        prepared = nil
+        identity = nil
+        phase = .failed
     }
 
 }

--- a/Sources/WikiFS/Renderer/RendererPreparingPane.swift
+++ b/Sources/WikiFS/Renderer/RendererPreparingPane.swift
@@ -1,0 +1,26 @@
+#if os(macOS)
+import SwiftUI
+
+// pattern: Value Widget
+
+/// Transient pane shown while an installed renderer session prepares. Hosts
+/// must show this instead of a load-failed fallback until preparation
+/// settles: an early fallback shows a false error and — in tabbed hosts
+/// whose fallback reverts the selection — cancels the very preparation it
+/// reports on, leaving the renderer tab unreachable.
+struct RendererPreparingPane: View {
+    let rendererName: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ProgressView()
+            Text("Preparing \(rendererName)…")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Preparing \(rendererName)")
+    }
+}
+#endif

--- a/Sources/WikiFS/Sources/SourceDetailView.swift
+++ b/Sources/WikiFS/Sources/SourceDetailView.swift
@@ -1238,13 +1238,24 @@ struct SourceDetailView: View {
 
     private func prepareSelectedRendererSession() {
         guard rendererPresentationLifecycle.state.selection == .rendered,
-              let reference = rendererPresentationLifecycle.state.pinnedRenderer,
-              let descriptor = rendererDescriptors.first(where: { $0.reference == reference }),
+              let reference = rendererPresentationLifecycle.state.pinnedRenderer else {
+            // No rendered pane is selected, so there is no session to prepare.
+            rendererSessionPreparation.cancel()
+            return
+        }
+        guard let descriptor = rendererDescriptors.first(where: { $0.reference == reference }),
               case .webPackage = descriptor.implementation,
               let configuration = routedInstalledRendererFactoryInputs.configuration(for: descriptor),
               let currentReader = rendererAuthorizedInputResolver.rendererAuthorizedInputReader(for: file.id),
               case .source(let versionID) = currentReader.authorizedInput
-        else { rendererSessionPreparation.cancel(); return }
+        else {
+            // The renderer tab is selected but its session can never be
+            // prepared (no package configuration, no authorized input). Mark
+            // the definitive failure so the host falls back to Source instead
+            // of holding the pane forever.
+            rendererSessionPreparation.markUnavailable()
+            return
+        }
         let input = currentReader.authorizedInput
         let admittedSource: RendererEmbeddedContent.Source?
         if let bytes = sourceBytesSnapshot, let mime = file.mimeType {
@@ -1268,14 +1279,26 @@ struct SourceDetailView: View {
         if let builtIn = BuiltInRendererFactoryMap.makeView(for: descriptor, inputs: rendererFactoryInputs) {
             return builtIn
         }
-        guard failedInstalledRendererReference != descriptor.reference,
-              let authority = rendererSessionPreparation.prepared,
-              authority.descriptor.reference == descriptor.reference else { return nil }
-        return installedRendererFactory.makeView(authority: authority) { _ in
-            Task { @MainActor in
-                rendererSessionPreparation.cancel()
-                failedInstalledRendererReference = descriptor.reference
+        guard failedInstalledRendererReference != descriptor.reference else { return nil }
+        switch rendererSessionPreparation.phase {
+        case .prepared:
+            guard let authority = rendererSessionPreparation.prepared,
+                  authority.descriptor.reference == descriptor.reference else { return nil }
+            return installedRendererFactory.makeView(authority: authority) { _ in
+                Task { @MainActor in
+                    rendererSessionPreparation.cancel()
+                    failedInstalledRendererReference = descriptor.reference
+                }
             }
+        case .failed:
+            return nil
+        case .idle, .preparing:
+            // Hold the pane while the session prepares. Falling back now
+            // would revert the selection to Source — and that revert cancels
+            // the in-flight preparation, which made the renderer tab
+            // unreachable for installed packages no matter how often the
+            // user retried.
+            return AnyView(RendererPreparingPane(rendererName: descriptor.displayName))
         }
     }
 

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -572,6 +572,10 @@ struct RendererActivationView: View {
                 builtInView
             } else if let packageView = packageRendererView(for: descriptor) {
                 packageView
+            } else if rendererSessionPreparation.isPending {
+                // Hold the window while the session prepares; "could not be
+                // presented" would be a false error during the in-flight window.
+                RendererPreparingPane(rendererName: descriptor.displayName)
             } else {
                 unavailableView(reason: "The renderer could not be presented.")
             }

--- a/Tests/WikiFSAppTests/RendererSessionPreparationTests.swift
+++ b/Tests/WikiFSAppTests/RendererSessionPreparationTests.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import Foundation
+import Synchronization
 import Testing
 @testable import WikiFS
 import WikiFSCore
@@ -11,13 +12,21 @@ import WikiFSTypes
 /// keeping primary rendering available (AC.14), exact pinned asset reads
 /// through the prepared authority (AC.6), and preparation-owner publication
 /// gating (AC.5).
-@Suite(.serialized, .timeLimit(.minutes(2)))
+/// Shared fixtures for preparation-owner and preparer suites.
 @MainActor
-struct RendererSessionPreparationTests {
-    // MARK: - Fixtures
+enum RendererPreparationFixtures {
+    struct UnavailableResourceProvider: RendererPackageResourceProviding {
+        func resource(for url: URL) throws -> RendererPackageResource {
+            throw RendererPackageResourceError.undeclaredAsset
+        }
+    }
+
+    enum FixtureError: Error {
+        case missingContentVersion
+    }
 
     /// A web-package descriptor. Mirrors the reviewed-package fixture shape.
-    private static func descriptor(
+    static func descriptor(
         assetRead: RendererAssetReadDeclaration?
     ) throws -> RendererDescriptor {
         let entry = RendererAsset(
@@ -47,7 +56,35 @@ struct RendererSessionPreparationTests {
             priority: 110)
     }
 
-    private static func assetReadDeclaration() throws -> RendererAssetReadDeclaration {
+    /// A descriptor identical to `descriptor(assetRead:)` except for the
+    /// registration ID, so two requests can carry distinct identities.
+    static func descriptor(
+        registrationID: String,
+        assetRead: RendererAssetReadDeclaration?
+    ) throws -> RendererDescriptor {
+        let base = try descriptor(assetRead: assetRead)
+        return try RendererDescriptor(
+            reference: RendererReference(
+                packageID: base.reference.packageID,
+                version: base.reference.version,
+                registrationID: RendererRegistrationID(rawValue: registrationID)!),
+            displayName: base.displayName,
+            implementation: base.implementation,
+            matchers: base.matchers,
+            presentations: base.presentations,
+            supportedEmbeddingRoles: base.supportedEmbeddingRoles,
+            hasExplicitEmbeddingRoles: base.hasExplicitEmbeddingRoles,
+            approvedAssets: base.approvedAssets,
+            capabilities: base.capabilities,
+            assetRead: assetRead,
+            sizeLimits: base.sizeLimits,
+            linkPolicy: base.linkPolicy,
+            accessibility: base.accessibility,
+            compatibility: base.compatibility,
+            priority: base.priority)
+    }
+
+    static func assetReadDeclaration() throws -> RendererAssetReadDeclaration {
         try RendererAssetReadDeclaration(
             allowedRoles: [.imageNode],
             allowedMIMETypes: [try RendererMIMEType(validating: "image/png")],
@@ -61,7 +98,7 @@ struct RendererSessionPreparationTests {
             extractorEntryFunction: "extractReferences")
     }
 
-    private static func configuration(
+    static func configuration(
         descriptor: RendererDescriptor
     ) -> InstalledRendererSessionConfiguration {
         InstalledRendererSessionConfiguration(
@@ -78,12 +115,40 @@ struct RendererSessionPreparationTests {
             failureRecorder: nil)
     }
 
-    private struct UnavailableResourceProvider: RendererPackageResourceProviding {
-        func resource(for url: URL) throws -> RendererPackageResource {
-            throw RendererPackageResourceError.undeclaredAsset
+    /// A real byteful source in the in-memory store plus its authorized
+    /// `.source(versionID:)` bridge input.
+    static func sourceInput(
+        store: GRDBWikiStore,
+        filename: String = "diagram.png"
+    ) throws -> (input: RendererBridgeInput, byteCount: Int) {
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        let summary = try store.addSource(filename: filename, data: png)
+        guard let version = try store.activeContentVersion(sourceID: summary.id) else {
+            throw FixtureError.missingContentVersion
         }
+        return (.source(versionID: version.id), png.count)
     }
 
+    static func request(
+        descriptor: RendererDescriptor,
+        input: RendererBridgeInput,
+        store: GRDBWikiStore
+    ) -> RendererSessionPreparationRequest {
+        .init(
+            descriptor: descriptor,
+            configuration: configuration(descriptor: descriptor),
+            input: input,
+            admittedSource: nil,
+            store: store,
+            siblingSources: [:],
+            sourceExtensions: [:],
+            hostNavigationRouting: .unavailable)
+    }
+}
+
+@Suite(.serialized, .timeLimit(.minutes(2)))
+@MainActor
+struct RendererSessionPreparationTests {
     private static func makeAuthority(
         _ descriptor: RendererDescriptor,
         input: RendererBridgeInput,
@@ -91,7 +156,7 @@ struct RendererSessionPreparationTests {
     ) async throws -> RendererPreparedSessionAuthority {
         try await RendererSessionPreparer.prepare(.init(
             descriptor: descriptor,
-            configuration: Self.configuration(descriptor: descriptor),
+            configuration: RendererPreparationFixtures.configuration(descriptor: descriptor),
             input: input,
             admittedSource: nil,
             store: store,
@@ -113,7 +178,7 @@ struct RendererSessionPreparationTests {
         // The validated provider cannot serve any asset, so if the helper
         // path ran, preparation would fail. A nil-assetRead descriptor must
         // prepare without touching the provider at all.
-        let descriptor = try Self.descriptor(assetRead: nil)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
         let authority = try await Self.makeAuthority(descriptor, input: input, store: store)
 
         defer { authority.close() }
@@ -133,7 +198,8 @@ struct RendererSessionPreparationTests {
 
         // assetRead declared, but the validated provider cannot serve the
         // extractor asset — preparation continues with nil asset authority.
-        let descriptor = try Self.descriptor(assetRead: Self.assetReadDeclaration())
+        let descriptor = try RendererPreparationFixtures.descriptor(
+            assetRead: RendererPreparationFixtures.assetReadDeclaration())
         let authority = try await Self.makeAuthority(descriptor, input: input, store: store)
 
         defer { authority.close() }
@@ -150,7 +216,7 @@ struct RendererSessionPreparationTests {
         let version = try #require(try store.activeContentVersion(sourceID: summary.id))
         let input = RendererBridgeInput.source(versionID: version.id)
 
-        let descriptor = try Self.descriptor(assetRead: nil)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
         let authority = try await Self.makeAuthority(descriptor, input: input, store: store)
 
         authority.close()
@@ -173,7 +239,7 @@ struct RendererSessionPreparationTests {
         let version = try #require(try store.activeContentVersion(sourceID: summary.id))
         let input = RendererBridgeInput.source(versionID: version.id)
 
-        let descriptor = try Self.descriptor(assetRead: nil)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
         let authority = try await Self.makeAuthority(descriptor, input: input, store: store)
 
         // Simulate the owner's stale gate: the authority is valid but the
@@ -226,6 +292,230 @@ struct RendererPreparedAssetReadTests {
         #expect(throws: RendererAuthorizedAssetReader.ReaderError.unadmittedReference) {
             _ = try reader.read(try RendererAssetReference(validating: "stranger.png"))
         }
+    }
+}
+
+/// The preparation owner's observable phase — the pane-holding contract.
+/// A tabbed host must hold its pane through `idle`/`preparing` and fall back
+/// only on definitive `failed`. An early fallback is what made installed
+/// renderer tabs unreachable: the fallback reverts the pane's selection, the
+/// revert re-keys the preparation task and cancels it, and every retry
+/// repeats the cycle.
+@Suite(.serialized, .timeLimit(.minutes(2)))
+@MainActor
+struct RendererSessionPreparationOwnerPhaseTests {
+    // MARK: - Helpers
+
+    /// Suspends a stub preparation until the test resumes it, so phase
+    /// transitions can be observed deterministically.
+    private final class PreparationGate: Sendable {
+        private let continuation = Mutex<CheckedContinuation<Void, Never>?>(nil)
+        private let entered = Mutex(false)
+
+        /// Whether the stub has reached its suspension point; resume before
+        /// this is true would be a no-op and leave the stub parked forever.
+        var isSuspended: Bool { entered.withLock { $0 } }
+
+        func suspend() async {
+            entered.withLock { $0 = true }
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                continuation.withLock { $0 = cont }
+            }
+        }
+
+        func resume() {
+            entered.withLock { $0 = false }
+            continuation.withLock { $0 }?.resume()
+        }
+    }
+
+    /// Bounded, non-blocking wait: polls the predicate with short sleeps so a
+    /// starved pool surfaces as a timed-out test, never a hang (#1051).
+    private func waitUntil(
+        _ predicate: @MainActor () -> Bool,
+        timeout: Duration = .seconds(5)
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while predicate() == false {
+            guard ContinuousClock.now < deadline else {
+                Issue.record("Timed out waiting for the owner phase condition")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    /// An authority-returning stub body for the owner's injected preparation.
+    private func succeedingPreparation(
+        _ request: RendererSessionPreparationRequest
+    ) async throws -> RendererPreparedSessionAuthority {
+        try await RendererSessionPreparer.prepare(request)
+    }
+
+    // MARK: - Phase transitions
+
+    @Test("prepare publishes preparing, then prepared with the authority")
+    func preparePublishesPreparingThenPrepared() async throws {
+        let store = try GRDBWikiStore()
+        let (input, _) = try RendererPreparationFixtures.sourceInput(store: store)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
+        let request = RendererPreparationFixtures.request(
+            descriptor: descriptor, input: input, store: store)
+        let gate = PreparationGate()
+        let owner = RendererSessionPreparationOwner { _ in
+            await gate.suspend()
+            return try await self.succeedingPreparation(request)
+        }
+
+        #expect(owner.phase == .idle)
+        #expect(owner.isPending)
+
+        owner.prepare(request)
+        #expect(owner.phase == .preparing)
+        #expect(owner.isPending)
+
+        // Wait until the stub actually sits in its suspension point before
+        // resuming, or the resume is a no-op and the stub parks forever.
+        try await waitUntil { gate.isSuspended }
+        gate.resume()
+        try await waitUntil { owner.phase == .prepared }
+        #expect(owner.prepared != nil)
+        #expect(owner.prepared?.descriptor.reference == descriptor.reference)
+        #expect(owner.identity == request.identity)
+        #expect(owner.isPending == false)
+
+        owner.cancel()
+    }
+
+    @Test("a thrown preparation publishes failed with no authority")
+    func preparationFailurePublishesFailed() async throws {
+        struct Boom: Error {}
+        let store = try GRDBWikiStore()
+        let (input, _) = try RendererPreparationFixtures.sourceInput(store: store)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
+        let request = RendererPreparationFixtures.request(
+            descriptor: descriptor, input: input, store: store)
+        let owner = RendererSessionPreparationOwner { _ in throw Boom() }
+
+        owner.prepare(request)
+        try await waitUntil { owner.phase == .failed }
+        #expect(owner.prepared == nil)
+        #expect(owner.identity == request.identity)
+        #expect(owner.isPending == false)
+    }
+
+    @Test("cancel during preparation returns to idle and ignores the late completion")
+    func cancelDuringPreparationIgnoresLateCompletion() async throws {
+        struct Late: Error {}
+        let store = try GRDBWikiStore()
+        let (input, _) = try RendererPreparationFixtures.sourceInput(store: store)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
+        let request = RendererPreparationFixtures.request(
+            descriptor: descriptor, input: input, store: store)
+        let gate = PreparationGate()
+        let owner = RendererSessionPreparationOwner { _ in
+            await gate.suspend()
+            throw Late()
+        }
+
+        owner.prepare(request)
+        #expect(owner.phase == .preparing)
+
+        try await waitUntil { gate.isSuspended }
+        owner.cancel()
+        #expect(owner.phase == .idle)
+        #expect(owner.prepared == nil)
+        #expect(owner.isPending)
+
+        // The late, stale completion must not republish any phase.
+        gate.resume()
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(owner.phase == .idle)
+    }
+
+    @Test("cancel closes a prepared authority and clears the phase")
+    func cancelClosesPreparedAuthority() async throws {
+        let store = try GRDBWikiStore()
+        let (input, _) = try RendererPreparationFixtures.sourceInput(store: store)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
+        let request = RendererPreparationFixtures.request(
+            descriptor: descriptor, input: input, store: store)
+        let owner = RendererSessionPreparationOwner { _ in
+            try await self.succeedingPreparation(request)
+        }
+
+        owner.prepare(request)
+        try await waitUntil { owner.phase == .prepared }
+        let authority = try #require(owner.prepared)
+
+        owner.cancel()
+        #expect(owner.phase == .idle)
+        #expect(owner.prepared == nil)
+        #expect(owner.identity == nil)
+        #expect(authority.isClosed)
+    }
+
+    @Test("markUnavailable is a definitive failure that closes any prepared authority")
+    func markUnavailableIsDefinitive() async throws {
+        let store = try GRDBWikiStore()
+        let (input, _) = try RendererPreparationFixtures.sourceInput(store: store)
+        let descriptor = try RendererPreparationFixtures.descriptor(assetRead: nil)
+        let request = RendererPreparationFixtures.request(
+            descriptor: descriptor, input: input, store: store)
+        let owner = RendererSessionPreparationOwner { _ in
+            try await self.succeedingPreparation(request)
+        }
+
+        owner.prepare(request)
+        try await waitUntil { owner.phase == .prepared }
+        let authority = try #require(owner.prepared)
+
+        owner.markUnavailable()
+        #expect(owner.phase == .failed)
+        #expect(owner.prepared == nil)
+        #expect(owner.isPending == false)
+        #expect(authority.isClosed)
+    }
+
+    @Test("a newer request supersedes a stale failure")
+    func newerRequestSupersedesStaleFailure() async throws {
+        struct Stale: Error {}
+        let store = try GRDBWikiStore()
+        let (input, _) = try RendererPreparationFixtures.sourceInput(store: store)
+        let descriptorA = try RendererPreparationFixtures.descriptor(assetRead: nil)
+        let descriptorB = try RendererPreparationFixtures.descriptor(
+            registrationID: "secondary", assetRead: nil)
+        let requestA = RendererPreparationFixtures.request(
+            descriptor: descriptorA, input: input, store: store)
+        let requestB = RendererPreparationFixtures.request(
+            descriptor: descriptorB, input: input, store: store)
+        let gate = PreparationGate()
+        let owner = RendererSessionPreparationOwner { request in
+            if request.identity == requestA.identity {
+                await gate.suspend()
+                throw Stale()
+            }
+            return try await self.succeedingPreparation(request)
+        }
+
+        owner.prepare(requestA)
+        #expect(owner.phase == .preparing)
+        #expect(owner.identity == requestA.identity)
+
+        try await waitUntil { gate.isSuspended }
+
+        // The newer request owns the phase; the older task is cancelled.
+        owner.prepare(requestB)
+        #expect(owner.phase == .preparing)
+        #expect(owner.identity == requestB.identity)
+
+        gate.resume()
+        try await waitUntil { owner.phase == .prepared }
+        #expect(owner.prepared?.descriptor.reference == descriptorB.reference)
+        #expect(owner.identity == requestB.identity)
+        #expect(owner.isPending == false)
+
+        owner.cancel()
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/SourceDetailRendererArchitectureAuditTests.swift
+++ b/Tests/WikiFSAppTests/SourceDetailRendererArchitectureAuditTests.swift
@@ -50,7 +50,10 @@ import Testing
         // inline attachments do not silently fall back to the host-only
         // default resolver.
         #expect(source.components(separatedBy: "RendererInlineAttachmentResolverFactory.make").count - 1 == 2)
-        #expect(source.components(separatedBy: "installedRendererFactoryInputs: installedRendererFactoryInputs").count - 1 == 2)
+        // The two markdown paths route the store-navigation-wrapped inputs so
+        // inline attachments do not silently fall back to the host-only
+        // default resolver.
+        #expect(source.components(separatedBy: "installedRendererFactoryInputs: routedInstalledRendererFactoryInputs").count - 1 == 2)
 
         let sourceRefreshStart = try #require(source.range(of: ".onChange(of: store.sources)"))
         let sourceRefreshEnd = try #require(source[sourceRefreshStart.lowerBound...].range(of: ".background"))
@@ -95,6 +98,29 @@ import Testing
 
         #expect(host.contains("let failedSourceID = state.sourceID"))
         #expect(host.contains("shouldApplyDeferredFallback(failedSourceID: failedSourceID, currentState: state)"))
+    }
+
+    @Test func rendererPaneHoldsWhileSessionPreparationIsPending() throws {
+        // The pane-holding contract for installed web-package renderers:
+        // `renderedContent` must return a preparing pane while the owner is
+        // idle/preparing and return nil only on a definitive failure. An
+        // early fallback reverts the selection to Source, the revert re-keys
+        // the preparation task and cancels it, and the renderer tab becomes
+        // unreachable no matter how often the user retries.
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let detail = try String(contentsOf: root.appendingPathComponent("Sources/WikiFS/Sources/SourceDetailView.swift"), encoding: .utf8)
+        let factory = try String(contentsOf: root.appendingPathComponent("Sources/WikiFS/Renderer/InstalledRendererFactory.swift"), encoding: .utf8)
+
+        #expect(detail.contains("switch rendererSessionPreparation.phase {"))
+        #expect(detail.contains("case .idle, .preparing:"))
+        #expect(detail.contains("RendererPreparingPane(rendererName: descriptor.displayName)"))
+        // A definitive request-assembly failure marks the pane failed instead
+        // of silently cancelling, so the host can fall back truthfully.
+        #expect(detail.contains("rendererSessionPreparation.markUnavailable()"))
+        #expect(factory.contains("enum Phase"))
+        #expect(factory.contains("func markUnavailable()"))
+        #expect(factory.contains("var isPending: Bool"))
     }
 
     @Test func rendererHostUsesOneTabPerAvailableRenderingAndNoSplitControl() throws {

--- a/progress/2026-09-05T213000Z-renderer-pane-preparing-state.md
+++ b/progress/2026-09-05T213000Z-renderer-pane-preparing-state.md
@@ -1,0 +1,73 @@
+---
+timestamp: 2026-09-05T213000Z
+title: Renderer panes hold while their session prepares
+branch: bugfix/renderer-pane-preparing-state
+status: complete
+---
+
+# Renderer panes hold while their session prepares
+
+## Progress
+
+Clicking the renderer tab of an installed web-package renderer in the source
+detail view bounced straight back to Source. The log showed only
+`SourceDetailView: renderer fallback ... The selected renderer could not be
+loaded.` retries. No preparation attempt ever failed, because no preparation
+ever finished.
+
+The root cause was a race between the fallback and the async session
+preparation. Built-in renderers (PDF, HTML, media) return a view
+synchronously, so the pane could show them at once. Installed packages need
+`RendererSessionPreparationOwner` to build a session first. The body ran
+before preparation finished, `renderedContent` returned nil, and the host
+fell back. The fallback reverted the selection to Source and cleared the pin.
+The revert changed `rendererPreparationKey`, so `.task(id:)` re-ran and its
+guard saw the Source selection and cancelled the in-flight preparation. Every
+retry repeated the cycle, so the tab was unreachable.
+
+The fix gives the owner an observable phase:
+`idle`, `preparing`, `prepared`, `failed`. `cancel()` returns to `idle`.
+A new `markUnavailable()` records a definitive failure for a pane whose
+request assembly cannot succeed. `renderedContent` now returns a
+`RendererPreparingPane` while the phase is `idle` or `preparing` and returns
+nil only on `failed` or a session failure after mount. The host no longer
+reverts during the in-flight window, so preparation completes and the real
+pane mounts. `RendererActivationView` ("Open in Window") uses the same pane
+instead of flashing a false "could not be presented" error during
+preparation.
+
+`prepareSelectedRendererSession` now splits its guard. A missing selection
+cancels quietly. A selected pane that cannot be prepared (no package
+configuration, no authorized input) calls `markUnavailable`, so the host
+falls back with a truthful reason instead of waiting forever.
+
+Tests: `RendererSessionPreparationOwnerPhaseTests` covers the phase
+transitions, the cancel-during-preparation staleness gate, authority closure
+on cancel and on `markUnavailable`, and a newer request superseding a stale
+failure. `SourceDetailRendererArchitectureAuditTests` gained a structural
+contract for the pane-holding rule. The audit file also carries one stale
+assertion repair: `installedRendererFactoryInputs: installedRendererFactoryInputs`
+became `installedRendererFactoryInputs: routedInstalledRendererFactoryInputs`
+when the routing wrapper landed on main, so the count assertion drifted red
+independent of this fix.
+
+## Related facts
+
+`architecture.mmd` in the Testbed wiki carries MIME
+`application/vnd.chipnuts.karaoke-mmd`. macOS maps `.mmd` to a karaoke UTI,
+which bypasses the `text/mermaid` extension fallback in
+`MimeType.mime(forExtension:)` because that fallback fires only when UTType
+cannot resolve at all. The renderer match still succeeds through the
+`.mmd` extension-fallback tier, so this is not the pane bug. But the
+`![[source:…]]` embed expansion requires `MimeType.isText`, so the embed
+shows "Source not yet extracted." A separate fix could normalize the MIME at
+ingest or widen the gate.
+
+## Verification
+
+- `make build` — pass (app built and signed).
+- `WIKIFS_APP_TESTS=1 swift test --filter RendererSessionPreparation` —
+  11 tests in 3 suites pass, including the 6 new phase tests.
+- `WIKIFS_APP_TESTS=1 swift test --filter "SourceDetailRendererArchitectureAuditTests|RendererPresentationStateTests|RendererSessionPreparation"` —
+  41 tests in 5 suites pass.
+- `make test` — 4192 tests in 456 suites pass.


### PR DESCRIPTION
## Summary

Installed web-package renderer tabs in the source detail view could not be
opened. Clicking the tab bounced back to Source every time. This change makes
the pane hold through the async session preparation instead of falling back
early.

## Root cause

Built-in renderers (PDF, HTML, media) return a view synchronously. Installed
packages need `RendererSessionPreparationOwner` to build a session first, and
that work is async. The view body ran before preparation finished, so
`renderedContent` returned nil. `RendererHostView` fell back to Source, and
the fallback reverted the selection and cleared the pin. The revert changed
`rendererPreparationKey`, so `.task(id:)` re-ran, saw the Source selection,
and cancelled the in-flight preparation. The cycle repeated on every click.

The console log showed only
`SourceDetailView: renderer fallback ... The selected renderer could not be
loaded.` retries and no preparation failure, because no preparation ever
finished.

## Changes

- `RendererSessionPreparationOwner` gains an observable `Phase`:
  `idle`, `preparing`, `prepared`, `failed`. `cancel()` returns to `idle`.
  A new `markUnavailable()` records a definitive failure when the host cannot
  assemble a preparation request at all.
- `SourceDetailView.renderedContent` returns a `RendererPreparingPane` while
  the phase is `idle` or `preparing`. It returns nil only on `failed` or on a
  session failure after mount. The host no longer reverts during the
  in-flight window, so preparation completes and the pane mounts.
- `SourceDetailView.prepareSelectedRendererSession` splits its guard. A
  missing selection cancels quietly. A selected pane that cannot be prepared
  marks the failure, so the fallback keeps a truthful reason.
- `RendererActivationView` ("Open in Window") shows the same preparing pane
  instead of a false "could not be presented" error during preparation.

## Test plan

- `RendererSessionPreparationOwnerPhaseTests` (new): phase transitions,
  cancel during preparation and its staleness gate, authority closure on
  cancel and on `markUnavailable`, and a newer request superseding a stale
  failure. Bounded waits, serialized suite, time limit.
- `SourceDetailRendererArchitectureAuditTests` gains a structural contract
  for the pane-holding rule. It also repairs one stale assertion that was
  already red on main: the audit counted
  `installedRendererFactoryInputs: installedRendererFactoryInputs`, but the
  routing wrapper changed those call sites to
  `routedInstalledRendererFactoryInputs`.
- `WIKIFS_APP_TESTS=1 swift test --filter RendererSessionPreparation` —
  11 tests pass.
- `WIKIFS_APP_TESTS=1 swift test --filter "SourceDetailRendererArchitectureAuditTests|RendererPresentationStateTests|RendererSessionPreparation"` —
  41 tests pass.
- `make build` — pass. `make test` — 4192 tests in 456 suites pass.

## Notes

`architecture.mmd` in the Testbed wiki carries MIME
`application/vnd.chipnuts.karaoke-mmd` because macOS maps `.mmd` to a karaoke
UTI. Renderer matching still succeeds through the `.mmd` extension-fallback
tier, so this is unrelated to the pane bug. The `![[source:…]]` embed gate
requires a `text/*` type, so that embed shows "Source not yet extracted." A
future fix could normalize the MIME at ingest or widen the gate.
