### PR TITLE
fix(menu-bar): start the activity blinker from queue events (#1222)

### DIFF
--- a/Sources/WikiFS/Window/MenuBarItemController.swift
+++ b/Sources/WikiFS/Window/MenuBarItemController.swift
@@ -64,6 +64,26 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
     private var hasFailedItems = false
     private var isPaused = false
     private var lastSnapshot: QueueSnapshot = QueueSnapshot()
+    /// Queue item IDs known to be `.queued`, maintained synchronously from
+    /// queue events (#1222). Every `.enqueued` inserts and every terminal
+    /// event removes, so the blinker reacts to the event the controller
+    /// actually received instead of waiting on an async snapshot RPC.
+    private var queuedItemIDs: Set<QueueItem.ID> = []
+    /// Queue item IDs known to be `.running` (`.started` → insert, terminal
+    /// event → remove). Split from ``queuedItemIDs`` so the tooltip's
+    /// "Processing (N active, M queued)" counts are consistent with the icon
+    /// state by construction.
+    private var runningItemIDs: Set<QueueItem.ID> = []
+    /// Bumped on every event-driven membership change. Snapshot refresh tasks
+    /// capture the epoch when the fetch starts and discard the result if the
+    /// epoch moved while the RPC was in flight — a snapshot taken BEFORE an
+    /// enqueue must never land AFTER it and clear the blinker (the #1222
+    /// stale-snapshot race).
+    private var membershipEpoch: UInt64 = 0
+    /// The icon state most recently derived by ``updateIcon()``. Test seam for
+    /// the lint/queue blinker regression tests (#1222) — AppKit offers no way
+    /// to read a status item's animation state back.
+    private(set) var lastDerivedIconState: IconState?
     private var hintPopover: NSPopover?
     private var hintDismissTask: Task<Void, Never>?
     /// Previous daemon connection state, used to detect the
@@ -131,14 +151,13 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         menu.delegate = self
         item.menu = menu
 
-        // Fetch initial snapshot so the icon reflects any items already
-        // in the queue (e.g. rehydrated from a previous session).
-        Task {
-            if let snapshot = await queueSnapshot() {
-                lastSnapshot = snapshot
-                updateIcon()
-            }
-        }
+        // Fetch initial snapshot so the icon reflects any items already in
+        // the queue (e.g. hosted by the daemon before this subscription
+        // existed). The guarded apply seeds the membership sets from that
+        // snapshot — events emitted before we subscribed are not replayed
+        // (#1222) — while still refusing stale data if events have already
+        // changed membership since the fetch started.
+        refreshSnapshotGuarded()
 
         // Observe engine events to update the icon + menu.
         streamTask = Task { @MainActor [weak self] in
@@ -178,6 +197,13 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         streamTask = nil
         stopIconAnimation()
         closeActivityWindow()
+        // #1222: drop the event-maintained membership so a restarted
+        // controller re-seeds from its own initial snapshot instead of
+        // inheriting stale activity.
+        queuedItemIDs.removeAll()
+        runningItemIDs.removeAll()
+        membershipEpoch &+= 1
+        lastDerivedIconState = nil
         if let item = statusItem {
             NSStatusBar.system.removeStatusItem(item)
             statusItem = nil
@@ -551,7 +577,9 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
 
     // MARK: - Icon management
 
-    private enum IconState {
+    /// Internal (not private) so `lastDerivedIconState` is assertable from
+    /// the @testable blinker regression tests (#1222).
+    enum IconState {
         case idle
         case working
         case paused
@@ -597,17 +625,25 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         // #878: daemon-disconnected takes precedence — even if items are
         // running on the local fallback, the user needs to know the daemon is
         // down.
+        // #1222: the working decision reads the event-maintained membership
+        // sets, NOT `lastSnapshot.activeItems`. The snapshot is refreshed by
+        // an async RPC per event, so it can return stale or empty data after
+        // the user already saw the "Lint queued" hint — leaving the icon idle
+        // while a lint sits queued or running. The events themselves are the
+        // timely truth; the snapshot only corrects them when provably fresh
+        // (see `applySnapshot`).
         if daemonHealthMonitor?.state == .disconnected {
             state = .daemonDown
         } else if hasFailedItems {
             state = .attention
         } else if isPaused {
             state = .paused
-        } else if !lastSnapshot.activeItems.isEmpty {
+        } else if !queuedItemIDs.isEmpty || !runningItemIDs.isEmpty {
             state = .working
         } else {
             state = .idle
         }
+        lastDerivedIconState = state
         statusItem?.button?.toolTip = tooltipText(for: state)
 
         // While working, breathe the books glyph between its outline and
@@ -626,8 +662,11 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
         switch state {
         case .idle: return "Self Driving Wiki — Idle"
         case .working:
-            let running = lastSnapshot.activeItems.filter { $0.state == .running }.count
-            let queued = lastSnapshot.activeItems.filter { $0.state == .queued }.count
+            // #1222: counts come from the event-maintained membership sets so
+            // the tooltip always agrees with the blinker — even in the window
+            // before a snapshot RPC returns (or when it returned stale data).
+            let running = runningItemIDs.count
+            let queued = queuedItemIDs.count
             if running > 0 && queued > 0 {
                 return "Self Driving Wiki — Processing (\(running) active, \(queued) queued)"
             } else if running > 0 {
@@ -682,36 +721,38 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
 
     // MARK: - Event handling
 
+    /// Handle one queue event. Membership changes (enqueued / started /
+    /// terminal) are applied SYNCHRONOUSLY to ``queuedItemIDs`` /
+    /// ``runningItemIDs`` — the blinker must react to the event itself, not
+    /// to a snapshot RPC that races it (#1222). Every membership change also
+    /// spawns an epoch-guarded snapshot refresh so `lastSnapshot` (menu,
+    /// failure badge) and the membership sets converge on daemon ground
+    /// truth without ever letting a stale snapshot override event truth.
     private func handleEvent(_ event: QueueEvent) {
         switch event {
         case .runStateChanged(_, let state):
             if state == .paused {
                 isPaused = true
             } else {
-                Task {
-                    guard let snapshot = await queueSnapshot() else { return }
-                    isPaused = snapshot.runStates.values.contains(.paused)
-                    lastSnapshot = snapshot
-                    updateIcon()
-                }
+                refreshSnapshotGuarded(recomputesPaused: true)
                 return
             }
-        case .failed:
+        case .failed(let item, _):
             hasFailedItems = true
-        case .completed, .cancelled:
-            Task {
-                guard let snapshot = await queueSnapshot() else { return }
-                hasFailedItems = snapshot.recentItems.contains {
-                    $0.state == .failed
-                }
-                lastSnapshot = snapshot
-                updateIcon()
-            }
+            // Terminal: drop from the active membership so the icon decision
+            // doesn't retain the failed item (the attention state takes over
+            // the icon here, matching the pre-#1222 behavior).
+            removeMembership(itemID: item.id)
+        case .completed(let item):
+            beginTerminalRefresh(itemID: item.id)
+            return
+        case .cancelled(let item):
+            beginTerminalRefresh(itemID: item.id)
             return
         case .enqueued(let item):
             // Show a transient popover anchored to the status item so the
-            // user gets immediate feedback that their ingest / extraction
-            // was queued — before the icon even updates.
+            // user gets immediate feedback that their ingest / extraction /
+            // lint was queued — before the icon even updates.
             let isLint = item.queue == .ingestion
                 && item.payload.lintPageIDs != nil
             showTransientHint(
@@ -726,42 +767,127 @@ final class MenuBarItemController: NSObject, NSMenuDelegate {
                         ? "books.vertical.fill"
                         : "doc.text.magnifyingglass")
             )
-            // Refresh snapshot + update icon so the menu bar immediately
-            // reflects queued items (not just running ones). Without this,
-            // the icon stays idle when an item is enqueued but hasn't
-            // started yet — giving no feedback that work was queued.
-            Task {
-                guard let snapshot = await queueSnapshot() else { return }
-                lastSnapshot = snapshot
-                updateIcon()
-            }
+            // #1222: record the queued membership synchronously so the icon
+            // enters the working state on THIS event. The old code only
+            // refreshed `lastSnapshot` via an async RPC — a stale or empty
+            // reply (or one racing the daemon's immediate dispatch) left the
+            // icon idle even though the user just saw the "Lint queued"
+            // hint.
+            queuedItemIDs.insert(item.id)
+            runningItemIDs.remove(item.id)
+            noteMembershipChanged()
             return
-        case .started:
-            // Refresh snapshot + update icon so the menu bar reflects
-            // items that have transitioned to running.
-            Task {
-                guard let snapshot = await queueSnapshot() else { return }
-                lastSnapshot = snapshot
-                updateIcon()
-            }
+        case .started(let item):
+            // Move the item queued → running on the event itself, then let
+            // the guarded refresh reconcile `lastSnapshot`.
+            queuedItemIDs.remove(item.id)
+            runningItemIDs.insert(item.id)
+            noteMembershipChanged()
             return
         case .reordered:
             // A queued item was moved; refresh the snapshot for menu
-            // accuracy. No hint popover (this is a reorder, not an enqueue).
-            Task {
-                guard let snapshot = await queueSnapshot() else { return }
-                lastSnapshot = snapshot
-            }
+            // accuracy. No hint popover (this is a reorder, not an enqueue),
+            // and no membership change (state is unchanged).
+            refreshSnapshotGuarded()
             return
         default:
             break
         }
-        Task {
-            guard let snapshot = await queueSnapshot() else { return }
-            lastSnapshot = snapshot
+        // Non-membership events (progress, usage, transcripts, …): the icon
+        // decision can't change from the event alone, but keep refreshing the
+        // snapshot so `lastSnapshot`/`hasFailedItems` track daemon truth.
+        // The synchronous `updateIcon()` reasserts the current state (it is
+        // idempotent while membership is unchanged).
+        refreshSnapshotGuarded()
+        updateIcon()
+    }
+
+    // MARK: - Membership + guarded snapshot refresh (#1222)
+
+    /// Remove an item from the active membership sets. Returns whether the
+    /// membership actually changed, so terminal handlers only spawn a
+    /// refresh (and bump the epoch) when needed.
+    @discardableResult
+    private func removeMembership(itemID: QueueItem.ID) -> Bool {
+        let removedQueued = queuedItemIDs.remove(itemID) != nil
+        let removedRunning = runningItemIDs.remove(itemID) != nil
+        return removedQueued || removedRunning
+    }
+
+    /// Bump the membership epoch, spawn a guarded snapshot refresh, and
+    /// re-derive the icon. Called after every event-driven membership change.
+    private func noteMembershipChanged() {
+        membershipEpoch &+= 1
+        refreshSnapshotGuarded()
+        updateIcon()
+    }
+
+    /// Terminal-event path: drop the item from membership, recompute the
+    /// failure badge from the fresh snapshot (as the pre-#1222 handler did),
+    /// and re-derive the icon.
+    private func beginTerminalRefresh(itemID: QueueItem.ID) {
+        let changed = removeMembership(itemID: itemID)
+        // Bump BEFORE capturing the epoch (and before spawning the fetch) so
+        // this refresh is discarded only by a LATER membership change, never
+        // by its own bump.
+        if changed {
+            membershipEpoch &+= 1
             updateIcon()
         }
-        updateIcon()
+        let epochAtFetch = membershipEpoch
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let snapshot = await self.queueSnapshot() else { return }
+            // Stale guard: a membership change bumped the epoch while this
+            // fetch was in flight — its own refresh applies fresher data.
+            guard epochAtFetch == self.membershipEpoch else { return }
+            self.lastSnapshot = snapshot
+            self.hasFailedItems = snapshot.recentItems.contains {
+                $0.state == .failed
+            }
+            if changed { self.applySnapshotMembership(from: snapshot) }
+            self.updateIcon()
+        }
+    }
+
+    /// Spawn a snapshot fetch that applies `lastSnapshot` (+ optional
+    /// reconciliation) ONLY if no membership change occurred while the RPC
+    /// was in flight. This is what makes snapshot data safe to apply as a
+    /// full membership replace: it can never resurrect an item a terminal
+    /// event already removed, nor erase one an enqueue event already added.
+    private func refreshSnapshotGuarded(recomputesPaused: Bool = false) {
+        let epochAtFetch = membershipEpoch
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let snapshot = await self.queueSnapshot() else { return }
+            guard epochAtFetch == self.membershipEpoch else { return }
+            if recomputesPaused {
+                self.isPaused = snapshot.runStates.values.contains(.paused)
+            }
+            self.lastSnapshot = snapshot
+            self.applySnapshotMembership(from: snapshot)
+            self.updateIcon()
+        }
+    }
+
+    /// Replace the membership sets from a provably-fresh snapshot. This is
+    /// the seed path for items the controller never saw events for — e.g.
+    /// daemon-hosted items already queued or running when the app launched —
+    /// and the reconcile path that drops items whose terminal event was
+    /// lost. `activeItems` contains only non-terminal items; anything not
+    /// `.running` counts toward the queued side.
+    private func applySnapshotMembership(from snapshot: QueueSnapshot) {
+        var queued: Set<QueueItem.ID> = []
+        var running: Set<QueueItem.ID> = []
+        for item in snapshot.activeItems {
+            if item.state == .running {
+                running.insert(item.id)
+            } else {
+                queued.insert(item.id)
+            }
+        }
+        queuedItemIDs = queued
+        runningItemIDs = running
     }
 
     // MARK: - Transient hint

--- a/Tests/WikiFSAppTests/MenuBarItemLintBlinkerTests.swift
+++ b/Tests/WikiFSAppTests/MenuBarItemLintBlinkerTests.swift
@@ -1,0 +1,337 @@
+#if os(macOS)
+import AppKit
+import Testing
+@testable import WikiFS
+@testable import WikiFSEngine
+@testable import WikiFSCore
+
+/// Regression coverage for #1222 — lint operations must drive the menu-bar
+/// activity blinker:
+///
+/// 1. A newly enqueued lint job starts the working state immediately, on the
+///    `.enqueued` event itself — not on an async snapshot RPC that can return
+///    stale (pre-enqueue) data after the user already saw the "Lint queued"
+///    hint.
+/// 2. The working state persists while the lint is queued or running.
+/// 3. Completion, cancellation, and failure clear it.
+/// 4. A stale empty snapshot landing AFTER an enqueue must not clear the
+///    blinker (the #1222 snapshot/event timing race).
+/// 5. Ingestion/extraction indication keeps working through the same
+///    event-driven path (queue-agnostic membership).
+///
+/// State is observed via `MenuBarItemController.lastDerivedIconState` — the
+/// value `updateIcon()` derived on its last pass. AppKit offers no way to
+/// read a status item's animation back.
+@MainActor
+@Suite(.serialized, .timeLimit(.minutes(2)))
+struct MenuBarItemLintBlinkerTests {
+
+    private let wikiID = WikiID(rawValue: "01992222-lint-wiki")
+
+    // MARK: - Real-engine end-to-end transitions
+
+    @Test("A newly enqueued page-level lint starts the blinker; cancelling stops it")
+    func enqueuedPageLintStartsBlinkerAndCancelStopsIt() async throws {
+        let harness = try makeRealEngineHarness()
+        let controller = harness.controller
+        controller.start()
+        defer { controller.stop() }
+
+        let settledIdle = await waitUntil { controller.lastDerivedIconState == .idle }
+        #expect(settledIdle, "fresh controller over an empty queue should settle idle")
+
+        let itemID = try await harness.engine.enqueue(QueueItemRequest(
+            queue: .ingestion,
+            wikiID: wikiID,
+            payload: QueueItemPayload(sourceIDs: [], lintPageIDs: [PageID(rawValue: "lint-page-1")])))
+        _ = itemID
+
+        // The engine never started (no dispatch in this fixture), so the item
+        // stays `.queued` — the blinker must still start (#1222: "remains
+        // active for queued and running lint jobs").
+        let started = await waitUntil { controller.lastDerivedIconState == .working }
+        #expect(started, "lint enqueue must start the menu-bar blinker (#1222)")
+
+        await harness.engine.cancelItem(itemID)
+        let stopped = await waitUntil { controller.lastDerivedIconState == .idle }
+        #expect(stopped, "lint cancellation must stop the blinker (#1222)")
+    }
+
+    @Test("A whole-wiki lint (empty lintPageIDs) starts the blinker too")
+    func enqueuedWholeWikiLintStartsBlinker() async throws {
+        let harness = try makeRealEngineHarness()
+        let controller = harness.controller
+        controller.start()
+        defer { controller.stop() }
+
+        _ = await waitUntil { controller.lastDerivedIconState == .idle }
+
+        _ = try await harness.engine.enqueue(QueueItemRequest(
+            queue: .ingestion,
+            wikiID: wikiID,
+            payload: QueueItemPayload(sourceIDs: [], lintPageIDs: [])))
+
+        let started = await waitUntil { controller.lastDerivedIconState == .working }
+        #expect(started, "whole-wiki lint enqueue must start the blinker (#1222)")
+    }
+
+    @Test("Extraction enqueue still drives the blinker (queue-agnostic membership)")
+    func extractionEnqueueStillStartsBlinker() async throws {
+        let harness = try makeRealEngineHarness()
+        let controller = harness.controller
+        controller.start()
+        defer { controller.stop() }
+
+        _ = await waitUntil { controller.lastDerivedIconState == .idle }
+
+        let itemID = try await harness.engine.enqueue(QueueItemRequest(
+            queue: .extraction,
+            wikiID: wikiID,
+            payload: QueueItemPayload(sourceIDs: [SourceID(rawValue: "source-1")])))
+
+        let started = await waitUntil { controller.lastDerivedIconState == .working }
+        #expect(started, "extraction enqueue must keep starting the blinker")
+
+        await harness.engine.cancelItem(itemID)
+        let stopped = await waitUntil { controller.lastDerivedIconState == .idle }
+        #expect(stopped, "extraction cancellation must stop the blinker")
+    }
+
+    // MARK: - Snapshot/event timing (#1222 race)
+
+    @Test("A stale empty snapshot landing after a lint enqueue cannot clear the blinker")
+    func staleSnapshotCannotClearLintBlinker() async throws {
+        let engine = GatedSnapshotEngine()
+        let controller = makeController(engine: engine)
+        controller.start()
+        // Safety net: resume any fetches still parked at the gate so the test
+        // process never exits with a leaked continuation.
+        defer {
+            engine.releaseAll(with: QueueSnapshot())
+            controller.stop()
+        }
+
+        // The initial fetch parks at the gate; release it empty → idle.
+        let initial = await waitUntil { engine.parkedCount == 1 }
+        #expect(initial, "the initial snapshot fetch should be parked at the gate")
+        engine.releaseOldest(with: QueueSnapshot())
+        let idle = await waitUntil { controller.lastDerivedIconState == .idle }
+        #expect(idle)
+
+        // A snapshot fetch is now in flight that started BEFORE the lint
+        // enqueue (progress events spawn these continuously during runs).
+        let lintItem = makeLintItem(state: .queued)
+        engine.yield(.progress(lintItem.id, line: "lint agent started"))
+        let parked = await waitUntil { engine.parkedCount == 1 }
+        #expect(parked, "the pre-enqueue snapshot fetch should be parked at the gate")
+
+        // The enqueue event arrives — the blinker must start on the EVENT,
+        // while its own snapshot fetch is still parked at the gate.
+        engine.yield(.enqueued(lintItem))
+        let started = await waitUntil { controller.lastDerivedIconState == .working }
+        #expect(started, "lint enqueue must start the blinker without waiting on a snapshot")
+
+        // Now the PRE-ENQUEUE snapshot returns: empty activeItems. The
+        // pre-#1222 code applied it and flipped the icon idle — the exact
+        // reported bug. The epoch guard must discard it. Release ONLY the
+        // pre-enqueue fetch (FIFO); the enqueue's own fetch stays parked.
+        engine.releaseOldest(with: QueueSnapshot())
+        await settle()
+        #expect(
+            controller.lastDerivedIconState == .working,
+            "a stale pre-enqueue snapshot must not clear the blinker (#1222)")
+
+        // Started keeps it working; completed stops it and releases cleanly.
+        engine.yield(.started(makeLintItem(state: .running, id: lintItem.id.rawValue)))
+        await settle()
+        #expect(controller.lastDerivedIconState == .working, "a running lint keeps the blinker on")
+
+        engine.yield(.completed(makeLintItem(state: .completed, id: lintItem.id.rawValue)))
+        let idleAgain = await waitUntil { controller.lastDerivedIconState == .idle }
+        #expect(idleAgain, "lint completion must stop the blinker (#1222)")
+    }
+
+    // MARK: - Fixtures
+
+    private struct RealEngineHarness {
+        let controller: MenuBarItemController
+        let engine: QueueEngine
+    }
+
+    /// Real in-memory `QueueEngine` (never started → no dispatch, items stay
+    /// `.queued`) wired to a real `MenuBarItemController`, mirroring
+    /// `MenuBarItemMaintenanceMenuTests`.
+    private func makeRealEngineHarness() throws -> RealEngineHarness {
+        let engine = try makeTestQueueEngine()
+        let controller = makeController(engine: engine)
+        return RealEngineHarness(controller: controller, engine: engine)
+    }
+
+    private func makeController(engine: any QueueEngineClient) -> MenuBarItemController {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lint-blinker-\(UUID().uuidString)", isDirectory: true)
+        let coordinator = ExtractionCoordinator(
+            containerDirectory: dir,
+            localExtractorFactory: { StubExtractor() })
+        let sessionManager = SessionManager(
+            containerDirectory: dir,
+            extractionCoordinator: coordinator,
+            queueEngine: engine,
+            extractionProvider: StubExtractionProvider(),
+            pdf2mdScriptPathResolver: { nil })
+        let registry = WikiRegistryClient(containerDirectory: dir)
+        return MenuBarItemController(
+            queueEngine: engine,
+            activityTracker: QueueActivityTracker(),
+            sessionManager: sessionManager,
+            registry: registry,
+            openWindowBridge: OpenWindowBridge())
+    }
+
+    private func makeTestQueueEngine() throws -> QueueEngine {
+        // A UNIQUE per-test database FILE. `URL(fileURLWithPath: ":memory:")`
+        // does NOT produce SQLite's private in-memory database — the colon is
+        // not preserved through URL path conversion, so GRDB opens a literal
+        // `:memory:` file in the process CWD that persists and accumulates
+        // items across every test run (which made the "fresh queue" fixture
+        // start with a pile of stale queued items and the controller sit in
+        // the working state forever).
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lint-blinker-queue-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = try QueueStore(databaseURL: dir.appendingPathComponent("queue.sqlite"))
+        let factory = QueueExtractionWorkerFactory(
+            provider: StubExtractionProvider(),
+            emitProgress: { _, _ in })
+        return QueueEngine(store: store, workerFactory: factory)
+    }
+
+    private func makeLintItem(
+        state: QueueItemState,
+        id: String = "01992222-lint-item",
+        lintPageIDs: [PageID] = [PageID(rawValue: "lint-page-1")]
+    ) -> QueueItem {
+        QueueItem(
+            id: QueueItemID(rawValue: id),
+            queue: .ingestion,
+            wikiID: wikiID,
+            payload: QueueItemPayload(sourceIDs: [], lintPageIDs: lintPageIDs),
+            state: state,
+            orderingKey: 1000,
+            attempt: 0,
+            createdAt: 0)
+    }
+
+    /// Poll a main-actor condition until it holds or the timeout elapses.
+    /// Task.sleep is non-blocking — the cooperative pool is never parked
+    /// (repo concurrency rule).
+    private func waitUntil(
+        timeout: Duration = .seconds(3),
+        _ condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            // Task.sleep only throws CancellationError — expected, not actionable.
+            // swiftlint:disable:next silent_try_optional
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return condition()
+    }
+
+    /// Let already-scheduled main-actor tasks (event loop, snapshot tasks)
+    /// run a few hops before asserting.
+    private func settle(hops: Int = 5) async {
+        for _ in 0..<hops {
+            // Task.sleep only throws CancellationError — expected, not actionable.
+            // swiftlint:disable:next silent_try_optional
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+// MARK: - Gated snapshot engine (event-timing race fixture)
+
+/// A `QueueEngineClient` whose `snapshot()` calls park at a gate until
+/// `releaseParked(with:)` resumes them, and whose events the test injects
+/// directly. This makes the snapshot/event interleaving of the #1222 race
+/// deterministic: the test controls exactly when a fetch started relative to
+/// each event, and what data it returns.
+private final class GatedSnapshotEngine: QueueEngineClient, @unchecked Sendable {
+    private enum GateError: Error { case unimplemented }
+
+    private let broadcaster = QueueEventBroadcaster()
+    private let lock = NSLock()
+    private var parked: [CheckedContinuation<QueueSnapshot, Never>] = []
+
+    var events: AsyncStream<QueueEvent> { broadcaster.subscribe() }
+
+    /// How many snapshot fetches are currently parked at the gate.
+    var parkedCount: Int {
+        lock.withLock { parked.count }
+    }
+
+    func snapshot() async throws -> QueueSnapshot {
+        await withCheckedContinuation { (cont: CheckedContinuation<QueueSnapshot, Never>) in
+            lock.withLock { parked.append(cont) }
+        }
+    }
+
+    /// Resume the OLDEST parked fetch with `snapshot`. Returns false when
+    /// nothing is parked. FIFO matters for the race test: the pre-enqueue
+    /// fetch parks before the enqueue's own fetch, so releasing one fetch
+    /// deterministically targets the stale one.
+    @discardableResult
+    func releaseOldest(with snapshot: QueueSnapshot) -> Bool {
+        let cont: CheckedContinuation<QueueSnapshot, Never>? = lock.withLock {
+            parked.isEmpty ? nil : parked.removeFirst()
+        }
+        guard let cont else { return false }
+        cont.resume(returning: snapshot)
+        return true
+    }
+
+    /// Resume every parked fetch with `snapshot` (no-op when none parked).
+    func releaseAll(with snapshot: QueueSnapshot) {
+        let toResume = lock.withLock { () -> [CheckedContinuation<QueueSnapshot, Never>] in
+            let pending = parked
+            parked.removeAll()
+            return pending
+        }
+        for cont in toResume { cont.resume(returning: snapshot) }
+    }
+
+    func yield(_ event: QueueEvent) {
+        broadcaster.yield(event)
+    }
+
+    // Unused client surface — throw loudly if the controller ever calls it.
+    func enqueue(_ request: QueueItemRequest) async throws -> QueueItem.ID { throw GateError.unimplemented }
+    func cancelItem(_ id: QueueItem.ID) async throws { throw GateError.unimplemented }
+    func cancelAllInFlight() async throws -> Int { throw GateError.unimplemented }
+    func retryItem(_ id: QueueItem.ID) async throws { throw GateError.unimplemented }
+    func pause(_ queue: QueueKind) async throws { throw GateError.unimplemented }
+    func resume(_ queue: QueueKind) async throws { throw GateError.unimplemented }
+    func halt(_ queue: QueueKind) async throws { throw GateError.unimplemented }
+    func reorderItem(id: QueueItem.ID, beforeItemID: QueueItem.ID?) async throws { throw GateError.unimplemented }
+    func hasActiveWork(for wikiID: WikiID) async throws -> Bool { throw GateError.unimplemented }
+    func waitForCompletion(of id: QueueItem.ID) async throws -> Result<Void, Error> { throw GateError.unimplemented }
+    func loadTranscript(for itemID: QueueItem.ID) async throws -> [ChatTranscriptItem] { throw GateError.unimplemented }
+    func loadAllActivitySnapshots() async throws -> [QueueItem.ID: QueueEngine.ActivitySnapshot] { throw GateError.unimplemented }
+}
+
+// MARK: - Minimal stubs (mirror MenuBarItemMaintenanceMenuTests)
+
+@MainActor
+private final class StubExtractor: MarkdownExtractor {
+    nonisolated var displayName: String { "Stub" }
+    func readiness() async -> ExtractionReadiness { .ready }
+    func convert(pdfData: Data, filename: String, onProgress: (@Sendable (String) -> Void)?) async throws -> String { "" }
+}
+
+private struct StubExtractionProvider: QueueExtractionProvider {
+    func resolveExtraction(wikiID: WikiID, sourceID: SourceID, backendOverride: ExtractionBackend?) async throws -> ExtractionResolution? { nil }
+    func persistBytesExtraction(wikiID: WikiID, sourceID: SourceID, resolution: BytesExtractionResolution, markdown: String) async throws {}
+    func persistTranscriptExtraction(wikiID: WikiID, sourceID: SourceID, resolution: TranscriptExtractionResolution, outcome: TranscriptFetchOutcome) async throws {}
+}
+#endif

--- a/Tests/WikiFSAppTests/MenuBarItemMaintenanceMenuTests.swift
+++ b/Tests/WikiFSAppTests/MenuBarItemMaintenanceMenuTests.swift
@@ -121,7 +121,13 @@ private struct StubExtractionProvider: QueueExtractionProvider {
 }
 
 private func makeTestQueueEngine() throws -> QueueEngine {
-    let store = try QueueStore(databaseURL: URL(fileURLWithPath: ":memory:"))
+    // Unique per-test database FILE — `URL(fileURLWithPath: ":memory:")` does
+    // not yield SQLite's private in-memory DB (the colon is lost in URL path
+    // conversion, so GRDB opens a shared literal `:memory:` file in the CWD).
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("menu-item-controller-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let store = try QueueStore(databaseURL: dir.appendingPathComponent("queue.sqlite"))
     let provider = StubExtractionProvider()
     let factory = QueueExtractionWorkerFactory(provider: provider, emitProgress: { _, _ in })
     return QueueEngine(store: store, workerFactory: factory)

--- a/progress/2026-09-07T153400Z-fix-lint-menu-bar-blinker-1222.md
+++ b/progress/2026-09-07T153400Z-fix-lint-menu-bar-blinker-1222.md
@@ -1,0 +1,57 @@
+---
+timestamp: 2026-09-07T153400Z
+title: Fix lint operations not starting the menu-bar activity blinker (#1222)
+branch: fix/lint-menu-bar-blinker-1222
+status: complete
+---
+
+# Fix lint operations not starting the menu-bar activity blinker (#1222)
+
+## Progress
+
+The menu-bar status item shows live queue work by breathing the books glyph.
+`MenuBarItemController` derived the working state only from
+`lastSnapshot.activeItems`. Every queue event spawned an async snapshot RPC,
+and the icon waited on that reply. The reply can return stale data: a fetch
+that started before an enqueue can land after it and erase the new item, and
+unstructured fetch tasks can apply out of order. A lint enqueue showed the
+"Lint queued" hint (the event arrived) while the icon stayed idle (the
+snapshot disagreed).
+
+The controller now records active items from the events themselves:
+
+- `.enqueued` inserts the item into `queuedItemIDs`.
+- `.started` moves it to `runningItemIDs`.
+- `.completed`, `.failed`, and `.cancelled` remove it.
+
+`updateIcon` reads these sets, so the blinker starts on the enqueue event.
+Tooltip counts come from the same sets, so the tooltip agrees with the icon.
+
+Snapshot replies still refresh `lastSnapshot` and the failure badge, and they
+replace the membership sets when they are provably fresh. Each fetch captures
+a membership epoch at its start. The controller bumps the epoch on every
+event-driven membership change and discards replies from older epochs. A
+stale reply can no longer clear the blinker or resurrect a removed item. The
+initial snapshot still seeds items the daemon hosted before the app
+subscribed.
+
+Tests found an unrelated fixture bug: `QueueStore(databaseURL:
+URL(fileURLWithPath: ":memory:"))` does not give a private in-memory
+database. URL path conversion drops the colon, so GRDB opened a literal
+`:memory:` file in the working directory. The file persisted across test runs
+and collected stale queued items, which made the controller sit in the
+working state forever. Both test helpers now use a unique temporary
+directory, and the stray files are deleted.
+
+## Verification
+
+- `WIKIFS_APP_TESTS=1 swift test --filter MenuBarItemLintBlinkerTests` —
+  4 tests pass in ~0.5 s. Covers page-level lint, whole-wiki lint,
+  extraction parity, enqueue-to-blink timing, and the stale-snapshot race
+  with a gated snapshot engine.
+- `WIKIFS_APP_TESTS=1 swift test --filter MenuBarItemMaintenanceMenuTests` —
+  2 tests pass.
+- `make build` — clean.
+- `make test` — full default suite passes (4232 tests, 460 suites). The
+  opt-in app-test suites that host AppKit views are not part of CI; they run
+  locally per `scripts/test-vm.sh`.


### PR DESCRIPTION
## Problem

Starting a lint operation did not reliably start the menu-bar activity
blinker (issue #1222). The transient "Lint queued" hint appeared, so the
`.enqueued` event reached `MenuBarItemController`. The icon still stayed
idle while the lint sat queued or running.

## Root cause

`updateIcon()` derived the working state only from
`lastSnapshot.activeItems`. Every queue event spawned an async snapshot RPC,
and the icon waited on that reply. The reply can disagree with the event:

- A fetch that started before an enqueue can return after it. The reply
  shows the pre-enqueue state and erases the new item.
- Unstructured fetch tasks apply in completion order, not start order.

The pre-fix code applied every reply and re-derived the icon, so a stale
reply cleared (or never set) the working state. The event the user actually
saw — the hint — had already arrived.

## Fix

`MenuBarItemController` now records active items from the events
themselves:

- `.enqueued` inserts the item into `queuedItemIDs`.
- `.started` moves it to `runningItemIDs`.
- `.completed`, `.failed`, and `.cancelled` remove it.

`updateIcon()` reads these sets, so the blinker starts on the enqueue event
itself. Tooltip counts come from the same sets, so the tooltip always agrees
with the icon.

Snapshot replies still refresh `lastSnapshot` and the failure badge, and
they replace the membership sets when they are provably fresh. Each fetch
captures a membership epoch at its start. Membership changes bump the epoch
and discard replies from older epochs. A stale reply can no longer clear the
blinker or resurrect a removed item. The initial snapshot still seeds items
the daemon hosted before the app subscribed.

Ingestion and extraction keep working through the same path; the membership
is queue-agnostic.

## Fixture fix found by the new tests

`QueueStore(databaseURL: URL(fileURLWithPath: ":memory:"))` does not give a
private in-memory database. URL path conversion drops the colon, so GRDB
opened a literal `:memory:` file in the working directory. The file
persisted across test runs and collected stale queued items. Both test
helpers now create a unique temporary directory, and the stray files are
deleted.

## Tests

New `MenuBarItemLintBlinkerTests` (opt-in app target, AppKit-hosted —
local/VM run per repo convention, not CI):

- A page-level lint enqueue starts the blinker. Cancel stops it.
- A whole-wiki lint (`lintPageIDs == []`) starts the blinker.
- Extraction enqueue and cancel still drive the blinker.
- The race: a pre-enqueue snapshot fetch returns empty data after the
  enqueue event. The epoch guard discards it, the blinker stays on, and
  completion stops it. Uses a gated snapshot engine for deterministic
  fetch/event interleaving.

`WIKIFS_APP_TESTS=1 swift test --filter MenuBarItemLintBlinkerTests` — 4
pass. `make build` and `make test` (full default suite) pass.

Closes: #1222
