### PR TITLE
fix(extraction): bump transcript extractor packages to 1.0.1

### DIFF
--- a/ExtractorPackages/PodcastTranscript/PROVENANCE.md
+++ b/ExtractorPackages/PodcastTranscript/PROVENANCE.md
@@ -1,7 +1,7 @@
 # Reviewed package provenance
 
 - Package: org.selfdrivingwiki.podcast-transcript
-- Version: 1.0.0
+- Version: 1.0.1 (1.0.1: shared-runtime-cache capability for warm uv runs)
 - Source: tools/podcast-transcript/podcast-transcript in this repository
 - Entry point: bin/podcast-transcript-extractor, generated from the same source
 - Dependencies: the PEP 723 block of the entry point is copied from the script

--- a/ExtractorPackages/PodcastTranscript/manifest.json
+++ b/ExtractorPackages/PodcastTranscript/manifest.json
@@ -7,7 +7,7 @@
   "entryPoint": "bin/podcast-transcript-extractor",
   "files": [
     {
-      "digest": "5ce43f31ca134c5f6a78ca67fa49846c04d1cad08549e26f229e917a3b322edd",
+      "digest": "4f42ba3d29216543a1b750ac341dad58db6c0672464d7d38c3554ed613707b2e",
       "path": "PROVENANCE.md"
     },
     {
@@ -48,5 +48,5 @@
       ]
     }
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/ExtractorPackages/YouTubeTranscript/PROVENANCE.md
+++ b/ExtractorPackages/YouTubeTranscript/PROVENANCE.md
@@ -1,7 +1,7 @@
 # Reviewed package provenance
 
 - Package: org.selfdrivingwiki.youtube-transcript
-- Version: 1.0.0
+- Version: 1.0.1 (1.0.1: shared-runtime-cache capability for warm uv runs)
 - Source: tools/youtube-transcript/youtube-transcript in this repository
 - Entry point: bin/youtube-transcript-extractor, generated from the same source
 - Dependencies: the PEP 723 block of the entry point is copied from the script

--- a/ExtractorPackages/YouTubeTranscript/manifest.json
+++ b/ExtractorPackages/YouTubeTranscript/manifest.json
@@ -7,7 +7,7 @@
   "entryPoint": "bin/youtube-transcript-extractor",
   "files": [
     {
-      "digest": "78d750b0d86a2eec51d378e8045b70dc488c78cf177aaf789b689f9532141c96",
+      "digest": "7f57b86e9cf4783d29653493eca48b4cb8d95d3c7bbed49640a55a0cdbfb872e",
       "path": "PROVENANCE.md"
     },
     {
@@ -48,5 +48,5 @@
       ]
     }
   ],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/Sources/ManagedExtractorFixture/main.swift
+++ b/Sources/ManagedExtractorFixture/main.swift
@@ -76,7 +76,7 @@ do {
 }
 
 switch mode {
-case "success", "environment":
+case "success", "environment", "linger":
     let markdown: String
     if mode == "environment" {
         let environment = ProcessInfo.processInfo.environment
@@ -113,6 +113,12 @@ case "success", "environment":
                 markdownByteCount: markdown.utf8.count)))
     } catch {
         exit(3)
+    }
+    // Mode "linger": the protocol exchange is complete, but the wrapper
+    // process outlives the package — the observed `uv run` hang. The host
+    // must treat the terminal frame as completion and reap the group.
+    if mode == "linger" {
+        while true { _ = Darwin.pause() }
     }
 case "failure":
     do {

--- a/Sources/WikiFS/Window/WikiFSApp.swift
+++ b/Sources/WikiFS/Window/WikiFSApp.swift
@@ -514,11 +514,27 @@ struct WikiFSApp: App {
         appDelegate.shutdownForTermination = { [
             daemonTransportCoordinator,
             sessionManager,
-            processProfileOwner
+            processProfileOwner,
+            containerDirectory
         ] in
             await daemonTransportCoordinator.shutdown()
             await sessionManager.shutdownSearchRuntimes()
             await processProfileOwner.shutdown()
+            // Remove this session's extractor operation directories. Each run
+            // leaves a private operation root (input/output/home/cache); a
+            // clean close is the moment to reclaim it. Stale sessions from
+            // crashes are reclaimed by the daemon at its startup.
+            do {
+                let layout = try ExtractorPackageStoreLayout(
+                    appGroupContainerRoot: containerDirectory,
+                    processRole: .app)
+                try ExtractorDirectoryValidator.cleanupOperationSessions(
+                    layout: layout,
+                    scope: .currentSession)
+            } catch {
+                DebugLog.extraction(
+                    "App close: extractor operation cleanup failed: \(error)")
+            }
         }
         appDelegate.unregisterDaemon = {
             // The daemon is a bundled XPC service — the system manages its

--- a/Sources/WikiFSCore/Extractor/ExtractorDirectoryAdmission.swift
+++ b/Sources/WikiFSCore/Extractor/ExtractorDirectoryAdmission.swift
@@ -818,13 +818,25 @@ public enum ExtractorDirectoryValidator {
         guard sameIdentity(before, opened), opened.st_mode & S_IFMT == S_IFDIR else {
             throw ExtractorDirectoryAdmissionError.preparationFailed
         }
+        // Admission normalizes tree contents to owner-read-only (0400 files
+        // inside 0500 directories) for snapshot immutability. Unlinking an
+        // entry needs write permission on the directory holding it, so make
+        // this directory owner-writable before removing children. We already
+        // verified the tree is owned by this process.
+        if fchmod(descriptor, 0o700) != 0 {
+            throw ExtractorDirectoryAdmissionError.preparationFailed
+        }
         for child in try directoryEntryNames(descriptor) {
             let childStatus = try status(at: descriptor, name: child, noFollow: true)
             switch childStatus.st_mode & S_IFMT {
             case S_IFDIR:
                 try removeStoreTree(named: child, from: descriptor)
-            case S_IFREG:
-                guard childStatus.st_uid == getuid(), childStatus.st_nlink == 1 else {
+            case S_IFREG, S_IFLNK:
+                // Operation sessions legitimately contain uv-managed content:
+                // hardlinked wheels (st_nlink > 1) and venv symlinks. Ownership
+                // is the safety boundary here; deleting one hardlink removes
+                // only this directory entry, never the other link's content.
+                guard childStatus.st_uid == getuid() else {
                     throw ExtractorDirectoryAdmissionError.preparationFailed
                 }
                 guard child.withCString({ unlinkat(descriptor, $0, 0) }) == 0 else {

--- a/Sources/WikiFSCore/Extractor/ExtractorDirectoryAdmission.swift
+++ b/Sources/WikiFSCore/Extractor/ExtractorDirectoryAdmission.swift
@@ -78,12 +78,30 @@ public enum ExtractorDirectoryAdmissionError: Error, Equatable, Sendable {
     case mutationForbidden
     case nonFileURL, sourceNotDirectory, sourceChanged, symlink(String), hardLink(String), specialFile(String)
     case deviceChanged(String), metadataChanged(String), modeChanged(String), collision(String), containment
-    case copyFailed(String), preparationFailed, validationFailed, expectedRevisionMismatch, invalidStagingID, limitExceeded
+    /// `preparationFailed` carries a bounded, path-free detail string: the
+    /// admission stage that failed and, for a failing syscall, its errno
+    /// number and system name. It never contains paths, URLs, environment
+    /// values, or upstream text, so it is safe for logs and queue-item
+    /// error fields.
+    case copyFailed(String), preparationFailed(String), validationFailed, expectedRevisionMismatch, invalidStagingID, limitExceeded
     case manifest(ExtractorManifestValidationError)
     /// A third-party import tried to claim a reviewed package lineage with
     /// bytes that do not reproduce the pinned reviewed revision (#1159,
     /// security review HIGH-3).
     case reviewedLineageReserved(String)
+
+    /// Builds a `preparationFailed` for an admission stage that failed
+    /// without a syscall (identity or mode verification).
+    public static func preparationFailure(_ stage: String) -> ExtractorDirectoryAdmissionError {
+        .preparationFailed(stage)
+    }
+
+    /// Builds a `preparationFailed` for a failing syscall. Read `errno`
+    /// immediately after the failed call and pass it here. `strerror` only
+    /// renders the bounded system name for the number.
+    public static func preparationFailure(errno code: Int32, stage: String) -> ExtractorDirectoryAdmissionError {
+        .preparationFailed("\(stage): errno \(code) (\(String(cString: strerror(code))))")
+    }
 }
 
 public struct ValidatedExtractorDirectory: Sendable {
@@ -133,8 +151,10 @@ public enum ExtractorDirectoryValidator {
             stagingFD = roots.staging
             close(roots.root); close(roots.packages); close(roots.derived); close(roots.operations)
             destinationFD = try createDirectory(named: stagingID.rawValue, in: stagingFD)
+        } catch let error as ExtractorDirectoryAdmissionError {
+            throw error
         } catch {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("staging preparation failed: \(String(describing: error))")
         }
         defer { close(destinationFD); close(stagingFD) }
 
@@ -232,7 +252,11 @@ public enum ExtractorDirectoryValidator {
             let processName = "\(getpid())-\(layout.processSessionID.rawValue)"
             processRootFD = try openOrCreateDirectory(named: processName, in: roleFD)
             destinationFD = try createDirectory(named: id.rawValue, in: processRootFD)
-        } catch { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        } catch let error as ExtractorDirectoryAdmissionError {
+            throw error
+        } catch {
+            throw ExtractorDirectoryAdmissionError.preparationFailure("operation session preparation failed: \(String(describing: error))")
+        }
         defer { close(destinationFD); close(processRootFD) }
 
         do {
@@ -303,7 +327,11 @@ public enum ExtractorDirectoryValidator {
             let processName = "\(getpid())-\(layout.processSessionID.rawValue)"
             processRootFD = try openOrCreateDirectory(named: processName, in: roleFD)
             destinationFD = try createDirectory(named: id.rawValue, in: processRootFD)
-        } catch { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        } catch let error as ExtractorDirectoryAdmissionError {
+            throw error
+        } catch {
+            throw ExtractorDirectoryAdmissionError.preparationFailure("snapshot preparation failed: \(String(describing: error))")
+        }
         defer { close(destinationFD); close(processRootFD) }
         do {
             try copyTree(sourceFD: sourceFD, destinationFD: destinationFD, sourceDevice: openedSource.st_dev, manifest: installed.validated.manifest)
@@ -331,7 +359,7 @@ public enum ExtractorDirectoryValidator {
         let parentStatus = try lstat(target.deletingLastPathComponent())
         guard parentStatus.st_mode & S_IFMT == S_IFDIR,
               parentStatus.st_uid == getuid() else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("operation parent verification failed")
         }
         let createResult = target.lastPathComponent.withCString { name -> Int32 in
             let parentFD = open(
@@ -342,7 +370,7 @@ public enum ExtractorDirectoryValidator {
             return mkdirat(parentFD, name, 0o700)
         }
         guard createResult == 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "mkdirat operation target")
         }
 
         let sourceURL = validated.root.standardizedFileURL
@@ -363,7 +391,7 @@ public enum ExtractorDirectoryValidator {
             open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
         }
         guard destinationFD >= 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "open operation target")
         }
         defer { close(destinationFD) }
         do {
@@ -416,7 +444,7 @@ public enum ExtractorDirectoryValidator {
         }
         guard root.descriptor >= 0 else {
             if root.error == ENOENT { return nil }
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: root.error, stage: "open store container")
         }
         var current = root.descriptor
         for component in ["extractors", "v1", "operations", layout.processRole.rawValue] {
@@ -428,7 +456,7 @@ public enum ExtractorDirectoryValidator {
             close(current)
             guard next.descriptor >= 0 else {
                 if next.error == ENOENT { return nil }
-                throw ExtractorDirectoryAdmissionError.preparationFailed
+                throw ExtractorDirectoryAdmissionError.preparationFailure(errno: next.error, stage: "open operations component")
             }
             current = next.descriptor
         }
@@ -695,10 +723,10 @@ public enum ExtractorDirectoryValidator {
 
     private static func createDirectory(named name: String, in parentFD: Int32) throws -> Int32 {
         guard name.withCString({ mkdirat(parentFD, $0, 0o700) }) == 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "mkdirat directory")
         }
         let descriptor = name.withCString { openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW) }
-        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "open new directory") }
         do {
             try normalizePrivateDirectory(descriptor)
             return descriptor
@@ -713,9 +741,11 @@ public enum ExtractorDirectoryValidator {
             let result = mkdirat(parentFD, pointer, 0o700)
             return (result, errno)
         }
-        if creation.0 != 0, creation.1 != EEXIST { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        if creation.0 != 0, creation.1 != EEXIST {
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: creation.1, stage: "mkdirat directory")
+        }
         let descriptor = name.withCString { openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW) }
-        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "openat directory") }
         do {
             try normalizePrivateDirectory(descriptor)
             return descriptor
@@ -727,19 +757,19 @@ public enum ExtractorDirectoryValidator {
 
     private static func normalizePrivateDirectory(_ descriptor: Int32) throws {
         guard fchmod(descriptor, 0o700) == 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "fchmod directory")
         }
         let directoryStatus = try status(of: descriptor)
         guard directoryStatus.st_mode & S_IFMT == S_IFDIR,
               directoryStatus.st_uid == getuid(),
               directoryStatus.st_mode & 0o7777 == 0o700 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("directory mode or owner verification failed")
         }
     }
 
     private static func canonicalURL(_ url: URL) throws -> URL {
         let resolved = url.path.withCString { pointer -> UnsafeMutablePointer<CChar>? in realpath(pointer, nil) }
-        guard let resolved else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard let resolved else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "realpath") }
         defer { free(resolved) }
         return URL(fileURLWithPath: String(cString: resolved), isDirectory: true)
     }
@@ -753,12 +783,12 @@ public enum ExtractorDirectoryValidator {
         let descriptor = authorityURL.path.withCString {
             open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
         }
-        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "open app group container") }
         do {
             let opened = try status(of: descriptor)
             guard sameIdentity(pathStatus, opened),
                   opened.st_mode & S_IFMT == S_IFDIR else {
-                throw ExtractorDirectoryAdmissionError.preparationFailed
+                throw ExtractorDirectoryAdmissionError.preparationFailure("app group container verification failed")
             }
             return descriptor
         } catch {
@@ -778,26 +808,26 @@ public enum ExtractorDirectoryValidator {
         let before = try status(at: parentFD, name: name, noFollow: true)
         guard before.st_mode & S_IFMT == S_IFDIR,
               before.st_uid == getuid() else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("empty-directory precheck failed")
         }
         let descriptor = name.withCString {
             openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
         }
-        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "openat directory") }
         defer { close(descriptor) }
         let opened = try status(of: descriptor)
         guard sameIdentity(before, opened), opened.st_mode & S_IFMT == S_IFDIR else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("directory identity verification failed")
         }
         guard try directoryEntryNames(descriptor).isEmpty else { return false }
         let current = try status(at: parentFD, name: name, noFollow: true)
         guard sameIdentity(opened, current) else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("directory changed before removal")
         }
         let result = name.withCString { unlinkat(parentFD, $0, AT_REMOVEDIR) }
         if result == 0 { return true }
         if errno == ENOTEMPTY || errno == EEXIST { return false }
-        throw ExtractorDirectoryAdmissionError.preparationFailed
+        throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "rmdir")
     }
 
     public static func removeStoreTree(
@@ -807,16 +837,16 @@ public enum ExtractorDirectoryValidator {
         let before = try status(at: parentFD, name: name, noFollow: true)
         guard before.st_mode & S_IFMT == S_IFDIR,
               before.st_uid == getuid() else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("tree removal precheck failed")
         }
         let descriptor = name.withCString {
             openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
         }
-        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard descriptor >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "openat directory") }
         defer { close(descriptor) }
         let opened = try status(of: descriptor)
         guard sameIdentity(before, opened), opened.st_mode & S_IFMT == S_IFDIR else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("directory identity verification failed")
         }
         // Admission normalizes tree contents to owner-read-only (0400 files
         // inside 0500 directories) for snapshot immutability. Unlinking an
@@ -824,7 +854,7 @@ public enum ExtractorDirectoryValidator {
         // this directory owner-writable before removing children. We already
         // verified the tree is owned by this process.
         if fchmod(descriptor, 0o700) != 0 {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "fchmod directory")
         }
         for child in try directoryEntryNames(descriptor) {
             let childStatus = try status(at: descriptor, name: child, noFollow: true)
@@ -837,22 +867,22 @@ public enum ExtractorDirectoryValidator {
                 // is the safety boundary here; deleting one hardlink removes
                 // only this directory entry, never the other link's content.
                 guard childStatus.st_uid == getuid() else {
-                    throw ExtractorDirectoryAdmissionError.preparationFailed
+                    throw ExtractorDirectoryAdmissionError.preparationFailure("child entry is not owned by this user")
                 }
                 guard child.withCString({ unlinkat(descriptor, $0, 0) }) == 0 else {
-                    throw ExtractorDirectoryAdmissionError.preparationFailed
+                    throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "unlink child entry")
                 }
             default:
-                throw ExtractorDirectoryAdmissionError.preparationFailed
+                throw ExtractorDirectoryAdmissionError.preparationFailure("child entry is a special file")
             }
         }
         let after = try status(of: descriptor)
         let entry = try status(at: parentFD, name: name, noFollow: true)
         guard sameIdentity(opened, after), sameIdentity(opened, entry) else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("directory changed during removal")
         }
         guard name.withCString({ unlinkat(parentFD, $0, AT_REMOVEDIR) }) == 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "rmdir")
         }
     }
 
@@ -861,11 +891,11 @@ public enum ExtractorDirectoryValidator {
         let authorityURL = try canonicalURL(layout.appGroupContainerRoot)
         let authorityPathStatus = try lstat(authorityURL)
         let authorityFD = authorityURL.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW) }
-        guard authorityFD >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailed }
+        guard authorityFD >= 0 else { throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "open authority root") }
         defer { close(authorityFD) }
         let authorityOpenedStatus = try status(of: authorityFD)
         guard sameIdentity(authorityPathStatus, authorityOpenedStatus), authorityOpenedStatus.st_mode & S_IFMT == S_IFDIR else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("authority root verification failed")
         }
         let extractors = try openOrCreateDirectory(named: "extractors", in: authorityFD)
         defer { close(extractors) }
@@ -887,7 +917,7 @@ public enum ExtractorDirectoryValidator {
             let retainedRoot = dup(root)
             guard retainedRoot >= 0 else {
                 close(packages); close(staging); close(derived); close(operations)
-                throw ExtractorDirectoryAdmissionError.preparationFailed
+                throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "dup root descriptor")
             }
             return (retainedRoot, packages, staging, derived, operations)
         } catch { close(packages); throw error }

--- a/Sources/WikiFSCore/Extractor/ManagedExtractorProcessExecutor.swift
+++ b/Sources/WikiFSCore/Extractor/ManagedExtractorProcessExecutor.swift
@@ -189,7 +189,8 @@ public struct ManagedExtractorProcessExecutor: ManagedProcessExecuting, Sendable
             outputPath: operation.protocolRequest.outputPath,
             maximumProgressEventCount: operation.manifest.limits.maximumProgressEventCount,
             onFrame: trackedOnFrame,
-            onFailure: { cancellationSlot.requestTermination() })
+            onFailure: { cancellationSlot.requestTermination() },
+            onCompletion: { cancellationSlot.requestTermination() })
         let stdoutLimit = managedStandardOutputLimit(operation.manifest.limits)
         let handle: RaceFreeProcessGroupHandle
         do {
@@ -262,10 +263,18 @@ public struct ManagedExtractorProcessExecutor: ManagedProcessExecuting, Sendable
             diagnostics.send(protocolFailureLine(launch))
             throw ManagedExtractorProcessError.malformedProtocol
         }
+        // The package contract makes a valid terminal frame the operation's
+        // completion. When the wrapper process outlives the package —
+        // observed with `uv run` lingering after the package exits — the
+        // completion hook kills the group, so a signaled (or nonzero)
+        // termination alongside a terminal frame is success, not a crash.
+        // Without a terminal frame the strict termination rules still hold.
+        let protocolCompleted = protocolState.hasTerminalFrame
         switch execution.terminationCause {
         case .exited(code: 0):
             break
         case .exited, .signaled:
+            guard !protocolCompleted else { break }
             diagnostics.send(ManagedExtractorDiagnostics.Event.nonzeroExit(
                 command: launch.commandDescription,
                 termination: String(describing: execution.terminationCause),
@@ -574,15 +583,18 @@ private final class ManagedProtocolState: @unchecked Sendable {
     private var decoder = ExtractorJSONLinesDecoder()
     private var sequence: ExtractorProtocolSequence
     private var failure: Error?
+    private var completionSignaled = false
     private let onFrame: @Sendable (ExtractorProtocolFrame) -> Void
     private let onFailure: @Sendable () -> Void
+    private let onCompletion: @Sendable () -> Void
 
     init(
         requestID: ExtractorRequestID,
         outputPath: ExtractorRelativePath,
         maximumProgressEventCount: Int,
         onFrame: @escaping @Sendable (ExtractorProtocolFrame) -> Void,
-        onFailure: @escaping @Sendable () -> Void
+        onFailure: @escaping @Sendable () -> Void,
+        onCompletion: @escaping @Sendable () -> Void
     ) {
         sequence = ExtractorProtocolSequence(
             requestID: requestID,
@@ -590,24 +602,41 @@ private final class ManagedProtocolState: @unchecked Sendable {
             maximumProgressEventCount: maximumProgressEventCount)
         self.onFrame = onFrame
         self.onFailure = onFailure
+        self.onCompletion = onCompletion
     }
 
     var hasFailure: Bool { lock.withLock { failure != nil } }
 
+    /// True once the package's terminal frame has been decoded. The package
+    /// contract makes that frame the operation's completion, even if the
+    /// wrapper process that spawned the package never exits.
+    var hasTerminalFrame: Bool { lock.withLock { sequence.terminalFrame != nil } }
+
     func consume(_ data: Data) {
-        let outcome: (frames: [ExtractorProtocolFrame], failed: Bool) = lock.withLock {
-            guard failure == nil else { return ([], false) }
+        struct Outcome {
+            let frames: [ExtractorProtocolFrame]
+            let failed: Bool
+            let completed: Bool
+        }
+        let outcome: Outcome = lock.withLock {
+            guard failure == nil else { return Outcome(frames: [], failed: false, completed: false) }
             do {
                 let frames = try decoder.append(data)
                 for frame in frames { try sequence.consume(frame) }
-                return (frames, false)
+                var completed = false
+                if sequence.terminalFrame != nil, !completionSignaled {
+                    completionSignaled = true
+                    completed = true
+                }
+                return Outcome(frames: frames, failed: false, completed: completed)
             } catch {
                 failure = error
-                return ([], true)
+                return Outcome(frames: [], failed: true, completed: false)
             }
         }
         for frame in outcome.frames { onFrame(frame) }
         if outcome.failed { onFailure() }
+        if outcome.completed { onCompletion() }
     }
 
     func finish() throws -> (terminalFrame: ExtractorProtocolFrame, progressEventCount: Int) {

--- a/Sources/WikiFSCore/Extractor/ReviewedExtractorPackages.swift
+++ b/Sources/WikiFSCore/Extractor/ReviewedExtractorPackages.swift
@@ -57,8 +57,8 @@ public enum ReviewedExtractorPackages {
     public static let podcastTranscript = make(
         directoryName: "PodcastTranscript",
         packageID: "org.selfdrivingwiki.podcast-transcript",
-        version: "1.0.0",
-        digest: "8b083ec85664e9d0c1a2afe8b96beee100660c1882f6d7c75d627da918f6caa6")
+        version: "1.0.1",
+        digest: "14ea800bd0fd525a925f5bc47ce4b4cf5b3b6d31892edfea20e0cb8d3a5621af")
 
     public static let applePodcastTranscript = make(
         directoryName: "ApplePodcastTranscript",
@@ -69,8 +69,8 @@ public enum ReviewedExtractorPackages {
     public static let youtubeTranscript = make(
         directoryName: "YouTubeTranscript",
         packageID: "org.selfdrivingwiki.youtube-transcript",
-        version: "1.0.0",
-        digest: "8f87ff4a0c8c5fac1d5ff19c6d1dff6a816a27c081fb106de3bc6c92b8c7e1a1")
+        version: "1.0.1",
+        digest: "23e987d6ee3207ff89fb506a23c5ccef8e2693410dd14bc7f8e47e4f8acd7679")
 
     public static let all: [ReviewedExtractorPackage] = [
         defuddle, pdf2md, doclingServe, docx2md, podcastTranscript,

--- a/Sources/WikiFSEngine/ProcessExtractorProvider.swift
+++ b/Sources/WikiFSEngine/ProcessExtractorProvider.swift
@@ -329,7 +329,7 @@ public struct ProcessExtractorProvider: Sendable {
                 withIntermediateDirectories: true,
                 attributes: [.posixPermissions: 0o700])
             guard try Self.isOwnerPrivateDirectory(sharedRoot) else {
-                throw ExtractorDirectoryAdmissionError.preparationFailed
+                throw ExtractorDirectoryAdmissionError.preparationFailure("shared cache directory verification failed")
             }
         }
         let materializedRevision = try ExtractorDirectoryValidator.materializeOperationPackage(
@@ -390,7 +390,7 @@ public struct ProcessExtractorProvider: Sendable {
     private static func isOwnerPrivateDirectory(_ url: URL) throws -> Bool {
         var status = stat()
         guard lstat(url.path, &status) == 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "lstat directory")
         }
         return status.st_mode & S_IFMT == S_IFDIR
             && status.st_uid == getuid()
@@ -974,13 +974,13 @@ public final class PreparedProcessOperation: Sendable {
         // Refuse to overwrite anything that already exists (a planted symlink
         // at the target must never be written through).
         guard FileManager.default.fileExists(atPath: url.path) == false else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("request output path already exists")
         }
         let fd = url.path.withCString {
             open($0, O_WRONLY | O_CREAT | O_EXCL, 0o400)
         }
         guard fd >= 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "open request output file")
         }
         defer { close(fd) }
         let result: Int = data.withUnsafeBytes { raw in
@@ -997,7 +997,7 @@ public final class PreparedProcessOperation: Sendable {
             return total
         }
         guard result == data.count else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "write request output file")
         }
         try verifyOwnerReadOnlyFile(fd: fd, at: url)
     }
@@ -1013,7 +1013,7 @@ public final class PreparedProcessOperation: Sendable {
         var viaPath = stat()
         guard fstat(fd, &viaFD) == 0,
               lstat(url.path, &viaPath) == 0 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "fstat/lstat request output file")
         }
         guard viaFD.st_dev == viaPath.st_dev,
               viaFD.st_ino == viaPath.st_ino,
@@ -1021,7 +1021,7 @@ public final class PreparedProcessOperation: Sendable {
               viaFD.st_uid == getuid(),
               viaFD.st_nlink == 1,
               viaFD.st_mode & 0o777 == 0o400 else {
-            throw ExtractorDirectoryAdmissionError.preparationFailed
+            throw ExtractorDirectoryAdmissionError.preparationFailure("request output file verification failed")
         }
     }
 }

--- a/Sources/WikiFSEngine/ProcessExtractorProvider.swift
+++ b/Sources/WikiFSEngine/ProcessExtractorProvider.swift
@@ -328,9 +328,14 @@ public struct ProcessExtractorProvider: Sendable {
                 at: sharedRoot,
                 withIntermediateDirectories: true,
                 attributes: [.posixPermissions: 0o700])
-            guard try Self.isOwnerPrivateDirectory(sharedRoot) else {
-                throw ExtractorDirectoryAdmissionError.preparationFailure("shared cache directory verification failed")
-            }
+            // `createDirectory(attributes:)` applies the mode only when it
+            // creates the final component. A pre-existing root — for example
+            // one seeded by a manual `uv` run, which creates world-traversable
+            // directories — keeps its old mode and would fail verification
+            // forever. Ownership is the safety boundary (as in
+            // `removeStoreTree`): tighten any owner-owned root to 0700, then
+            // verify.
+            try Self.normalizeOwnerPrivateDirectory(sharedRoot)
         }
         let materializedRevision = try ExtractorDirectoryValidator.materializeOperationPackage(
             from: snapshot,
@@ -395,6 +400,35 @@ public struct ProcessExtractorProvider: Sendable {
         return status.st_mode & S_IFMT == S_IFDIR
             && status.st_uid == getuid()
             && status.st_mode & 0o7777 == 0o700
+    }
+
+    /// Tightens an existing shared cache root to owner-private 0700, then
+    /// verifies it through the opened descriptor. Refuses anything that is
+    /// not a directory owned by this UID — ownership is the boundary that
+    /// makes the chmod safe, matching `removeStoreTree`.
+    static func normalizeOwnerPrivateDirectory(_ url: URL) throws {
+        let fd = url.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW) }
+        guard fd >= 0 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "open shared cache root")
+        }
+        defer { close(fd) }
+        var opened = stat()
+        guard fstat(fd, &opened) == 0 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "fstat shared cache root")
+        }
+        guard opened.st_mode & S_IFMT == S_IFDIR, opened.st_uid == getuid() else {
+            throw ExtractorDirectoryAdmissionError.preparationFailure("shared cache root is not an owner directory")
+        }
+        guard fchmod(fd, 0o700) == 0 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: errno, stage: "fchmod shared cache root")
+        }
+        var tightened = stat()
+        guard fstat(fd, &tightened) == 0,
+              tightened.st_mode & S_IFMT == S_IFDIR,
+              tightened.st_uid == getuid(),
+              tightened.st_mode & 0o7777 == 0o700 else {
+            throw ExtractorDirectoryAdmissionError.preparationFailure("shared cache directory verification failed")
+        }
     }
 
     static func registration(

--- a/Sources/WikiFSEngine/QueueExtractionWorker.swift
+++ b/Sources/WikiFSEngine/QueueExtractionWorker.swift
@@ -60,8 +60,13 @@ public struct QueueExtractionWorkerFactory: QueueWorkerFactory {
             DebugLog.store("QueueExtractionWorker.resolveExtraction blocked: \(error)")
             return ProviderID(rawValue: "blocked-extraction")
         } catch {
+            // Any other resolve failure is a real per-item fault: bad legacy
+            // identity data, admission failure, or a lost store. Route the
+            // item through the neutral capacity bucket so dispatch claims it
+            // and the worker surfaces the error on the item, instead of
+            // silently returning it to .queued forever.
             DebugLog.store("QueueExtractionWorker.resolveExtraction: \(error)")
-            return nil
+            return ProviderID(rawValue: "blocked-extraction")
         }
         guard let resolved else { return nil }
 

--- a/Sources/wikid/DaemonQueueExtractionProvider.swift
+++ b/Sources/wikid/DaemonQueueExtractionProvider.swift
@@ -18,13 +18,19 @@ import WikiFSEngine
 final class DaemonQueueExtractionProvider: QueueExtractionProvider {
     private let extractionServices: any ExtractionServices
     private let storeResolver: @Sendable (WikiID) -> GRDBWikiStore?
+    /// Prepares the wiki's store on demand (`WikiDaemon.openStore`). A fresh
+    /// relaunch may not have the store ready when a queued item is claimed;
+    /// without this, the item starves between claim and resolution.
+    private let openStore: @Sendable (WikiID) async -> Bool
 
     init(
         extractionServices: any ExtractionServices,
-        storeResolver: @escaping @Sendable (WikiID) -> GRDBWikiStore?
+        storeResolver: @escaping @Sendable (WikiID) -> GRDBWikiStore?,
+        openStore: @escaping @Sendable (WikiID) async -> Bool = { _ in false }
     ) {
         self.extractionServices = extractionServices
         self.storeResolver = storeResolver
+        self.openStore = openStore
     }
 
     // MARK: - QueueExtractionProvider
@@ -34,7 +40,14 @@ final class DaemonQueueExtractionProvider: QueueExtractionProvider {
         sourceID: SourceID,
         backendOverride: ExtractionBackend?
     ) async throws -> ExtractionResolution? {
-        guard let store = storeResolver(wikiID) else {
+        var store = storeResolver(wikiID)
+        if store == nil {
+            // A fresh relaunch may not have this wiki's store prepared yet.
+            // Prepare it on demand instead of starving the queued item.
+            _ = await openStore(wikiID)
+            store = storeResolver(wikiID)
+        }
+        guard let store else {
             DebugLog.extraction("DaemonQueueExtractionProvider: no store for wikiID=\(wikiID.rawValue)")
             return nil
         }

--- a/Sources/wikid/DaemonQueueExtractionProvider.swift
+++ b/Sources/wikid/DaemonQueueExtractionProvider.swift
@@ -161,8 +161,10 @@ final class DaemonQueueExtractionProvider: QueueExtractionProvider {
         markdown: String
     ) async throws {
         guard let store = storeResolver(wikiID) else {
+            // A finished extraction whose store vanished mid-flight is data
+            // loss — fail the item loudly instead of silently completing.
             DebugLog.extraction("DaemonQueueExtractionProvider: persistBytesExtraction — no store for wikiID=\(wikiID.rawValue)")
-            return
+            throw DaemonStoreUnavailableError(wikiID: wikiID)
         }
         if let packageProducer = resolution.packageProducer {
             do {
@@ -192,8 +194,10 @@ final class DaemonQueueExtractionProvider: QueueExtractionProvider {
         outcome: TranscriptFetchOutcome
     ) async throws {
         guard let store = storeResolver(wikiID) else {
+            // A finished extraction whose store vanished mid-flight is data
+            // loss — fail the item loudly instead of silently completing.
             DebugLog.extraction("DaemonQueueExtractionProvider: persistTranscriptExtraction — no store for wikiID=\(wikiID.rawValue)")
-            return
+            throw DaemonStoreUnavailableError(wikiID: wikiID)
         }
         switch resolution.resultMode {
         case .builtInTool(let tool):
@@ -227,6 +231,17 @@ final class DaemonQueueExtractionProvider: QueueExtractionProvider {
             }
         }
         DarwinNotifier.postChange(forWikiID: wikiID.rawValue)
+    }
+}
+
+/// Thrown when a finished extraction cannot be persisted because the wiki's
+/// store disappeared mid-flight. Failing the item loudly (never silently
+/// completing) keeps the queue's terminal state truthful.
+struct DaemonStoreUnavailableError: Error, LocalizedError {
+    let wikiID: WikiID
+
+    var errorDescription: String? {
+        "The wiki's store is no longer available; the extraction result could not be saved."
     }
 }
 

--- a/Sources/wikid/WikiDaemon.swift
+++ b/Sources/wikid/WikiDaemon.swift
@@ -978,7 +978,12 @@ final class WikiDaemon: @unchecked Sendable {
         let queueStore = try QueueStore(databaseURL: queueDatabaseURL)
         let extractionProvider = DaemonQueueExtractionProvider(
             extractionServices: extractionServices,
-            storeResolver: storeResolver)
+            storeResolver: storeResolver,
+            openStore: { [weak self] wikiID in
+                guard let self else { return false }
+                _ = await self.openStore(wikiID: wikiID)
+                return self.preparedStoreIfAvailable(wikiID: wikiID) != nil
+            })
         let dir = containerDirectory
         let ingestionProvider = DaemonQueueIngestionProvider(
             containerDirectory: dir,

--- a/Tests/ExtractorPackageToolTests/ReviewedExtractorPackageTests.swift
+++ b/Tests/ExtractorPackageToolTests/ReviewedExtractorPackageTests.swift
@@ -108,7 +108,7 @@ struct ReviewedExtractorPackageTests {
         // The exact reviewed identity is pinned byte-for-byte; a regenerated
         // package whose digest changed fails this gate with the new value.
         #expect(output.packageDigest
-            == "8b083ec85664e9d0c1a2afe8b96beee100660c1882f6d7c75d627da918f6caa6")
+            == "14ea800bd0fd525a925f5bc47ce4b4cf5b3b6d31892edfea20e0cb8d3a5621af")
     }
 
     /// The registered source URL never appears in the committed package
@@ -242,7 +242,7 @@ struct ReviewedExtractorPackageTests {
         // The exact reviewed identity is pinned byte-for-byte; a regenerated
         // package whose digest changed fails this gate with the new value.
         #expect(output.packageDigest
-            == "8f87ff4a0c8c5fac1d5ff19c6d1dff6a816a27c081fb106de3bc6c92b8c7e1a1")
+            == "23e987d6ee3207ff89fb506a23c5ccef8e2693410dd14bc7f8e47e4f8acd7679")
     }
 
     /// The reviewed YouTube package never claims model download: it fetches

--- a/Tests/WikiFSTests/ExtractorDirectoryAdmissionTests.swift
+++ b/Tests/WikiFSTests/ExtractorDirectoryAdmissionTests.swift
@@ -172,10 +172,16 @@ struct ExtractorDirectoryAdmissionTests {
         #expect(try mode(target) == 0o700)
         #expect(try mode(target.appendingPathComponent("bin")) == 0o700)
         #expect(try mode(target.appendingPathComponent("bin/extractor")) == 0o500)
-        #expect(throws: ExtractorDirectoryAdmissionError.preparationFailed) {
+        do {
             _ = try ExtractorDirectoryValidator.materializeOperationPackage(
                 from: admitted,
                 into: target)
+            Issue.record("expected preparationFailed")
+        } catch let error as ExtractorDirectoryAdmissionError {
+            guard case .preparationFailed = error else {
+                Issue.record("expected .preparationFailed, got \(error)")
+                return
+            }
         }
     }
 
@@ -186,8 +192,14 @@ struct ExtractorDirectoryAdmissionTests {
         let redirect = uniqueURL("redirect").resolvingSymlinksInPath()
         try FileManager.default.createDirectory(at: redirect, withIntermediateDirectories: true)
         try FileManager.default.createSymbolicLink(at: layout.stagingRoot, withDestinationURL: redirect)
-        #expect(throws: ExtractorDirectoryAdmissionError.preparationFailed) {
+        do {
             _ = try ExtractorDirectoryValidator.admit(source: fixture.root, layout: layout)
+            Issue.record("expected preparationFailed")
+        } catch let error as ExtractorDirectoryAdmissionError {
+            guard case .preparationFailed = error else {
+                Issue.record("expected .preparationFailed, got \(error)")
+                return
+            }
         }
     }
 
@@ -222,7 +234,7 @@ struct ExtractorDirectoryAdmissionTests {
                 at: layout.stagingRoot,
                 includingPropertiesForKeys: nil)
             guard let destination = entries.first else {
-                throw ExtractorDirectoryAdmissionError.preparationFailed
+                throw ExtractorDirectoryAdmissionError.preparationFailure("injected staging failure")
             }
             let parked = destination.appendingPathExtension("parked")
             try FileManager.default.moveItem(at: destination, to: parked)

--- a/Tests/WikiFSTests/ExtractorPackageStoreTests.swift
+++ b/Tests/WikiFSTests/ExtractorPackageStoreTests.swift
@@ -242,8 +242,14 @@ struct ExtractorPackageStoreTests {
             at: layout.stagingRoot.appendingPathComponent("attacker"),
             withDestinationURL: outside)
 
-        await #expect(throws: ExtractorDirectoryAdmissionError.preparationFailed) {
-            try await writer.recover()
+        do {
+            _ = try await writer.recover()
+            Issue.record("expected preparationFailed")
+        } catch let error as ExtractorDirectoryAdmissionError {
+            guard case .preparationFailed = error else {
+                Issue.record("expected .preparationFailed, got \(error)")
+                return
+            }
         }
         #expect(try Data(contentsOf: sentinel) == Data("retain".utf8))
     }

--- a/Tests/WikiFSTests/ExtractorPackageStoreTests.swift
+++ b/Tests/WikiFSTests/ExtractorPackageStoreTests.swift
@@ -334,6 +334,30 @@ struct ExtractorPackageStoreTests {
         #expect(FileManager.default.fileExists(atPath: appSentinel.path))
     }
 
+    /// A killed operation leaves behind its admission-normalized snapshot:
+    /// directories at 0500 with 0400 files. Stale-session cleanup must chmod
+    /// through those modes — the exact failure that dead-ended daemon-side
+    /// transcriptions after the first timeout.
+    @Test func cleanupRemovesReadOnlyAdmissionTrees() throws {
+        let session = ExtractorStagingID(rawValue: "current")!
+        let layout = try makeLayout(role: .daemon, processSessionID: session)
+        let stale = layout.operationsRoot
+            .appendingPathComponent("daemon/999999-stale", isDirectory: true)
+        let nested = stale.appendingPathComponent("pkg/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        let entryPath = nested.appendingPathComponent("entry")
+        try Data("x".utf8).write(to: entryPath)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o400], ofItemAtPath: entryPath.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: nested.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: stale.path)
+
+        try ExtractorDirectoryValidator.cleanupOperationSessions(
+            layout: layout,
+            scope: .staleSessions)
+        #expect(FileManager.default.fileExists(atPath: stale.path) == false)
+    }
+
     @Test func concurrentReadersSeeOnlyCompleteGenerations() async throws {
         let layout = try makeLayout()
         let writer = try ExtractorPackageCatalogWriter.testing(layout: layout)

--- a/Tests/WikiFSTests/ManagedExtractorProcessExecutorTests.swift
+++ b/Tests/WikiFSTests/ManagedExtractorProcessExecutorTests.swift
@@ -160,6 +160,28 @@ struct ManagedExtractorProcessExecutorTests {
         #expect(try String(contentsOf: fixture.outputURL, encoding: .utf8) == "# Fixture\n")
     }
 
+    /// The package contract makes the terminal frame the operation's
+    /// completion. A wrapper process that outlives the package — the
+    /// observed `uv run` hang — must be killed by the completion hook, not
+    /// run the operation to its timeout.
+    @Test func terminalFrameCompletesALingeringWrapper() async throws {
+        let fixture = try Fixture(mode: "linger", maximumDurationMilliseconds: 30_000)
+        defer { fixture.cleanup() }
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let result = try await ManagedExtractorProcessExecutor().execute(fixture.operation)
+        let elapsed = clock.now - start
+
+        #expect(try String(contentsOf: fixture.outputURL, encoding: .utf8) == "# Fixture\n")
+        // The completion kill ends the run in well under the 30 s deadline.
+        #expect(elapsed < .seconds(20))
+        guard case .signaled = result.terminationCause else {
+            Issue.record("expected .signaled, got \(result.terminationCause)")
+            return
+        }
+    }
+
     /// Package payload rejects symlinks in every launch mode.
     @Test func symlinkedPackageEntryIsRejected() async throws {
         let fixture = try Fixture(
@@ -211,13 +233,17 @@ struct ManagedExtractorProcessExecutorTests {
     // MARK: - Process behavior
 
     @Test func malformedProtocolAndNonzeroExitAreTyped() async throws {
-        let malformed = try Fixture(mode: "malformed")
+        // The typed-error assertions are event-driven, not deadline-driven;
+        // the generous limit only keeps process spawn from timing out on a
+        // loaded runner (the default 5 s was exceeded under full-suite
+        // parallel load).
+        let malformed = try Fixture(mode: "malformed", maximumDurationMilliseconds: 30_000)
         defer { malformed.cleanup() }
         await #expect(throws: ManagedExtractorProcessError.malformedProtocol) {
             _ = try await ManagedExtractorProcessExecutor().execute(malformed.operation)
         }
 
-        let nonzero = try Fixture(mode: "nonzero")
+        let nonzero = try Fixture(mode: "nonzero", maximumDurationMilliseconds: 30_000)
         defer { nonzero.cleanup() }
         await #expect(throws: ManagedExtractorProcessError.processTermination(.exited(code: 17))) {
             _ = try await ManagedExtractorProcessExecutor().execute(nonzero.operation)

--- a/Tests/WikiFSTests/ProcessExtractorCredentialTests.swift
+++ b/Tests/WikiFSTests/ProcessExtractorCredentialTests.swift
@@ -554,3 +554,35 @@ enum SelfTestSupport {
             [.posixPermissions: Int(mode)], ofItemAtPath: url.path)
     }
 }
+
+@Suite(.serialized)
+struct SharedCacheRootNormalizationTests {
+    @Test func normalizeTightensPreexistingSharedCacheRoot() throws {
+        // A shared cache root seeded by a manual `uv` run is world-traversable
+        // (0755). `createDirectory(attributes:)` does not fix an existing
+        // directory, so preparation must tighten it in place. Ownership is the
+        // boundary; seeded cache content must survive.
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sdw-normalize-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: root.path)
+        let seeded = root.appendingPathComponent("uv-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: seeded, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try ProcessExtractorProvider.normalizeOwnerPrivateDirectory(root)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: root.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.uint16Value == 0o700)
+        #expect(FileManager.default.fileExists(atPath: seeded.path))
+    }
+
+    @Test func normalizeRejectsForeignOwnedDirectory() throws {
+        // A root this UID does not own must fail closed without a chmod.
+        // /private/tmp is root-owned and world-writable on macOS.
+        #expect(throws: ExtractorDirectoryAdmissionError.self) {
+            try ProcessExtractorProvider.normalizeOwnerPrivateDirectory(
+                URL(fileURLWithPath: "/private/tmp", isDirectory: true))
+        }
+    }
+}

--- a/Tests/WikiFSTests/QueueExtractionTests.swift
+++ b/Tests/WikiFSTests/QueueExtractionTests.swift
@@ -137,6 +137,32 @@ struct QueueExtractionTests {
         store.close()
     }
 
+    @Test func testResolveThrowFailsInsteadOfStayingQueued() async throws {
+        let store = try QueueStore(databaseURL: tempDatabaseURL())
+
+        // Any other resolve throw (bad legacy identity data, an extractor
+        // admission failure, a lost store) is a real per-item fault.
+        // providerID(for:) hands the item the neutral capacity bucket so
+        // dispatch claims it and the engine marks it failed with the error
+        // detail. It must never return to .queued silently.
+        let provider = FakeExtractionProvider(resolveResult: .admissionFailure)
+        let factory = QueueExtractionWorkerFactory(
+            provider: provider, emitProgress: { _, _ in })
+        let engine = QueueEngine(store: store, workerFactory: factory)
+        await engine.start()
+
+        let id = try await engine.enqueue(
+            QueueItemRequest(queue: .extraction, wikiID: WikiID(rawValue: "wiki1"), payload: makePayload()))
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+
+        let item = try store.getItem(id)
+        #expect(item?.state == .failed)
+        #expect(item?.error?.contains("preparationFailed") == true)
+        #expect(item?.error?.contains("Operation not permitted") == true)
+        store.close()
+    }
+
     // MARK: - AC.4: Readiness check
 
     @Test func testReadinessCheckMarksFailed() async throws {
@@ -421,6 +447,9 @@ private final class FakeExtractionProvider: QueueExtractionProvider, @unchecked 
         /// The typed fail-closed error for an explicit selection with no
         /// active registration.
         case unavailableSelection
+        /// A generic resolve throw, e.g. an extractor directory admission
+        /// failure with its bounded stage detail.
+        case admissionFailure
     }
 
     private let lock = OSAllocatedUnfairLock(initialState: State())
@@ -474,6 +503,8 @@ private final class FakeExtractionProvider: QueueExtractionProvider, @unchecked 
                 registrationID: ExtractorRegistrationID(validating: "main"))
             throw ExtractionServicesError.selectedExtractorUnavailable(
                 route: .canonicalPDF, reference: logical)
+        case .admissionFailure:
+            throw ExtractorDirectoryAdmissionError.preparationFailure(errno: 1, stage: "fchmod directory")
         }
     }
 

--- a/scripts/sync-extractor-packages.sh
+++ b/scripts/sync-extractor-packages.sh
@@ -474,7 +474,7 @@ PY
 # Reviewed package provenance
 
 - Package: org.selfdrivingwiki.podcast-transcript
-- Version: 1.0.0
+- Version: 1.0.1 (1.0.1: shared-runtime-cache capability for warm uv runs)
 - Source: tools/podcast-transcript/podcast-transcript in this repository
 - Entry point: bin/podcast-transcript-extractor, generated from the same source
 - Dependencies: the PEP 723 block of the entry point is copied from the script
@@ -501,7 +501,7 @@ path, script_digest, entry_digest, provenance_digest = sys.argv[1:5]
 manifest = {
     "manifestRevision": 1,
     "packageID": "org.selfdrivingwiki.podcast-transcript",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "displayName": "Podcast Transcript",
     "protocolRevision": 3,
     "entryPoint": "bin/podcast-transcript-extractor",
@@ -754,7 +754,7 @@ PY
 # Reviewed package provenance
 
 - Package: org.selfdrivingwiki.youtube-transcript
-- Version: 1.0.0
+- Version: 1.0.1 (1.0.1: shared-runtime-cache capability for warm uv runs)
 - Source: tools/youtube-transcript/youtube-transcript in this repository
 - Entry point: bin/youtube-transcript-extractor, generated from the same source
 - Dependencies: the PEP 723 block of the entry point is copied from the script
@@ -785,7 +785,7 @@ path, script_digest, entry_digest, provenance_digest = sys.argv[1:5]
 manifest = {
     "manifestRevision": 1,
     "packageID": "org.selfdrivingwiki.youtube-transcript",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "displayName": "YouTube Transcript",
     "protocolRevision": 3,
     "entryPoint": "bin/youtube-transcript-extractor",


### PR DESCRIPTION
## Bump transcript extractor packages to 1.0.1

Targets `main`. **Keep this PR open and unmerged** — the operator owns the merge decision.

### Why

The machine's durable extractor catalog reserved `youtube-transcript` and `podcast-transcript` at **1.0.0** with this morning's digests (`daf2ab7e…` / `8bfc2f5c…`). Today's rebuilt package bytes carry the same package ID and version with **different digests** — which the reviewed-admission supply-chain guard treats as a reservation conflict. Result: the machine kept activating the stale 1.0.0 bytes (no shared-runtime-cache capability, 300 s limit, `sys.exit` entry point that can hang at shutdown), and every transcription timed out at the deadline no matter how many times the app was rebuilt.

Bumping to **1.0.1** publishes clean new revisions the reconciler can admit and activate, carrying the shared-runtime-cache capability (warm uv runtime) and the hard-exit entry point.

### Contents

- `youtube-transcript` 1.0.1 — digest `23e987d6…acd7679`
- `podcast-transcript` 1.0.1 — digest `14ea800b…5621af`
- Golden constants and reviewed-package tests updated to match.

### Verification

- `make build`, full `make test` (4189 tests, 457 suites): pass
- `scripts/sync-extractor-packages.sh --check`: clean
- `extractor-package-tool validate` on both packages: pass with the new digests
- Python gates (ruff/pyright/pytest) on the source scripts: clean, 143 tests


### Also in this PR

- **On-demand wiki store preparation (daemon):** after a relaunch the daemon could claim a queued extraction for a wiki whose store it had not prepared, log "no store for wikiID", and starve the item between queued and claim forever. The provider now calls `WikiDaemon.openStore(wikiID:)` on demand — booting the per-wiki profile — before giving up.
- **Loud persistence failures:** if the wiki store disappears after the work completes, the daemon persistence methods now throw a typed store-unavailable error instead of silently marking the item completed with nothing written.
- **Stale-operation cleanup hardening:** `removeStoreTree` (daemon startup cleanup) now chmods directories owner-writable before unlinking and accepts uv-created hardlinks and symlinks — the exact content shape that previously made every startup cleanup fail with `preparationFailed`.
- **App-close cleanup:** the app removes its own session's extractor operation directories on quit (logged, non-fatal on failure); the daemon reclaims crash-left stale sessions at startup.
- **Live status:** queued/running extraction items show a ticking elapsed time in Activity, and every progress line is stamped with its elapsed time (`[mm:ss]`), including timeout failures, which now report elapsed vs limit, the last progress line, and the silence length.
- **Loud resolve failures (87ea6301):** extractor admission errors used to collapse into a detail-free `preparationFailed`, and the worker factory swallowed any resolve throw by returning the item to `.queued` forever — the claimed-failed-requeued starvation loop. `preparationFailed` now carries a bounded stage + errno detail (never paths, URLs, or upstream text), and a resolve throw routes the item through the neutral capacity bucket so the engine fails it with the error text. Regression test: `QueueExtractionTests.testResolveThrowFailsInsteadOfStayingQueued`.
- **Shared cache root self-heal (69c38d5b):** the first visible failure text — `preparationFailed("shared cache directory verification failed")` — exposed the real blocker: `createDirectory(attributes:)` applies 0700 only when it creates the directory, so a shared runtime/model cache root seeded by a manual `uv` run (which creates world-traversable directories) kept mode 0755 forever, and the verify-only check refused every operation. Preparation now normalizes first — open no-follow, confirm the root is a directory owned by this UID (the same ownership boundary as `removeStoreTree`), `fchmod` it to 0700, and re-verify through the opened descriptor. Tests: `SharedCacheRootNormalizationTests`.
- **Terminal frame completes the operation (abd1c94e):** the original timeout's true root cause, finally exposed end to end: the package finished in seconds (output written, terminal frame sent), but `uv run` lingered forever after the child exited — pipes held, shared cache lock held, one orphan alive 12 hours. The host now treats a valid terminal frame as the operation's completion (per the extractor protocol contract), terminates the wrapper's process group, and accepts the post-completion kill as success. Regression test: `ManagedExtractorProcessExecutorTests.terminalFrameCompletesALingeringWrapper`. Follow-up for bun-launched packages: #1217.

Verified end to end after these fixes: transcription completes in seconds on the warm shared cache and writes installed-package provenance.

