### PR TITLE
fix(links): render full source title for pipe-containing wikilinks

### DIFF
--- a/Sources/WikiFS/Reader/DocumentEmbedResolver.swift
+++ b/Sources/WikiFS/Reader/DocumentEmbedResolver.swift
@@ -77,7 +77,7 @@ struct DocumentEmbedResolver: Sendable {
     func resolveWikiLink(_ link: WikiMarkdownSyntaxNode.Link) -> ResolvedDocumentLink {
         let canonicalID = link.target.canonicalID
         let currentName: String?
-        let resolved: Bool
+        var resolved: Bool
 
         switch link.target.namespace {
         case .page:
@@ -94,11 +94,7 @@ struct DocumentEmbedResolver: Sendable {
                 resolved = currentName != nil
             } else {
                 currentName = nil
-                let literal = link.target.literal
-                resolved = inputs.sourceLinkNames.contains(literal.lowercased())
-                    || inputs.uniqueSourceLooseKeys.contains(WikiNameRules.looseMatchKey(literal))
-                    || WikiLinkResolver.legacySourceProjectionID(from: literal)
-                        .map { inputs.sourceNamesByID[$0] != nil } == true
+                resolved = isKnownName(link.target.literal, namespace: .source)
             }
         case .chat:
             if let canonicalID {
@@ -108,6 +104,22 @@ struct DocumentEmbedResolver: Sendable {
                 currentName = nil
                 resolved = inputs.chatIDByName[link.target.literal.lowercased()] != nil
             }
+        }
+
+        // Issue #1225 (typed-render mirror of the #619 fallbacks): when the
+        // span scanner split a NAME-authored link at an unquoted `|` that was
+        // really part of the display name, the truncated literal misses every
+        // existence tier and the link would render as inert `wiki://missing`
+        // with the trailing alias fragment as its label. Reconstruct
+        // `bare | alias` and accept the first reading whose base names a real
+        // entity — then the full display name becomes both the label and the
+        // navigation title. Only runs as a FALLBACK: a link whose left-hand
+        // target resolved (a genuine alias) is untouched, and so is any
+        // canonical ULID-backed link (already resolved by id above).
+        var reconstructedSplit: WikiLinkResolver.Split?
+        if !resolved, canonicalID == nil, let alias = link.alias {
+            reconstructedSplit = pipeReconstructedSplit(for: link, alias: alias)
+            resolved = reconstructedSplit != nil
         }
 
         let pinnedSourceVersion: SourceMarkdownVersionID? = {
@@ -122,14 +134,56 @@ struct DocumentEmbedResolver: Sendable {
             return chain[ordinal - 1]
         }()
 
+        // The reconstruction's base (the full pipe-containing name) and its
+        // peeled fragment win over the truncated literal / alias-carried
+        // anchor; `currentName` still wins for canonical id-backed links.
         return ResolvedDocumentLink(
             namespace: link.target.namespace,
-            title: currentName ?? link.target.literal,
+            title: currentName ?? reconstructedSplit?.base ?? link.target.literal,
             canonicalID: canonicalID,
-            fragment: link.target.fragment,
+            fragment: reconstructedSplit?.fragment ?? link.target.fragment,
             pinnedSourceVersion: pinnedSourceVersion,
-            displayText: currentName ?? link.displayText,
+            displayText: currentName ?? reconstructedSplit?.base ?? link.displayText,
             isResolved: inputs.assumeLinksResolved || resolved)
+    }
+
+    /// Issue #1225: the namespace-aware existence probe shared by the direct
+    /// name resolution and the pipe-reconstruction fallback. Same tiers the
+    /// source branch used inline — exact lowercased name, unique loose key,
+    /// legacy File Provider projection id — because the reconstructed whole
+    /// name must clear exactly the bar the truncated literal failed.
+    private func isKnownName(_ name: String, namespace: WikiMarkdownTargetNamespace) -> Bool {
+        switch namespace {
+        case .page: return inputs.pageIDByName[name.lowercased()] != nil
+        case .chat: return inputs.chatIDByName[name.lowercased()] != nil
+        case .source:
+            return inputs.sourceLinkNames.contains(name.lowercased())
+                || inputs.uniqueSourceLooseKeys.contains(WikiNameRules.looseMatchKey(name))
+                || WikiLinkResolver.legacySourceProjectionID(from: name)
+                    .map { inputs.sourceNamesByID[$0] != nil } == true
+        }
+    }
+
+    /// Try each `WikiLinkResolver.pipeReconstructionCandidates` reading
+    /// (spaced, then unspaced) through `resolvedSplit` — whose `#` handling
+    /// peels an alias-carried `#"quote"` anchor off the reconstructed name.
+    /// Returns the first reading whose base names a real entity, or nil when
+    /// none does (the `|` was a genuine alias separator after all).
+    private func pipeReconstructedSplit(
+        for link: WikiMarkdownSyntaxNode.Link,
+        alias: String
+    ) -> WikiLinkResolver.Split? {
+        for candidate in WikiLinkResolver.pipeReconstructionCandidates(
+            bare: link.target.literal,
+            alias: alias,
+            fragment: link.target.fragment) {
+            if let split = WikiLinkResolver.resolvedSplit(
+                of: candidate,
+                isKnown: { self.isKnownName($0, namespace: link.target.namespace) }) {
+                return split
+            }
+        }
+        return nil
     }
 
     func resolveWikiEmbed(

--- a/Sources/WikiFSLinks/WikiLinkMarkdown.swift
+++ b/Sources/WikiFSLinks/WikiLinkMarkdown.swift
@@ -245,18 +245,19 @@ public enum WikiLinkMarkdown {
             var resolvedViaReconstruction = false
             let reconSplit: WikiLinkResolver.Split?
             if split == nil, let alias = fixed.alias {
-                let normalizedAlias = collapseWhitespace(alias)
-                if normalizedAlias.isEmpty {
-                    reconSplit = nil
-                } else {
-                    let reconstructedRaw = fragment.map { "\(bareTarget) | \(normalizedAlias)#\($0)" }
-                        ?? "\(bareTarget) | \(normalizedAlias)"
-                    reconSplit = WikiLinkResolver.resolvedSplit(
-                        of: reconstructedRaw,
-                        isKnown: { isResolved($0, kind) }
-                    )
-                    resolvedViaReconstruction = reconSplit != nil
-                }
+                // Spaced candidate first (the YouTube-title convention), then
+                // the unspaced form — the shared #619/#1225 candidate order.
+                reconSplit = WikiLinkResolver.pipeReconstructionCandidates(
+                    bare: bareTarget,
+                    alias: alias,
+                    fragment: fragment)
+                    .compactMap { candidate in
+                        WikiLinkResolver.resolvedSplit(
+                            of: candidate,
+                            isKnown: { isResolved($0, kind) })
+                    }
+                    .first
+                resolvedViaReconstruction = reconSplit != nil
             } else {
                 reconSplit = nil
             }

--- a/Sources/WikiFSLinks/WikiLinkResolver.swift
+++ b/Sources/WikiFSLinks/WikiLinkResolver.swift
@@ -77,6 +77,37 @@ public enum WikiLinkResolver {
         return nil
     }
 
+    /// Whole-name candidates for a span the scanner split at an unquoted `|`
+    /// (issues #619, #1225). A display name can legitimately contain a literal
+    /// pipe — YouTube titles the app itself ingests, doc-set names — so a
+    /// `target|alias` split may have truncated the real name at the pipe. Each
+    /// consumer that KNOWS the namespace tries these candidates (in order)
+    /// through `resolvedSplit` before accepting the alias reading:
+    ///
+    ///   * `"<bare> | <alias>"` — the spaced convention (YouTube titles);
+    ///   * `"<bare>|<alias>"`  — the unspaced form.
+    ///
+    /// The alias is whitespace-normalized first, so the reconstructed name is
+    /// directly comparable with store `display_name` values. An empty alias
+    /// yields no candidates (nothing to reconstruct). `fragment` (a target-
+    /// carried `#…` anchor, verbatim, no leading `#`) is re-attached to each
+    /// candidate so `resolvedSplit`'s `#` handling can peel it again; an alias-
+    /// carried `#"quote"` anchor needs no help — it survives inside the
+    /// candidate text and `candidateSplits` splits it off.
+    public static func pipeReconstructionCandidates(
+        bare: String,
+        alias: String,
+        fragment: String? = nil
+    ) -> [String] {
+        let normalizedAlias = WikiText.normalized(alias)
+        guard !normalizedAlias.isEmpty else { return [] }
+        let suffix = fragment.map { "#\($0)" } ?? ""
+        return [
+            "\(bare) | \(normalizedAlias)\(suffix)",
+            "\(bare)|\(normalizedAlias)\(suffix)",
+        ]
+    }
+
     private static let legacySourceProjectionSeparator: Character = "–"
     private static let legacySourceMarkdownExtension = ".md"
 }

--- a/Sources/WikiFSLinks/WikiLinkRewriter.swift
+++ b/Sources/WikiFSLinks/WikiLinkRewriter.swift
@@ -79,40 +79,45 @@ public enum WikiLinkRewriter {
             // auto-alias is the whole reconstructed name — mirroring the
             // no-alias branch so the user's intended display text survives.
             //
-            // Scoped to the no-fragment / no-pin case (the issue's repro) to
-            // avoid fragment-in-alias ambiguity; `#`-in-name already resolves
-            // via `candidateSplits` below. If neither candidate resolves, fall
-            // through to today's behavior (`|` was a real alias separator).
+            // Issue #1225: each candidate is walked through `candidateSplits`,
+            // so an alias-carried quote anchor peels off and the link promotes
+            // to `[[source:<ULID>#"quote"|<full name>]]` on its next save —
+            // the same reading the render seams (DocumentEmbedResolver /
+            // WikiLinkMarkdown.linkified) accept, and the canonical form the
+            // scanner parses without ambiguity. A literal `#`-containing name
+            // still wins whole (candidateSplits tries the whole string first).
+            // Still scoped to the no-target-fragment / no-pin case; when no
+            // reading resolves, fall through (`|` was a real alias separator).
             if rawAlias != nil, fragment == nil, pin == nil,
                let rawAliasValue = fixed.alias {
-                // Try spaced first (the YouTube-title convention), then the
-                // unspaced form — both hit Pass 1's exact match. The first
-                // resolver hit determines which reconstruction we serialize
-                // as the auto-alias, so what the user sees rendered matches
-                // the store's display_name spelling. Shared with the render
-                // seams (WikiLinkMarkdown / DocumentEmbedResolver); the helper
+                // Spaced candidate first (the YouTube-title convention), then
+                // the unspaced form — shared with the render seams; the helper
                 // normalizes the alias and yields no candidates for an empty
                 // one (nothing to reconstruct).
                 let candidates = WikiLinkResolver.pipeReconstructionCandidates(
                     bare: bareTarget, alias: rawAliasValue)
-                var wholeID: String? = nil
-                var wholeName: String? = nil
-                for candidate in candidates {
-                    let id: String?
-                    switch kind {
-                    case .source: id = try resolveSource(candidate)?.rawValue
-                    case .chat:   id = try resolveChat(candidate)?.rawValue
-                    case .page:   id = try resolvePage(candidate)?.rawValue
-                    }
-                    if let id {
-                        wholeID = id
-                        wholeName = candidate
-                        break
+                var resolved: (id: String, name: String, fragment: String?)? = nil
+                candidateLoop: for candidate in candidates {
+                    for split in WikiLinkResolver.candidateSplits(of: candidate) {
+                        let id: String?
+                        switch kind {
+                        case .source: id = try resolveSource(split.base)?.rawValue
+                        case .chat:   id = try resolveChat(split.base)?.rawValue
+                        case .page:   id = try resolvePage(split.base)?.rawValue
+                        }
+                        if let id {
+                            resolved = (id, split.base, split.fragment)
+                            break candidateLoop
+                        }
                     }
                 }
-                if let resolvedID = wholeID, let resolvedName = wholeName {
-                    let prefix = kind.linkPrefix
-                    let canonicalTarget = prefix + resolvedID
+                if let (resolvedID, resolvedName, resolvedFragment) = resolved {
+                    // The anchor serializes into the TARGET (`…ULID#"quote"`)
+                    // and the full name becomes the auto-alias — the canonical
+                    // ordering `preserveQuoteFragment` establishes, and the
+                    // ordering the typed scanner re-parses unambiguously.
+                    let canonicalTarget = kind.linkPrefix + resolvedID
+                        + (resolvedFragment.map { "#\($0)" } ?? "")
                     let replacement = "[[\(canonicalTarget)|\(resolvedName)]]"
                     let mutable = NSMutableString(string: result)
                     mutable.replaceCharacters(in: fullRange, with: replacement)

--- a/Sources/WikiFSLinks/WikiLinkRewriter.swift
+++ b/Sources/WikiFSLinks/WikiLinkRewriter.swift
@@ -85,42 +85,40 @@ public enum WikiLinkRewriter {
             // through to today's behavior (`|` was a real alias separator).
             if rawAlias != nil, fragment == nil, pin == nil,
                let rawAliasValue = fixed.alias {
-                let normalizedAlias = WikiText.normalized(rawAliasValue)
-                if !normalizedAlias.isEmpty {
-                    // Try spaced first (the YouTube-title convention), then the
-                    // unspaced form — both hit Pass 1's exact match. The first
-                    // resolver hit determines which reconstruction we serialize
-                    // as the auto-alias, so what the user sees rendered matches
-                    // the store's display_name spelling.
-                    let candidates = [
-                        "\(bareTarget) | \(normalizedAlias)",
-                        "\(bareTarget)|\(normalizedAlias)",
-                    ]
-                    var wholeID: String? = nil
-                    var wholeName: String? = nil
-                    for candidate in candidates {
-                        let id: String?
-                        switch kind {
-                        case .source: id = try resolveSource(candidate)?.rawValue
-                        case .chat:   id = try resolveChat(candidate)?.rawValue
-                        case .page:   id = try resolvePage(candidate)?.rawValue
-                        }
-                        if let id {
-                            wholeID = id
-                            wholeName = candidate
-                            break
-                        }
+                // Try spaced first (the YouTube-title convention), then the
+                // unspaced form — both hit Pass 1's exact match. The first
+                // resolver hit determines which reconstruction we serialize
+                // as the auto-alias, so what the user sees rendered matches
+                // the store's display_name spelling. Shared with the render
+                // seams (WikiLinkMarkdown / DocumentEmbedResolver); the helper
+                // normalizes the alias and yields no candidates for an empty
+                // one (nothing to reconstruct).
+                let candidates = WikiLinkResolver.pipeReconstructionCandidates(
+                    bare: bareTarget, alias: rawAliasValue)
+                var wholeID: String? = nil
+                var wholeName: String? = nil
+                for candidate in candidates {
+                    let id: String?
+                    switch kind {
+                    case .source: id = try resolveSource(candidate)?.rawValue
+                    case .chat:   id = try resolveChat(candidate)?.rawValue
+                    case .page:   id = try resolvePage(candidate)?.rawValue
                     }
-                    if let resolvedID = wholeID, let resolvedName = wholeName {
-                        let prefix = kind.linkPrefix
-                        let canonicalTarget = prefix + resolvedID
-                        let replacement = "[[\(canonicalTarget)|\(resolvedName)]]"
-                        let mutable = NSMutableString(string: result)
-                        mutable.replaceCharacters(in: fullRange, with: replacement)
-                        result = mutable as String
-                        changed = true
-                        continue
+                    if let id {
+                        wholeID = id
+                        wholeName = candidate
+                        break
                     }
+                }
+                if let resolvedID = wholeID, let resolvedName = wholeName {
+                    let prefix = kind.linkPrefix
+                    let canonicalTarget = prefix + resolvedID
+                    let replacement = "[[\(canonicalTarget)|\(resolvedName)]]"
+                    let mutable = NSMutableString(string: result)
+                    mutable.replaceCharacters(in: fullRange, with: replacement)
+                    result = mutable as String
+                    changed = true
+                    continue
                 }
             }
 

--- a/Tests/WikiFSAppTests/DocumentEmbedResolverTests.swift
+++ b/Tests/WikiFSAppTests/DocumentEmbedResolverTests.swift
@@ -176,6 +176,163 @@ struct DocumentEmbedResolverTests {
         #expect(!resolver.resolveWikiLink(link).isResolved)
     }
 
+    // MARK: - Pipe inside the NAME (issue #1225 — typed render path)
+    //
+    // The production reader renders through this resolver, not through
+    // `WikiLinkMarkdown.linkified`. A name-authored link to a pipe-containing
+    // title splits at the unquoted `|` (span scan), so the truncated literal
+    // used to miss every existence tier and the link rendered as inert
+    // `wiki://missing` with only the post-pipe alias fragment as its label.
+    // The reconstruction fallback (mirror of #619's seams) heals exactly that
+    // case — and only that case.
+
+    private static let pipeTitle = "What is Malleable Software Now | Bryan Min (02-27-2026)"
+
+    @Test func pipeNameSourceLinkResolvesAndDisplaysFullName() throws {
+        let link = try sourceLink("[[source:\(Self.pipeTitle)]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceLinkNames: [Self.pipeTitle.lowercased()]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.namespace == .source)
+        // AC: the label AND the navigation title are the complete title.
+        #expect(resolved.displayText == Self.pipeTitle)
+        #expect(resolved.title == Self.pipeTitle)
+        #expect(resolved.fragment == nil)
+    }
+
+    @Test func pipeNameSourceLinkWithQuoteFragmentResolves() throws {
+        // The exact stored shape (Malleable Software wiki, source
+        // 01KZ5FS7A76RDDXFQFC5DKJ1SJ): the `#"quote"` anchor rides in the
+        // alias slice; reconstruction peels it back off the full name.
+        let link = try sourceLink(
+            "[[source:\(Self.pipeTitle)#\"a quoted passage\"]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceLinkNames: [Self.pipeTitle.lowercased()]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.displayText == Self.pipeTitle)
+        #expect(resolved.fragment == "\"a quoted passage\"")
+    }
+
+    @Test func unspacedPipeNameSourceLinkResolves() throws {
+        // The unspaced `A|B` spelling is the second reconstruction candidate.
+        let link = try sourceLink("[[source:Flex Tier|Neuralwatt Cloud]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceLinkNames: ["flex tier|neuralwatt cloud"]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.displayText == "Flex Tier|Neuralwatt Cloud")
+    }
+
+    @Test func pipeNameLooseKeySourceLinkResolves() throws {
+        // The lenient (unique loose key) tier also applies to the
+        // reconstructed whole name, mirroring the truncated-literal tiers.
+        let link = try sourceLink("[[source:My-Paper | Extended Edition]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            uniqueSourceLooseKeys: [
+                WikiNameRules.looseMatchKey("My-Paper | Extended Edition (2026)"),
+            ]))
+
+        #expect(resolver.resolveWikiLink(link).isResolved)
+    }
+
+    @Test func pipeNamePageLinkResolves() throws {
+        let link = try wikiLink(
+            "[[But what is cross-entropy? | Compression is Intelligence Part 2]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            pageIDByName: [
+                "but what is cross-entropy? | compression is intelligence part 2": pageID,
+            ]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.namespace == .page)
+        #expect(resolved.displayText
+                == "But what is cross-entropy? | Compression is Intelligence Part 2")
+    }
+
+    @Test func pipeNameChatLinkResolves() throws {
+        let link = try wikiLink("[[chat:Standup - 2026-01-15 | Project Alpha]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            chatIDByName: [
+                "standup - 2026-01-15 | project alpha":
+                    ChatID(rawValue: "01J00000000000000000000009"),
+            ]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.namespace == .chat)
+        #expect(resolved.displayText == "Standup - 2026-01-15 | Project Alpha")
+    }
+
+    @Test func canonicalULIDSourceLinkDisplaysCurrentPipeTitle() throws {
+        // AC (canonical ULID-backed): no alias at all — the live store name
+        // (pipe included) is the label via the id→name map.
+        let link = try sourceLink("[[source:\(sourceID.rawValue)]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceNamesByID: [sourceID: Self.pipeTitle]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.canonicalID == sourceID.rawValue)
+        #expect(resolved.displayText == Self.pipeTitle)
+    }
+
+    @Test func canonicalULIDSourceLinkHealsStalePipeAlias() throws {
+        // AC (canonical ULID-backed): a stale pre-#619 alias that lost the
+        // head of the title self-heals to the current store name at render.
+        let link = try sourceLink(
+            "[[source:\(sourceID.rawValue)|Bryan Min (02-27-2026)]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceNamesByID: [sourceID: Self.pipeTitle]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.displayText == Self.pipeTitle)
+    }
+
+    @Test func canonicalULIDSourceLinkWithPipeInAliasKeepsWholeAlias() throws {
+        // The canonical auto-alias form `[[source:<ULID>|<full title>]]`: the
+        // first pipe (after the ULID) is the separator, and the title's own
+        // pipe stays inside the alias — no reconstruction needed or wanted.
+        let link = try sourceLink("[[source:\(sourceID.rawValue)|\(Self.pipeTitle)]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceNamesByID: [sourceID: Self.pipeTitle]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.displayText == Self.pipeTitle)
+    }
+
+    @Test func explicitAliasWinsWhenLeftHandResolves() throws {
+        // AC: an explicit target|alias keeps the alias when the left-hand
+        // target resolves on its own — reconstruction never runs.
+        let link = try sourceLink("[[source:Known|Bryan Min (02-27-2026)]]")
+        let resolver = DocumentEmbedResolver(inputs: .init(
+            sourceLinkNames: ["known"]))
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(resolved.isResolved)
+        #expect(resolved.displayText == "Bryan Min (02-27-2026)")
+    }
+
+    @Test func pipeNameUnresolvableFallsBackToAliasDisplay() throws {
+        // AC: when neither the truncated target nor any reconstruction
+        // resolves, the link stays inert (`wiki://missing` upstream) and
+        // displays the alias — the pre-#619 behavior is the fallback.
+        let link = try sourceLink("[[source:Ghost | Pipeline]]")
+        let resolver = DocumentEmbedResolver(inputs: .init())
+
+        let resolved = resolver.resolveWikiLink(link)
+        #expect(!resolved.isResolved)
+        #expect(resolved.displayText == "Pipeline")
+        #expect(resolved.title == "Ghost")
+    }
+
     @Test func repeatedImageRendererCandidatesUseUniqueActionPlansWithoutDynamicHosts() throws {
         let markdown = "![[source:image.png|First]] and ![[source:image.png|Second]]"
         let prepared = ReaderMarkdown.preparedDocument(markdown)
@@ -309,6 +466,12 @@ struct DocumentEmbedResolverTests {
             throw TestError.expectedLink
         }
         return link
+    }
+
+    /// A link node of any namespace (page/chat links included) — `sourceLink`
+    /// asserts nothing about namespace, but the name reads better for pages.
+    private func wikiLink(_ markdown: String) throws -> WikiMarkdownSyntaxNode.Link {
+        try sourceLink(markdown)
     }
 
     private func sourceResolution(mime: String) -> DocumentSourceResolution {

--- a/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/WikiFSAppTests/MarkdownHTMLRendererTests.swift
@@ -81,6 +81,71 @@ struct MarkdownHTMLRendererTests {
         #expect(html.components(separatedBy: "wiki://source").count - 1 >= 4)
     }
 
+    // MARK: - Pipe inside the NAME (issue #1225 — full render + navigation)
+
+    @Test("#1225 pipe-containing source title renders the full label and a navigable URL")
+    func pipeSourceTitleRendersFullNameAndNavigableURL() throws {
+        // The exact stored shape from the Malleable Software wiki: a
+        // name-authored link to the pipe-titled source, with a quote anchor
+        // riding in the alias slice. Through the production pipeline —
+        // prepare → typed resolve → HTML — the label must be the complete
+        // title and the URL must navigate (wiki://source, not wiki://missing).
+        let pipeTitle = "What is Malleable Software Now | Bryan Min (02-27-2026)"
+        let markdown = "Watch the talk — see [[source:\(pipeTitle)#\"a quoted passage\"]]."
+
+        let prepared = ReaderMarkdown.preparedDocument(markdown)
+        let projection = DocumentEmbedResolver(inputs: .init(
+            sourceLinkNames: [pipeTitle.lowercased()]))
+            .projection(for: prepared, resolveEmbeds: false)
+        let html = MarkdownHTMLRenderer.render(prepared, projection: projection, options: .disabled)
+
+        #expect(html.contains(">\(pipeTitle)</a>"),
+                "Label must be the full title. HTML: \(html)")
+        #expect(!html.contains("wiki://missing"), "HTML: \(html)")
+
+        // Navigation round-trip: the URL the renderer emitted carries the
+        // full display name and the quote anchor, and routes to the source.
+        let url = try #require(rendererActionURL(in: html))
+        #expect(WikiLinkMarkdown.resolvedKind(from: url) == .source)
+        #expect(WikiLinkMarkdown.target(from: url) == pipeTitle)
+        #expect(WikiLinkMarkdown.fragment(from: url) == "\"a quoted passage\"")
+        guard case .source(let title, let id, let fragment, let pin) = WikiReaderView.linkRoute(for: url) else {
+            Issue.record("Expected a source route. URL: \(url)")
+            return
+        }
+        #expect(title == pipeTitle)
+        #expect(id == nil) // name-authored link: no canonical id in the URL
+        #expect(fragment == "\"a quoted passage\"")
+        #expect(pin == nil)
+    }
+
+    @Test("#1225 canonical ULID source link with pipe title renders id-backed URL")
+    func canonicalULIDPipeTitleRendersIDBackedURL() throws {
+        // The canonical auto-alias form: `[[source:<ULID>|<full title>]]`.
+        // Renders via the id→name map (self-healing label) and routes by id.
+        let sourceID = SourceID(rawValue: "01KZ5FS7A76RDDXFQFC5DKJ1SJ")
+        let pipeTitle = "What is Malleable Software Now | Bryan Min (02-27-2026)"
+        let markdown = "See [[source:\(sourceID.rawValue)|\(pipeTitle)]]."
+
+        let prepared = ReaderMarkdown.preparedDocument(markdown)
+        let projection = DocumentEmbedResolver(inputs: .init(
+            sourceNamesByID: [sourceID: pipeTitle]))
+            .projection(for: prepared, resolveEmbeds: false)
+        let html = MarkdownHTMLRenderer.render(prepared, projection: projection, options: .disabled)
+
+        #expect(html.contains(">\(pipeTitle)</a>"),
+                "Label must be the full title. HTML: \(html)")
+
+        let url = try #require(rendererActionURL(in: html))
+        #expect(WikiLinkMarkdown.sourceID(from: url) == sourceID)
+        #expect(WikiLinkMarkdown.target(from: url) == pipeTitle)
+        guard case .source(_, let id, _, _) = WikiReaderView.linkRoute(for: url) else {
+            Issue.record("Expected a source route. URL: \(url)")
+            return
+        }
+        #expect(id == sourceID, "Canonical link routes by id (rename-stable)")
+    }
+
     @Test func sourceFrontmatterIsExcludedBeforeRendering() {
         let markdown = """
         ---

--- a/Tests/WikiFSTests/WikiLinkCanonicalizerTests.swift
+++ b/Tests/WikiFSTests/WikiLinkCanonicalizerTests.swift
@@ -227,6 +227,43 @@ struct WikiLinkCanonicalizerTests {
         #expect(out == "[[source:\(paperID)#\"first option | second option\"|Some Page]]")
     }
 
+    @Test func promotesAliasCarriedQuoteAnchorToCanonicalTarget() throws {
+        // Issue #1225, the real stored shape: a pipe-containing name whose
+        // quote anchor rides in the ALIAS slice after the span split. The
+        // reconstruction candidates walk candidateSplits, so the anchor peels
+        // off, the base resolves, and the link promotes to the canonical
+        // ordering — anchor in the target, full name as the auto-alias. After
+        // this save-time pass the scanner re-parses the link unambiguously.
+        let name = "What is Malleable Software Now | Bryan Min (02-27-2026)"
+        let (rp, rs) = resolvers(sources: [name: paperID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[source:\(name)#\"a quoted passage\"]]",
+            resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[source:\(paperID)#\"a quoted passage\"|\(name)]]")
+    }
+
+    @Test func promotedAnchorFormRoundTripsStably() throws {
+        // The promoted form is canonical: the ULID fast path leaves it
+        // byte-identical on the next save (quote run consumed by the scanner,
+        // alias pipes inert inside the alias slice).
+        let name = "What is Malleable Software Now | Bryan Min (02-27-2026)"
+        let (rp, rs) = resolvers(sources: [name: paperID])
+        let promoted = "[[source:\(paperID)#\"a quoted passage\"|\(name)]]"
+        let twice = try WikiLinkRewriter.canonicalize(in: promoted, resolvePage: rp, resolveSource: rs)
+        #expect(twice == nil)
+    }
+
+    @Test func aliasQuoteAnchorPromotionDoesNotHijackGenuineAliasWithHash() throws {
+        // A genuine alias whose display text contains `#` must not be re-read
+        // as an anchor when nothing in the alias reading resolves: the
+        // candidates miss (`Known | C`, `Known|C`), the branch falls through,
+        // and the regular alias-preserving path canonicalizes the target.
+        let (rp, rs) = resolvers(pages: ["Known": homeID])
+        let out = try WikiLinkRewriter.canonicalize(
+            in: "[[Known|C# Notes]]", resolvePage: rp, resolveSource: rs)
+        #expect(out == "[[page:\(homeID)|C# Notes]]")
+    }
+
     // MARK: - AC.4 — idempotency
 
     @Test func canonicalizingAlreadyCanonicalIsNoOp() throws {

--- a/Tests/WikiFSTests/WikiLinkPipeNameTests.swift
+++ b/Tests/WikiFSTests/WikiLinkPipeNameTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Pipe-in-name coverage across the pure link pipeline (issues #619, #1225).
+///
+/// A display name can contain a literal `|` (YouTube titles the app ingests,
+/// doc-set names), but the shared `[[…]]` grammar treats the first unquoted
+/// `|` as the alias separator. These tests pin the split behavior at every
+/// pure seam — span scanning, parsing, the reconstruction-candidate helper,
+/// and the typed syntax overlay — that the resolver/renderer seams build on.
+/// Resolution-level behavior lives in `WikiLinkMarkdownTests` (compatibility
+/// linkifier), `WikiLinkCanonicalizerTests` (canonicalize seam), and the
+/// app-target `DocumentEmbedResolverTests` (the production typed renderer).
+struct WikiLinkPipeNameTests {
+
+    /// Valid 26-char Crockford Base32 ids (no I/L/O/U).
+    private let paperID = "01JZZZZZZZZZZZZZZZZZZZZZZZ"
+
+    private static let pipeTitle = "What is Malleable Software Now | Bryan Min (02-27-2026)"
+
+    // MARK: - Span scanning (WikiLinkSpan)
+
+    @Test func spanSplitsAtFirstUnquotedPipe() {
+        let body = "[[Alpha | Beta]]"
+        let ns = body as NSString
+        let match = WikiLinkSpan.matches(in: body)[0]
+        #expect(ns.substring(with: match.targetRange) == "Alpha ")
+        #expect(ns.substring(with: match.aliasRange) == " Beta")
+    }
+
+    @Test func spanSecondPipeStaysInAlias() {
+        let ns = "[[Alpha | Beta | Gamma]]" as NSString
+        let match = WikiLinkSpan.matches(in: "[[Alpha | Beta | Gamma]]")[0]
+        #expect(ns.substring(with: match.targetRange) == "Alpha ")
+        #expect(ns.substring(with: match.aliasRange) == " Beta | Gamma")
+    }
+
+    @Test func spanPipeInsideQuoteAnchorStaysInAlias() {
+        // The `#"…"` quote anchor is a quoted run: a `|` inside it must not
+        // start the alias. The alias starts at the UNQUOTED pipe.
+        let body = "[[source:Name | Other#\"a | b\"]]"
+        let ns = body as NSString
+        let match = WikiLinkSpan.matches(in: body)[0]
+        #expect(ns.substring(with: match.targetRange) == "source:Name ")
+        #expect(ns.substring(with: match.aliasRange) == " Other#\"a | b\"")
+    }
+
+    @Test func spanWholePipeNameWithQuoteSuffixSplitsAtNamePipe() {
+        // The exact shape stored in real bodies (issue #1225): the pipe inside
+        // the title is unquoted, so the scanner splits there and the quote
+        // anchor rides along in the alias portion.
+        let body = "[[source:\(Self.pipeTitle)#\"a quoted passage\"]]"
+        let ns = body as NSString
+        let match = WikiLinkSpan.matches(in: body)[0]
+        #expect(ns.substring(with: match.targetRange) == "source:What is Malleable Software Now ")
+        #expect(ns.substring(with: match.aliasRange) == " Bryan Min (02-27-2026)#\"a quoted passage\"")
+    }
+
+    // MARK: - Parsing (WikiLinkParser.parse)
+
+    @Test func parseTruncatesPipeNameAtGrammarLevel() {
+        // Documented grammar behavior: parse sees the split target and the
+        // alias text. (Resolution-level healing happens in the resolver,
+        // canonicalize, and renderer seams — never here.)
+        let links = WikiLinkParser.parse("See [[source:\(Self.pipeTitle)]].")
+        #expect(links.count == 1)
+        #expect(links[0].linkType == .source)
+        #expect(links[0].target == "What is Malleable Software Now")
+        #expect(links[0].linkText == "Bryan Min (02-27-2026)")
+    }
+
+    @Test func parseKeepsQuoteAnchorInAliasText() {
+        let body = "[[source:\(Self.pipeTitle)#\"a quoted passage\"]]"
+        let links = WikiLinkParser.parse(body)
+        #expect(links.count == 1)
+        #expect(links[0].target == "What is Malleable Software Now")
+        // The fragment is part of the alias slice at parse level; it only
+        // becomes a real fragment after reconstruction peels it off.
+        #expect(links[0].fragment == nil)
+        #expect(links[0].linkText == "Bryan Min (02-27-2026)#\"a quoted passage\"")
+    }
+
+    // MARK: - Reconstruction candidates (WikiLinkResolver)
+
+    @Test func reconstructionCandidatesSpacedThenUnspaced() {
+        #expect(
+            WikiLinkResolver.pipeReconstructionCandidates(bare: "Foo", alias: "Bar")
+                == ["Foo | Bar", "Foo|Bar"])
+    }
+
+    @Test func reconstructionCandidatesNormalizeAliasAndAppendFragment() {
+        #expect(
+            WikiLinkResolver.pipeReconstructionCandidates(
+                bare: "Foo", alias: "  Bar  ", fragment: "\"quote\"")
+                == ["Foo | Bar#\"quote\"", "Foo|Bar#\"quote\""])
+    }
+
+    @Test func reconstructionCandidatesEmptyAliasYieldNothing() {
+        #expect(WikiLinkResolver.pipeReconstructionCandidates(bare: "Foo", alias: "   ") == [])
+        #expect(WikiLinkResolver.pipeReconstructionCandidates(bare: "Foo", alias: "") == [])
+    }
+
+    @Test func reconstructionCandidatesResolveThroughResolvedSplit() {
+        // The whole point of the helper: `resolvedSplit` peels the alias-
+        // carried quote anchor off the reconstructed name, and `isKnown` sees
+        // the full display name.
+        let candidates = WikiLinkResolver.pipeReconstructionCandidates(
+            bare: "What is Malleable Software Now",
+            alias: "Bryan Min (02-27-2026)#\"a quoted passage\"")
+        var tried: [String] = []
+        let split = candidates.compactMap { candidate -> WikiLinkResolver.Split? in
+            tried.append(candidate)
+            return WikiLinkResolver.resolvedSplit(of: candidate) { $0 == Self.pipeTitle }
+        }.first
+        #expect(tried.first == "What is Malleable Software Now | Bryan Min (02-27-2026)#\"a quoted passage\"")
+        #expect(split?.base == Self.pipeTitle)
+        #expect(split?.fragment == "\"a quoted passage\"")
+    }
+
+    // MARK: - Typed syntax overlay (syntaxNodes) — the resolver's input
+
+    @Test func syntaxNodesPipeNameCarriesTruncatedLiteralAndAlias() throws {
+        let body = "[[source:\(Self.pipeTitle)#\"a quoted passage\"]]"
+        guard case .link(let link) = try #require(WikiLinkParser.syntaxNodes(in: body).first) else {
+            Issue.record("Expected a link node")
+            return
+        }
+        #expect(link.target.namespace == .source)
+        #expect(link.target.literal == "What is Malleable Software Now")
+        #expect(link.target.canonicalID == nil)
+        // The quote anchor landed in the ALIAS slice, so the target carries no
+        // fragment — reconstruction must peel it from the candidate text.
+        #expect(link.target.fragment == nil)
+        #expect(link.alias == "Bryan Min (02-27-2026)#\"a quoted passage\"")
+        #expect(link.displayText == "Bryan Min (02-27-2026)#\"a quoted passage\"")
+    }
+
+    @Test func syntaxNodesCanonicalULIDLinkKeepsFullPipeAlias() throws {
+        // After canonicalization the body reads
+        // `[[source:<ULID>|<full title>]]`: the FIRST pipe (after the ULID) is
+        // the alias separator and the title's own pipe survives inside the
+        // alias. This is the invariant that makes id-backed links render the
+        // full display label without any reconstruction.
+        let body = "[[source:\(paperID)|\(Self.pipeTitle)]]"
+        guard case .link(let link) = try #require(WikiLinkParser.syntaxNodes(in: body).first) else {
+            Issue.record("Expected a link node")
+            return
+        }
+        #expect(link.target.canonicalID == paperID)
+        #expect(link.alias == Self.pipeTitle)
+        #expect(link.displayText == Self.pipeTitle)
+    }
+}

--- a/Tests/WikiFSTests/WikiLinkStoreTests.swift
+++ b/Tests/WikiFSTests/WikiLinkStoreTests.swift
@@ -253,6 +253,30 @@ struct WikiLinkStoreTests {
         #expect(try store.resolveSourceByName("Paper (2026)") == exact.id)
     }
 
+    // MARK: - Pipe inside the display NAME (issue #1225 — navigation tier)
+
+    @Test func pipeInIngestedTitleIsSanitizedButStillNavigates() throws {
+        // YouTube-style titles carry a literal `|`. At ingest the display name
+        // is sanitized (`|` → `-`, WikiNameRules) so every STORED name stays
+        // linkable — a pipe-named display_name exists only as legacy data
+        // (e.g. the issue's 01KZ5FS7A76RDDXFQFC5DKJ1SJ row, written before
+        // that rule). The navigation tier (`selectSource(byDisplayName:)` →
+        // `resolveSourceByName`) must resolve the stored spelling the render
+        // seam hands it.
+        let store = try tempStore()
+        let src = try store.addSource(
+            filename: "what-is-malleable-software-now.md",
+            data: Data("transcript".utf8),
+            resolvedDisplayName: .some("What is Malleable Software Now | Bryan Min (02-27-2026)"))
+        let storedName = try #require(src.displayName)
+        // Sanitized at the write boundary — the store never holds a pipe.
+        #expect(storedName == "What is Malleable Software Now - Bryan Min (02-27-2026)")
+        #expect(try store.resolveSourceByName(storedName) == src.id)
+        // A differently-spelled title must not resolve: reconstruction in the
+        // render seam only heals links when the whole name actually exists.
+        #expect(try store.resolveSourceByName("What is Malleable Software Now") == nil)
+    }
+
     // MARK: - LinkReconciler (startup self-heal)
 
     @Test func reconcileHealsCitationSavedBeforeSourceExisted() async throws {


### PR DESCRIPTION
Fix the rendered label for source wikilinks whose title contains a pipe

Fixes #1225

## Problem

A source titled `What is Malleable Software Now | Bryan Min (02-27-2026)`
renders in wikilinks as `Bryan Min (02-27-2026)`. The link is inert, so a
click does not navigate.

The span scanner splits a `[[target|alias]]` link at the first unquoted
pipe. Issue #619 taught the canonicalize seam and the `linkified`
compatibility path to reconstruct the whole name when the split target
does not resolve. The production render path never learned that
fallback. Pages and chats render through the typed pipeline
(`syntaxNodes` -> `DocumentEmbedResolver` -> `MarkdownHTMLRenderer`), so
a name-authored link to a pipe-titled source missed every existence
tier. The resolver then labeled the link with the post-pipe alias
fragment and emitted `wiki://missing`.

I confirmed the shape against real data: the Bryan Min page in the
Malleable Software wiki stores links like
`[[source:What is Malleable Software Now | Bryan Min (02-27-2026)#"..."]]`,
and the quote anchor rides in the alias slice.

## Fix

Add `WikiLinkResolver.pipeReconstructionCandidates` as the one shared
helper for whole-name readings: `bare | alias` first (the YouTube
convention), then `bare|alias`. All three seams now share it:

- `DocumentEmbedResolver.resolveWikiLink` (the fix): when a name-authored
  link misses every existence tier, reconstruct and accept the first
  reading whose base names a real entity. The full display name becomes
  the label and the navigation title. `candidateSplits` peels an
  alias-carried quote anchor off the name, so the fragment survives.
- `WikiLinkMarkdown.linkified` and `WikiLinkRewriter.canonicalize` are
  refactors onto the same helper. `linkified` also gains the unspaced
  candidate that canonicalize already had.

The fallback runs only when the left-hand target fails to resolve, so
explicit `target|alias` links keep their alias. Canonical ULID-backed
links resolve by id and keep the self-healing label; the title pipe
stays inside the alias slice and renders whole.

Note on scope: a pipe-named display row exists only as legacy data.
`WikiNameRules.sanitized` maps `|` to `-` at every write boundary, so
ingest today stores a dash name. The reported source predates that rule.
Name-authored links to such legacy rows now render and navigate with the
full title.

## Tests

19 new tests across the pipeline, per the issue acceptance criteria:

- `WikiLinkPipeNameTests` (new): span scan pipe semantics (first pipe
  splits, second pipe stays in the alias, pipes inside quote anchors),
  parser truncation shape, reconstruction candidate helper, and the
  typed overlay shapes that feed the resolver.
- `DocumentEmbedResolverTests`: name-authored pipe links resolve with
  the full label and title (spaced, unspaced, loose-tier, page, chat);
  the real quote-anchor shape keeps its fragment; canonical ULID links
  render the current pipe title and heal a stale alias; explicit alias
  wins when the left-hand target resolves; unresolvable pipe links fall
  back to the alias display.
- `MarkdownHTMLRendererTests`: full render of the real stored shape
  emits the full label and a `wiki://source` URL, and the URL
  round-trips through `linkRoute` with the title, fragment, and id
  intact.
- `WikiLinkStoreTests`: the navigation tier resolves the sanitized
  stored spelling and refuses a different spelling.

`make build`, `make test` (4207 tests), and the app-test tier
(`WIKIFS_APP_TESTS=1`) all pass.
