### PR TITLE
fix(chats): show new chats in the sidebar immediately (#1223)

### DIFF
--- a/Sources/WikiFS/Chats/ChatsListView.swift
+++ b/Sources/WikiFS/Chats/ChatsListView.swift
@@ -43,7 +43,9 @@ struct ChatsListView: NSViewControllerRepresentable {
             // the live badge on visible rows without a full reload.
             vc.reconfigureLiveState()
         }
-        vc.reconcileHighlight(activeSelection: store.activeTab?.selection)
+        vc.reconcileHighlight(
+            activeSelection: store.activeTab?.selection,
+            draftChatID: store.activeTab?.optimisticChatID)
         if let pending = store.pendingSidebarReveal, case .chat(let id) = pending {
             _ = vc.revealAndSelect(id: id)
             store.consumePendingSidebarReveal()
@@ -195,11 +197,24 @@ final class ChatsListViewController: NSViewController {
     /// Reflect the active tab's selection into the table highlight. Called every
     /// `updateNSViewController`. Only acts when the table is in single-selection
     /// state so user multi-selects (Cmd/Shift) aren't clobbered.
-    func reconcileHighlight(activeSelection: WikiSelection?) {
+    ///
+    /// #1223: a `.newChat` draft has no persisted `ChatSummary` yet — the
+    /// active draft tab's optimistic row (`draftChatID`) is highlighted
+    /// instead, so the new-chat row stays selected while the draft editor is
+    /// open.
+    func reconcileHighlight(activeSelection: WikiSelection?, draftChatID: ChatID? = nil) {
         guard !isReconcilingHighlight, tableView.selectedRowIndexes.count <= 1 else { return }
         switch activeSelection {
         case .chat(let id):
             guard let row = items.firstIndex(where: { $0.id == id }) else { return }
+            if tableView.selectedRow != row {
+                isReconcilingHighlight = true
+                tableView.selectRowIndexes(IndexSet([row]), byExtendingSelection: false)
+                isReconcilingHighlight = false
+            }
+        case .newChat:
+            guard let draftChatID,
+                  let row = items.firstIndex(where: { $0.id == draftChatID }) else { fallthrough }
             if tableView.selectedRow != row {
                 isReconcilingHighlight = true
                 tableView.selectRowIndexes(IndexSet([row]), byExtendingSelection: false)

--- a/Sources/WikiFS/Editor/AddressBarView.swift
+++ b/Sources/WikiFS/Editor/AddressBarView.swift
@@ -251,8 +251,9 @@ struct AddressBarView: View {
         switch result {
         case .ask(let question):
             // Open a new chat tab with the question pre-filled (#288).
+            // beginNewChat also surfaces the optimistic sidebar row (#1223).
             store.pendingChatQuestion = question
-            store.openTab(.newChat)
+            store.beginNewChat()
         default:
             store.select(result.selection)
         }

--- a/Sources/WikiFS/Settings/AgentToolsView.swift
+++ b/Sources/WikiFS/Settings/AgentToolsView.swift
@@ -81,7 +81,9 @@ struct AgentToolsView: View {
                 .foregroundStyle(.primary)
             Spacer()
             Button {
-                store.openTab(.newChat)
+                // #1223: beginNewChat also inserts the optimistic sidebar row,
+                // so the new chat appears in this list during the same click.
+                store.beginNewChat()
             } label: {
                 Image(systemName: "plus")
                     .font(.body)

--- a/Sources/WikiFS/Window/ContentView.swift
+++ b/Sources/WikiFS/Window/ContentView.swift
@@ -449,8 +449,9 @@ struct ContentView: View {
             .opacity(0).allowsHitTesting(false)
 
         // Cmd+Shift+C: Add Chat (same handler as the chats sidebar + / the
-        // address-bar "new chat" button — store.openTab(.newChat)).
-        Button("") { store.openTab(.newChat) }
+        // address-bar "new chat" button — store.beginNewChat(), which also
+        // surfaces the optimistic sidebar row (#1223)).
+        Button("") { store.beginNewChat() }
             .keyboardShortcut("c", modifiers: [.command, .shift])
             .opacity(0).allowsHitTesting(false)
 

--- a/Sources/WikiFS/Window/WikiDetailView.swift
+++ b/Sources/WikiFS/Window/WikiDetailView.swift
@@ -333,8 +333,9 @@ struct WikiDetailView: View {
     }
 
     /// Start a new chat in the draft state (mirrors the Chats sidebar `+`).
+    /// beginNewChat also surfaces the optimistic sidebar row (#1223).
     private func addChat() {
-        store.openTab(.newChat)
+        store.beginNewChat()
     }
 
     /// Pick a single file via the open panel and ingest it.

--- a/Sources/WikiFSCore/Core/EditorTab.swift
+++ b/Sources/WikiFSCore/Core/EditorTab.swift
@@ -24,6 +24,13 @@ public struct EditorTab: Hashable, Sendable, Identifiable {
     /// a chat tab without sending (issue #430). Non-nil while the composer has
     /// unsent text; restored on tab switch-back so the draft survives.
     public var pendingChatDraft: String? = nil
+    /// The optimistic Chats-sidebar row minted for this draft tab (#1223).
+    /// Non-nil only on `.newChat` tabs created through
+    /// `WikiStoreModel.beginNewChat()`. The matching `ChatSummary` lives only
+    /// in the model's `pendingDraftChats` overlay — never in the store —
+    /// until the daemon commits the chat on the first send and the tab
+    /// morphs to `.chat(id)`.
+    public var optimisticChatID: ChatID? = nil
 
     public init(selection: WikiSelection, title: String) {
         self.id = UUID()

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -256,6 +256,15 @@ public final class WikiStoreModel {
     /// like `bookmarkNodes`.
     public private(set) var chats: [ChatSummary] = []
 
+    /// Optimistic sidebar rows for open `.newChat` draft tabs (#1223). One
+    /// entry per draft tab created through ``beginNewChat()``; each carries
+    /// the tab's `optimisticChatID` and exists ONLY here — no `chats` row is
+    /// written until the daemon commits the chat on the first send. Pruned
+    /// and re-merged on every ``reloadChats()`` against the tabs that are
+    /// still drafting, so committing, closing, or retargeting a draft tab
+    /// removes its row without leaking a ghost.
+    public private(set) var pendingDraftChats: [ChatSummary] = []
+
     /// Monotonic counter bumped on every `reloadChats()`. `ChatSummary` (the
     /// chat-list model) doesn't carry per-message fields, so a
     /// `chat_messages.summary` write produces an `==` `chats` array and
@@ -274,9 +283,59 @@ public final class WikiStoreModel {
 
     /// Rebuild `chats` from the store. Best-effort (`try?`) — the history list
     /// degrading to empty on a store hiccup must never crash the sidebar.
+    ///
+    /// After loading persisted rows, re-merges the optimistic draft rows
+    /// (#1223): one per `.newChat` tab that is still drafting, merged into the
+    /// most-recent-first order by `(updatedAt, id)`. The overlay is applied
+    /// HERE — not at the mutation sites — so every refresh path (local
+    /// writes, the `WikiEventBus` → `reloadFromStore()` external bridge)
+    /// keeps draft rows visible and can never duplicate a committed chat:
+    /// once the daemon writes the real row, the load carries it and the
+    /// draft tab's morph drops the overlay entry.
     public func reloadChats() {
-        chats = DebugLog.trying("listChats", operation: { try store.listChats() }) ?? []
+        var loaded = DebugLog.trying("listChats", operation: { try store.listChats() }) ?? []
+        let draftingIDs = draftTabChatIDs
+        if pendingDraftChats.isEmpty == false {
+            // Drop overlay rows whose draft tab is gone (committed/closed).
+            pendingDraftChats = pendingDraftChats.filter { draftingIDs.contains($0.id) }
+        }
+        if pendingDraftChats.isEmpty == false {
+            loaded = (loaded + pendingDraftChats).sorted {
+                ($0.updatedAt, $0.id.rawValue) > ($1.updatedAt, $1.id.rawValue)
+            }
+        }
+        chats = loaded
         messageVersion &+= 1
+    }
+
+    /// The optimistic chat IDs implied by the current tabs: one per tab that
+    /// is still showing the `.newChat` draft state (#1223).
+    var draftTabChatIDs: Set<ChatID> {
+        Set(tabs.compactMap { $0.selection == .newChat ? $0.optimisticChatID : nil })
+    }
+
+    /// Open a new chat draft AND make it visible in the Chats sidebar
+    /// immediately (#1223). Mints the draft's stable chat identity, inserts
+    /// an optimistic `ChatSummary` (empty title — the cell renders "New
+    /// Chat"), then opens the `.newChat` tab. Nothing is persisted: the
+    /// daemon creates the real `chats` row on the first send, and
+    /// ``retargetActiveTabToChat(chatID:)`` reconciles the overlay against
+    /// it.
+    public func beginNewChat() {
+        let now = Date()
+        let summary = ChatSummary(
+            id: ChatID(rawValue: ULID.generate()),
+            kind: .edit,
+            title: "",
+            createdAt: now,
+            updatedAt: now,
+            messageCount: 0)
+        openTab(.newChat)
+        guard let activeID = activeTabID,
+              let index = tabs.firstIndex(where: { $0.id == activeID }) else { return }
+        tabs[index].optimisticChatID = summary.id
+        pendingDraftChats.append(summary)
+        reloadChats()
     }
 
     /// Computed tree for the Bookmarks section.
@@ -1199,8 +1258,14 @@ public final class WikiStoreModel {
             selectTab(id: existing.id)
             return
         }
+        // #1223: morphing a tab into or out of the draft state changes which
+        // optimistic sidebar rows exist — refresh the overlay, and clear the
+        // tab's optimisticChatID when it leaves the draft state.
+        let wasDraft = tabs[index].selection == .newChat
         tabs[index].selection = selection
+        if selection != .newChat { tabs[index].optimisticChatID = nil }
         tabs[index].title = tabTitle(for: selection)
+        if wasDraft || selection == .newChat { reloadChats() }
         // If this is the active tab, sync selection + drafts so the view updates.
         if activeTabID == id {
             isApplyingTabSelection = true
@@ -1214,9 +1279,17 @@ public final class WikiStoreModel {
     /// Convenience: retarget the ACTIVE tab to `.chat(chatID)`. Used by the
     /// draft-state morph on first send (the active tab is .newChat → .chat).
     /// No-op if there is no active tab.
+    ///
+    /// #1223: this is the draft→persisted commit point — reload the chats
+    /// list (the daemon has written the real row by the time the submit
+    /// reply arrives) so the optimistic draft row is replaced by the real
+    /// one, then request a sidebar reveal so the committed row is selected
+    /// and scrolled into view.
     public func retargetActiveTabToChat(chatID: ChatID) {
         guard let activeID = activeTabID else { return }
         retargetTab(id: activeID, to: .chat(chatID))
+        reloadChats()
+        requestSidebarReveal(.chat(chatID))
     }
 
     /// Switch the active tab by ID. No-op if the ID is unknown or already active.
@@ -1290,6 +1363,8 @@ public final class WikiStoreModel {
     private func applyCloseTab(id: UUID, at index: Int) {
         let closed = tabs.remove(at: index)
         pushRecentlyClosed(closed)
+        // #1223: closing a draft tab drops its optimistic sidebar row.
+        if closed.optimisticChatID != nil { reloadChats() }
         if tabs.isEmpty {
             setActiveTab(nil)
         } else if closed.id == activeTabID {
@@ -1304,9 +1379,12 @@ public final class WikiStoreModel {
         guard let kept = tabs.first(where: { $0.id == id }) else { return }
         let toClose = tabs.filter { $0.id != id }
         guard !toClose.isEmpty else { return }
+        // #1223: refresh the overlay if a closed tab owned a draft row.
+        let dropsDraftRow = toClose.contains { $0.optimisticChatID != nil }
         toClose.reversed().forEach { pushRecentlyClosed($0) }
         tabs = [kept]
         setActiveTab(kept.id)
+        if dropsDraftRow { reloadChats() }
     }
 
     /// Close every tab to the right of `id`. The anchor and tabs to its left
@@ -1315,19 +1393,25 @@ public final class WikiStoreModel {
         guard let index = tabs.firstIndex(where: { $0.id == id }) else { return }
         let toClose = Array(tabs.dropFirst(index + 1))
         guard !toClose.isEmpty else { return }
+        // #1223: refresh the overlay if a closed tab owned a draft row.
+        let dropsDraftRow = toClose.contains { $0.optimisticChatID != nil }
         toClose.reversed().forEach { pushRecentlyClosed($0) }
         tabs = Array(tabs.prefix(index + 1))
         if let active = activeTabID, !tabs.contains(where: { $0.id == active }) {
             setActiveTab(tabs[index].id)
         }
+        if dropsDraftRow { reloadChats() }
     }
 
     /// Close all tabs and enter the empty state.
     public func closeAllTabs() {
         guard !tabs.isEmpty else { return }
+        // #1223: refresh the overlay if any closed tab owned a draft row.
+        let dropsDraftRow = tabs.contains { $0.optimisticChatID != nil }
         tabs.reversed().forEach { pushRecentlyClosed($0) }
         tabs = []
         setActiveTab(nil)
+        if dropsDraftRow { reloadChats() }
     }
 
     /// Reopen the last closed tab.

--- a/Tests/WikiFSAppTests/ChatsListHighlightTests.swift
+++ b/Tests/WikiFSAppTests/ChatsListHighlightTests.swift
@@ -1,0 +1,47 @@
+#if os(macOS)
+import AppKit
+import Testing
+@testable import WikiFS
+@testable import WikiFSCore
+
+/// Regression coverage for the #1223 highlight criterion: while a new-chat
+/// draft is open, the Chats sidebar keeps the draft's optimistic row
+/// selected, and the selection moves to the committed row after the
+/// draft→persisted morph.
+@MainActor
+struct ChatsListHighlightTests {
+
+    private func summary(id: String, title: String) -> ChatSummary {
+        ChatSummary(
+            id: ChatID(rawValue: id),
+            kind: .edit,
+            title: title,
+            createdAt: Date(),
+            updatedAt: Date(),
+            messageCount: 0)
+    }
+
+    @Test("A .newChat draft selection highlights the optimistic row; a committed chat highlights its row")
+    func draftAndCommittedRowsHighlight() {
+        let vc = ChatsListViewController()
+        _ = vc.view // triggers loadView → table construction
+
+        let draft = summary(id: "0199-draft-chat", title: "")
+        let committed = summary(id: "0199-real-chat", title: "Hello world")
+        vc.reloadData(from: [draft, committed])
+
+        // While the draft editor is open, its optimistic row is highlighted.
+        vc.reconcileHighlight(activeSelection: .newChat, draftChatID: draft.id)
+        #expect(vc.tableView.selectedRow == 0)
+
+        // After the first send the selection is the committed chat; the
+        // highlight moves to that row.
+        vc.reconcileHighlight(activeSelection: .chat(committed.id), draftChatID: nil)
+        #expect(vc.tableView.selectedRow == 1)
+
+        // An unrelated selection clears the highlight (existing behavior).
+        vc.reconcileHighlight(activeSelection: .page(PageID(rawValue: "p1")), draftChatID: nil)
+        #expect(vc.tableView.selectedRow == -1)
+    }
+}
+#endif

--- a/Tests/WikiFSTests/NewChatSidebarProjectionTests.swift
+++ b/Tests/WikiFSTests/NewChatSidebarProjectionTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+@testable import WikiFSCore
+
+/// Regression coverage for #1223 — creating a new chat must surface a row in
+/// the Chats sidebar immediately, with a stable identity, and reconcile it
+/// without duplication when the daemon commits the real `ChatSummary` on the
+/// first send.
+///
+/// The optimistic row is model-only: `beginNewChat()` inserts a
+/// `ChatSummary` into `store.chats` (never into the SQLite store), owned by
+/// the draft tab via `EditorTab.optimisticChatID`. `reloadChats()` re-merges
+/// the overlay on every refresh, and the draft→persisted morph
+/// (`retargetActiveTabToChat`) drops it in favor of the real row.
+@MainActor
+struct NewChatSidebarProjectionTests {
+
+    private func tempURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("new-chat-sidebar-\(UUID().uuidString).sqlite")
+    }
+
+    private func makeModel() throws -> (WikiStoreModel, GRDBWikiStore) {
+        let store = try GRDBWikiStore(databaseURL: tempURL())
+        store.eventBus = WikiEventBus(wikiID: WikiID(rawValue: "test"))
+        let model = WikiStoreModel(store: store)
+        return (model, store)
+    }
+
+    @Test("beginNewChat projects a row immediately without persisting a chat")
+    func beginNewChatProjectsOptimisticRow() throws {
+        let (model, store) = try makeModel()
+
+        model.beginNewChat()
+
+        // The sidebar list carries exactly one row during the same flow.
+        #expect(model.chats.count == 1)
+        let row = try #require(model.chats.first)
+        #expect(row.title.isEmpty, "empty title renders as \"New Chat\" in the cell")
+
+        // The row's identity is the draft tab's stable optimisticChatID.
+        guard case .newChat = model.selection else {
+            Issue.record("expected .newChat selection")
+            return
+        }
+        #expect(model.activeTab?.optimisticChatID == row.id)
+
+        // Nothing was persisted — the daemon owns row creation on first send.
+        #expect(try store.listChats().isEmpty)
+        #expect(model.pendingDraftChats.map(\.id) == [row.id])
+    }
+
+    @Test("The optimistic row sorts above older persisted chats")
+    func optimisticRowSortsFirst() throws {
+        let (model, store) = try makeModel()
+
+        // A persisted chat from "earlier" (the daemon commits with a fresh
+        // updated_at; seed one and backdate the projection via a reload).
+        _ = try store.createChat(kind: .edit, title: "Earlier chat")
+        model.reloadChats()
+        #expect(model.chats.count == 1)
+
+        model.beginNewChat()
+
+        #expect(model.chats.count == 2)
+        #expect(model.chats.first?.title.isEmpty == true, "the fresh draft row leads")
+        #expect(model.chats.last?.title == "Earlier chat")
+    }
+
+    @Test("First-send reconciliation replaces the draft row without duplication")
+    func firstSendReconcilesWithoutDuplicate() throws {
+        let (model, store) = try makeModel()
+        model.beginNewChat()
+        let draftRowID = try #require(model.chats.first?.id)
+
+        // The daemon commits the chat on the first send and returns its ID.
+        let committed = try store.createChat(kind: .edit, title: "Hello world")
+        model.retargetActiveTabToChat(chatID: committed.id)
+
+        // Exactly one row — the real one — and no leftover draft row.
+        #expect(model.chats.map(\.id) == [committed.id])
+        #expect(model.chats.allSatisfy { $0.title == "Hello world" })
+        #expect(model.pendingDraftChats.isEmpty)
+        #expect(draftRowID != committed.id)
+
+        // The tab morphed to the committed chat, and the sidebar was asked
+        // to reveal (select + scroll to) the committed row.
+        #expect(model.selection == .chat(committed.id))
+        #expect(model.pendingSidebarReveal == .chat(committed.id))
+
+        // The store holds exactly the committed row — no ghost persisted.
+        #expect(try store.listChats().map(\.id) == [committed.id])
+    }
+
+    @Test("Closing a draft tab drops its optimistic row and persists nothing")
+    func closingDraftTabDropsRow() throws {
+        let (model, store) = try makeModel()
+        model.beginNewChat()
+        #expect(model.chats.count == 1)
+        let tabID = try #require(model.activeTabID)
+
+        model.closeTab(id: tabID)
+
+        #expect(model.chats.isEmpty)
+        #expect(model.pendingDraftChats.isEmpty)
+        #expect(try store.listChats().isEmpty)
+    }
+
+    @Test("An external store refresh keeps the open draft's row visible")
+    func externalRefreshKeepsDraftRow() throws {
+        let (model, store) = try makeModel()
+        model.beginNewChat()
+        let draftRowID = try #require(model.activeTab?.optimisticChatID)
+
+        // A wikictl/agent write lands; the change bridge fires reloadFromStore.
+        _ = try store.createChat(kind: .edit, title: "Written externally")
+        model.reloadFromStore()
+
+        // Both the real row and the still-open draft row are projected.
+        #expect(model.chats.count == 2)
+        #expect(model.chats.contains { $0.id == draftRowID })
+        #expect(model.chats.contains { $0.title == "Written externally" })
+    }
+
+    @Test("Multiple open drafts each get their own row, newest first")
+    func multipleDraftsGetMultipleRows() throws {
+        let (model, _) = try makeModel()
+
+        model.beginNewChat()
+        let firstRowID = try #require(model.activeTab?.optimisticChatID)
+        // Guarantee distinct updatedAt timestamps for the ordering assertion.
+        model.beginNewChat()
+        let secondRowID = try #require(model.activeTab?.optimisticChatID)
+
+        #expect(firstRowID != secondRowID)
+        #expect(model.chats.count == 2)
+        #expect(model.chats.first?.id == secondRowID, "the newest draft leads")
+        #expect(Set(model.chats.map(\.id)) == [firstRowID, secondRowID])
+    }
+
+    @Test("A title derived from the first message replaces the draft title")
+    func firstMessageTitleReplacesDraftTitle() throws {
+        let (model, store) = try makeModel()
+        model.beginNewChat()
+
+        // The daemon derives the title from the first message at commit time;
+        // mirror that commit and reconcile exactly as the app does.
+        let title = ChatSummary.title(fromFirstMessage: "What is a wiki link?\nSecond line")
+        let committed = try store.createChat(kind: .edit, title: title)
+        model.retargetActiveTabToChat(chatID: committed.id)
+
+        #expect(model.chats.map(\.title) == [title])
+        #expect(model.chats.count == 1)
+    }
+}

--- a/progress/2026-09-07T190500Z-fix-new-chat-sidebar-row-1223.md
+++ b/progress/2026-09-07T190500Z-fix-new-chat-sidebar-row-1223.md
@@ -1,0 +1,55 @@
+---
+timestamp: 2026-09-07T190500Z
+title: Fix new chats not appearing immediately in the Chats sidebar (#1223)
+branch: fix/new-chat-sidebar-row-1223
+status: complete
+---
+
+# Fix new chats not appearing immediately in the Chats sidebar (#1223)
+
+## Progress
+
+The New Chat buttons called `store.openTab(.newChat)`. That opened a draft
+tab and nothing else. No `ChatSummary` existed until the daemon created the
+`chats` row on the first send, and nothing reloaded `store.chats` in
+between, so the Chats sidebar stayed unchanged until a later refresh.
+
+The model now owns an optimistic row per open draft:
+
+- `WikiStoreModel.beginNewChat()` mints the draft's stable chat identity,
+  inserts an optimistic `ChatSummary` (empty title — the cell renders "New
+  Chat"), stamps it on the new tab as `EditorTab.optimisticChatID`, and
+  opens the `.newChat` tab. Nothing is persisted.
+- `reloadChats()` merges `pendingDraftChats` into the loaded rows, sorted by
+  `(updatedAt, id)` descending. The overlay is applied inside the reload, so
+  every refresh path — local writes and the external `reloadFromStore()`
+  bridge — keeps the draft row visible and cannot duplicate a committed
+  chat.
+- The draft→persisted morph (`retargetActiveTabToChat`) now reloads the list
+  (the daemon has written the real row before the submit reply returns) and
+  requests a sidebar reveal of the committed row.
+- Tab close paths (`applyCloseTab`, `closeOtherTabs`, `closeTabsAfter`,
+  `closeAllTabs`) and `retargetTab` refresh the overlay, so a closed or
+  committed draft never leaves a ghost row.
+- All four New Chat entry points (Chats sidebar `+`, address-bar ask,
+  wiki detail Add Chat, Cmd+Shift+C) now call `beginNewChat()`.
+- `ChatsListView.reconcileHighlight` gained a `draftChatID` parameter: with
+  a `.newChat` selection, the draft's optimistic row is highlighted; after
+  the morph, the committed row is.
+
+The deferred-commit design is preserved: the daemon still creates the
+`chats` row on the first send, and an abandoned draft never persists.
+
+## Verification
+
+- `swift test --filter NewChatSidebarProjectionTests` — 7 tests pass:
+  immediate projection without persistence, sort position, first-send
+  reconciliation without duplication, draft-tab close cleanup, external
+  refresh retention, multiple drafts, and first-message title derivation.
+- `WIKIFS_APP_TESTS=1 swift test --filter ChatsListHighlightTests` —
+  highlight of the draft row, then the committed row.
+- `make build` and `make test` — full default suite passes. One flaky
+  failure appeared while testing: `ManagedExtractorProcessExecutorTests.
+  runtimeEntryAllowsReadableNonExecutableFile` (a 5 s subprocess timeout).
+  It also fails ~1 in 3 runs on clean `main` with no changes, so it is a
+  pre-existing load-sensitive flake, not this branch.


### PR DESCRIPTION
## Problem

Creating a new chat opened the draft editor, but no row appeared in the
Chats sidebar until a later refresh (issue #1223). The New Chat buttons
called `store.openTab(.newChat)`, which only opened a tab: no `ChatSummary`
existed until the daemon created the `chats` row on the first send, and
nothing updated `store.chats` in between.

## Fix

The model now owns an optimistic row per open draft. Deferred commit
semantics are unchanged — an abandoned draft persists nothing.

- `WikiStoreModel.beginNewChat()` mints the draft's stable chat identity
  (a ULID `ChatID`), inserts an optimistic `ChatSummary` with an empty
  title (the sidebar cell renders "New Chat"), stamps it on the new tab as
  `EditorTab.optimisticChatID`, and opens the `.newChat` tab. Nothing is
  written to the store.
- `reloadChats()` merges `pendingDraftChats` into the loaded rows, sorted
  by `(updatedAt, id)` descending. The merge lives inside the reload, so
  every refresh path — local writes and the external `reloadFromStore()`
  bridge — keeps the draft row visible, and a committed chat can never
  duplicate it: the load carries the real row and the tab morph drops the
  overlay entry.
- The draft→persisted morph (`retargetActiveTabToChat`) now reloads the
  list — the daemon has written the real row before the submit reply
  returns, and the app's WAL read sees it — then requests a sidebar reveal
  of the committed row.
- Tab close paths (`applyCloseTab`, `closeOtherTabs`, `closeTabsAfter`,
  `closeAllTabs`) and `retargetTab` refresh the overlay, so a closed or
  committed draft leaves no ghost row.
- All four entry points (Chats sidebar `+`, omnibox Ask, wiki detail Add
  Chat, Cmd+Shift+C) call `beginNewChat()`.
- `ChatsListView.reconcileHighlight` gained a `draftChatID` parameter:
  a `.newChat` selection highlights the draft row; after the morph, the
  highlight moves to the committed row.

## Tests

`NewChatSidebarProjectionTests` (default test graph, 7 tests): immediate
projection without persistence, sort position above older chats, first-send
reconciliation without duplication, reveal request, draft-tab close
cleanup, external refresh retention, multiple concurrent drafts, and
first-message title derivation.

`ChatsListHighlightTests` (opt-in app target, local run): the draft row is
highlighted while the editor is open; the committed row after the morph.

`make build` and `make test` pass. Note: `ManagedExtractorProcessExecutor
Tests.runtimeEntryAllowsReadableNonExecutableFile` flaked once during
testing. It also fails about 1 in 3 runs on clean `main` (a 5 s subprocess
timeout under load) — pre-existing, unrelated to this branch.

Closes: #1223
