### PR TITLE
Remove redundant diagram renderer headings

### DIFF
--- a/RendererPackages/Mermaid/index.html
+++ b/RendererPackages/Mermaid/index.html
@@ -20,7 +20,6 @@
   </head>
   <body>
     <main>
-      <h1>Mermaid diagram</h1>
       <p id="status" role="status">Rendering the diagram.</p>
       <p id="error" role="status" hidden></p>
       <div id="diagram"></div>

--- a/RendererPackages/Mermaid/manifest.json
+++ b/RendererPackages/Mermaid/manifest.json
@@ -94,7 +94,7 @@
         },
         {
           "path": "index.html",
-          "digest": "779f4d56ba0fe22006ddb47dfe9cd469538bb0608857cb286c08847f0e39619f"
+          "digest": "8a719b3bb8127bffbb6dbb8816df42060ba74bf00277fd472b95e67e73c4e70f"
         },
         {
           "path": "mermaid.min.js",
@@ -143,7 +143,7 @@
     },
     {
       "path": "index.html",
-      "digest": "779f4d56ba0fe22006ddb47dfe9cd469538bb0608857cb286c08847f0e39619f"
+      "digest": "8a719b3bb8127bffbb6dbb8816df42060ba74bf00277fd472b95e67e73c4e70f"
     },
     {
       "path": "mermaid.min.js",

--- a/RendererPackages/SVG/index.html
+++ b/RendererPackages/SVG/index.html
@@ -21,7 +21,6 @@
   </head>
   <body>
     <main>
-      <h1>SVG diagram</h1>
       <p id="status" role="status">Loading the SVG document.</p>
       <p id="error" role="status" hidden></p>
       <div id="diagram"></div>

--- a/RendererPackages/SVG/manifest.json
+++ b/RendererPackages/SVG/manifest.json
@@ -56,7 +56,7 @@
         },
         {
           "path": "index.html",
-          "digest": "44aeea2b38a0887cac9a6cdaac8f1f010bc9570c18d147037b7d2af0047eea0a"
+          "digest": "d87baa11ea379e14e569fe4c204401d2aa9591e50ac08f801fdc9b782705586c"
         },
         {
           "path": "viewer.js",
@@ -89,7 +89,7 @@
     },
     {
       "path": "index.html",
-      "digest": "44aeea2b38a0887cac9a6cdaac8f1f010bc9570c18d147037b7d2af0047eea0a"
+      "digest": "d87baa11ea379e14e569fe4c204401d2aa9591e50ac08f801fdc9b782705586c"
     },
     {
       "path": "viewer.js",

--- a/Tests/WikiFSAppTests/MermaidRendererPackageTests.swift
+++ b/Tests/WikiFSAppTests/MermaidRendererPackageTests.swift
@@ -147,6 +147,7 @@ struct MermaidRendererPackageTests {
         #expect(entrySource.contains("__sdw_validate_fence"))
         #expect(documentSource.contains("mermaid.min.js"))
         #expect(documentSource.contains("viewer.js"))
+        #expect(documentSource.contains("<h1") == false)
 
         for prohibitedPattern in [
             "window.open", "fetch(", "XMLHttpRequest", "WebSocket", "Worker(",

--- a/Tests/WikiFSAppTests/SVGRendererPackageTests.swift
+++ b/Tests/WikiFSAppTests/SVGRendererPackageTests.swift
@@ -243,6 +243,7 @@ struct SVGRendererPackageTests {
         // never decoded into markup, and the load is budget-bounded.
         #expect(viewerSource.contains("Promise.race"))
         #expect(documentSource.contains("viewer.js"))
+        #expect(documentSource.contains("<h1") == false)
 
         for prohibitedPattern in [
             "window.open", "fetch(", "XMLHttpRequest", "WebSocket", "Worker(",


### PR DESCRIPTION
## Summary

- Remove the visible shell heading from the Mermaid renderer.
- Remove the visible shell heading from the SVG renderer.
- Keep each document title and image accessibility label.
- Add regression checks for both renderer documents.
- Update the reviewed package asset digests.

## Validation

- `swift run RendererPackageTool validate RendererPackages/Mermaid`
- `swift run RendererPackageTool validate RendererPackages/SVG`
- `WIKIFS_APP_TESTS=1 swift test --filter 'MermaidRendererPackageTests|SVGRendererPackageTests'` (17 tests passed)
- Git pre-commit checks passed.

## Test note

`make test` built successfully but stopped during the test run without an assertion or test summary. The repository watchdog returned exit code 1. The two affected package suites passed separately.
