### PR TITLE
test(extraction): verify bun launcher process cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.4.0'
       - name: Select Xcode (mlx-swift needs Swift 6.3)
         run: |
           # macos-latest may default the `swift` command to the CLT toolchain

--- a/Tests/WikiFSTests/ManagedExtractorProcessExecutorTests.swift
+++ b/Tests/WikiFSTests/ManagedExtractorProcessExecutorTests.swift
@@ -182,6 +182,45 @@ struct ManagedExtractorProcessExecutorTests {
         }
     }
 
+    /// Issue #1217: the production login-shell resolution and real bun runtime
+    /// preserve terminal-frame completion and process-group cleanup.
+    @Test func bunRuntimeCompletesTerminalFrameAndReapsChild() async throws {
+        let bun = try ExtractorRuntimeName(validating: "bun")
+        guard case .resolved(let resolution) = await RuntimeCommandLocator().locate(bun) else {
+            // Bun is optional for local development. CI installs it so this
+            // availability-gated verification runs there.
+            return
+        }
+        let fixture = try BunFixture(runtimeResolution: resolution)
+        defer { fixture.cleanup() }
+        let frames = FrameCollector()
+        let before = try fixture.runtimeDirectorySnapshots()
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        let result = try await ManagedExtractorProcessExecutor().execute(
+            fixture.operation,
+            onFrame: { frames.append($0) })
+
+        #expect(start.duration(to: clock.now) < .seconds(30))
+        #expect(result.executableURL == resolution.executableURL)
+        #expect(result.progressEventCount == 1)
+        #expect(frames.values.count == 2)
+        #expect(result.terminalFrame.isTerminal)
+        #expect(try String(contentsOf: fixture.outputURL, encoding: .utf8) == "# Bun fixture\n")
+        guard case .signaled = result.terminationCause else {
+            Issue.record("expected bun to be signaled after its terminal frame, got \(result.terminationCause)")
+            return
+        }
+
+        let childPID = try #require(fixture.childPID(from: result.standardError))
+        #expect(await processIsGone(childPID, timeout: .seconds(30)))
+        #expect(try fixture.runtimeDirectorySnapshots() == before)
+        for directory in fixture.runtimeDirectories {
+            #expect(try fixture.permissions(of: directory) == 0o700)
+        }
+    }
+
     /// Package payload rejects symlinks in every launch mode.
     @Test func symlinkedPackageEntryIsRejected() async throws {
         let fixture = try Fixture(
@@ -298,11 +337,14 @@ struct ManagedExtractorProcessExecutorTests {
         }
     }
 
-    private func processIsGone(_ rawPID: Int32?) async -> Bool {
+    private func processIsGone(
+        _ rawPID: Int32?,
+        timeout: Duration = .seconds(2)
+    ) async -> Bool {
         guard let rawPID,
               let pid = ProcessSignalSafety.PositivePID(rawValue: rawPID) else { return true }
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
+        let deadline = clock.now.advanced(by: timeout)
         while clock.now < deadline {
             if ProcessIdentityObservation.observe(processID: pid) == nil { return true }
             do { try await Task.sleep(for: .milliseconds(20)) }
@@ -310,6 +352,161 @@ struct ManagedExtractorProcessExecutorTests {
         }
         return ProcessIdentityObservation.observe(processID: pid) == nil
     }
+}
+
+private final class BunFixture: @unchecked Sendable {
+    let root: URL
+    let operationRoot: URL
+    let packageRoot: URL
+    let homeRoot: URL
+    let temporaryRoot: URL
+    let cacheRoot: URL
+    let outputURL: URL
+    let operation: ManagedExtractorProcessRequest
+
+    var runtimeDirectories: [URL] { [homeRoot, temporaryRoot, cacheRoot] }
+
+    init(runtimeResolution: RuntimeCommandResolution) throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("managed-extractor-bun-\(UUID().uuidString)", isDirectory: true)
+        operationRoot = root.appendingPathComponent("operation", isDirectory: true)
+        packageRoot = operationRoot.appendingPathComponent("package", isDirectory: true)
+        homeRoot = operationRoot.appendingPathComponent("home", isDirectory: true)
+        temporaryRoot = operationRoot.appendingPathComponent("tmp", isDirectory: true)
+        cacheRoot = operationRoot.appendingPathComponent("cache", isDirectory: true)
+        let inputURL = operationRoot.appendingPathComponent("input/source.bin")
+        outputURL = operationRoot.appendingPathComponent("output/result.md")
+        for directory in [
+            packageRoot,
+            homeRoot,
+            temporaryRoot,
+            cacheRoot,
+            inputURL.deletingLastPathComponent(),
+            outputURL.deletingLastPathComponent(),
+        ] {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700])
+            guard chmod(directory.path, 0o700) == 0 else { throw POSIXError(.EIO) }
+        }
+        try Data("fixture".utf8).write(to: inputURL)
+
+        let entryPath = try ExtractorRelativePath(validating: "bin/fixture.js")
+        let entryURL = packageRoot.appendingPathComponent(entryPath.rawValue)
+        try FileManager.default.createDirectory(
+            at: entryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        let scriptBytes = Data(Self.script.utf8)
+        try scriptBytes.write(to: entryURL)
+        guard chmod(entryURL.path, 0o400) == 0 else { throw POSIXError(.EIO) }
+
+        let manifest = try ExtractorManifest(
+            manifestRevision: .v1,
+            packageID: ExtractorPackageID(validating: "org.example.bun-fixture"),
+            version: ExtractorPackageVersion(validating: "1.0.0"),
+            displayName: "Bun Fixture",
+            protocolRevision: .v1,
+            entryPoint: entryPath,
+            launch: .runtime(command: runtimeResolution.command, arguments: []),
+            registrations: [ExtractorRegistration(
+                id: ExtractorRegistrationID(validating: "docx"),
+                displayName: "DOCX",
+                kinds: [.docx],
+                mimeTypes: [ExtractorMIMEType(validating:
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document")])],
+            capabilities: [],
+            files: [ExtractorPackageFile(path: entryPath, digest: ExtractorSHA256.digest(scriptBytes))],
+            limits: ExtractorOperationLimits(
+                maximumInputByteCount: 1_024,
+                maximumMarkdownOutputByteCount: 16 * 1_024,
+                maximumDurationMilliseconds: 60_000,
+                maximumProgressEventCount: 8))
+        let revision = ExtractorPackageRevisionID(
+            packageID: manifest.packageID,
+            version: manifest.version,
+            digest: try manifest.packageDigest())
+        let request = try ExtractorProtocolRequest(
+            requestID: ExtractorRequestID(),
+            protocolRevision: .v1,
+            kind: .docx,
+            mimeType: ExtractorMIMEType(validating:
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+            originalFilename: "source.docx",
+            inputPath: ExtractorRelativePath(validating: "input/source.bin"),
+            outputPath: ExtractorRelativePath(validating: "output/result.md"),
+            deadlineMillisecondsSince1970: 1_900_000_000_000)
+        operation = ManagedExtractorProcessRequest(
+            revision: revision,
+            manifest: manifest,
+            protocolRequest: request,
+            paths: ManagedExtractorProcessPaths(
+                operationRoot: operationRoot,
+                packageRoot: packageRoot,
+                homeRoot: homeRoot,
+                temporaryRoot: temporaryRoot,
+                privateCacheRoot: cacheRoot),
+            runtimeResolution: runtimeResolution,
+            cancellationGracePeriod: .milliseconds(50))
+    }
+
+    func runtimeDirectorySnapshots() throws -> [String: [String]] {
+        try Dictionary(uniqueKeysWithValues: runtimeDirectories.map { directory in
+            let contents = try FileManager.default.subpathsOfDirectory(atPath: directory.path).sorted()
+            return (directory.lastPathComponent, contents)
+        })
+    }
+
+    func permissions(of directory: URL) throws -> Int {
+        let attributes = try FileManager.default.attributesOfItem(atPath: directory.path)
+        return try #require(attributes[.posixPermissions] as? Int) & 0o777
+    }
+
+    func childPID(from standardError: Data) -> Int32? {
+        guard let text = String(data: standardError, encoding: .utf8) else { return nil }
+        return text.split(separator: "\n").lazy.compactMap { line -> Int32? in
+            guard line.hasPrefix("CHILD_PID=") else { return nil }
+            return Int32(line.dropFirst("CHILD_PID=".count))
+        }.first
+    }
+
+    func cleanup() {
+        guard FileManager.default.fileExists(atPath: root.path) else { return }
+        do { try FileManager.default.removeItem(at: root) }
+        catch { Issue.record("Bun extractor fixture cleanup failed: \(error)") }
+    }
+
+    private static let script = #"""
+    const { mkdirSync, writeFileSync } = require("node:fs");
+    const { spawn } = require("node:child_process");
+
+    const chunks = [];
+    process.stdin.setEncoding("utf-8");
+    process.stdin.on("data", (chunk) => chunks.push(chunk));
+    process.stdin.on("end", () => {
+      const request = JSON.parse(chunks.join(""));
+      const markdown = "# Bun fixture\n";
+      mkdirSync("output", { recursive: true });
+      writeFileSync(request.outputPath, markdown);
+      const child = spawn("/bin/sleep", ["3600"], { stdio: "ignore" });
+      process.stderr.write("CHILD_PID=" + child.pid + "\n");
+      const frame = (kind, payload) =>
+        process.stdout.write(JSON.stringify({ kind, payload }) + "\n");
+      frame("progress", {
+        requestID: request.requestID,
+        completedUnitCount: 1,
+        totalUnitCount: 1,
+        message: "complete",
+      });
+      frame("result", {
+        requestID: request.requestID,
+        outputPath: request.outputPath,
+        markdownByteCount: Buffer.byteLength(markdown),
+      });
+      setInterval(() => {}, 60_000);
+    });
+    """#
 }
 
 private final class FrameCollector: @unchecked Sendable {

--- a/progress/2026-09-08T024450Z-bun-launcher-verification-test.md
+++ b/progress/2026-09-08T024450Z-bun-launcher-verification-test.md
@@ -1,0 +1,39 @@
+---
+timestamp: 2026-09-08T024450Z
+title: Bun launcher verification test
+branch: feature/issue-1217-bun-launcher-test
+status: complete
+---
+
+# Bun launcher verification test
+
+Implements the suggested automated test from
+[#1217](https://github.com/tqbf/selfdrivingwiki/issues/1217).
+
+## Progress
+
+`ManagedExtractorProcessExecutorTests.bunRuntimeCompletesTerminalFrameAndReapsChild`
+resolves bun through the production login-shell locator. The test returns
+cleanly when bun is not available. The macOS Swift CI job installs bun 1.4.0,
+so CI runs the gated path.
+
+The test launches a real bun process with an allowlisted operation environment.
+Its JavaScript entry reads the complete request from standard input and writes
+the requested Markdown output. It starts a long-lived child, records its PID,
+emits one progress frame and one result frame, and then remains alive.
+
+The test confirms that the terminal result completes the operation before its
+60-second limit. It accepts the expected signaled termination after the host
+kills the process group. It also confirms that the child process is gone.
+
+The fixture snapshots the operation home, temporary, and cache directories.
+The test confirms that bun creates no files or directories there. It also
+confirms that each host-created directory keeps mode `0700`.
+
+## Verification
+
+- `swift test --filter ManagedExtractorProcessExecutorTests.bunRuntimeCompletesTerminalFrameAndReapsChild`
+  passes with real bun in 2.342 seconds.
+- `make build` passes.
+- `make test` passes with 4,233 tests in 460 suites. The full suite includes
+  the bun test, which passes in 2.656 seconds.


### PR DESCRIPTION
## Summary

- Add an availability-gated executor test that launches real bun through the production runtime locator.
- Verify terminal-frame completion, process-group child cleanup, stdin EOF handling, and private operation directories.
- Install bun 1.4.0 in the macOS Swift CI job so CI runs the gated test.
- Record the verification in `progress/`.

## Test plan

- `swift test --filter ManagedExtractorProcessExecutorTests.bunRuntimeCompletesTerminalFrameAndReapsChild`
- `make build`
- `make test`

The full local suite passed with 4,233 tests in 460 suites.

Refs #1217
