### PR TITLE
fix(reader): fail loudly on lost document staging races

### DIFF
--- a/Sources/WikiFS/Reader/WikiReaderDocumentOrigin.swift
+++ b/Sources/WikiFS/Reader/WikiReaderDocumentOrigin.swift
@@ -7,13 +7,20 @@ import WikiFSCore
 /// The reader parent document must frame custom-scheme documents
 /// (`renderer-package:` iframes, `wiki-blob:` PDF/HTML frames). WebKit's
 /// custom-scheme CORS enforcement blocks framed custom-scheme loads from an
-/// https parent (proven in Phase 1 hosted probes), so the reader loads via
-/// `loadHTMLString(baseURL:)` under this dedicated scheme instead of the
-/// retired synthetic https origin.
+/// https parent (proven in Phase 1 hosted probes), so the reader loads via a
+/// real navigation under this dedicated scheme instead of the retired
+/// synthetic https origin.
 ///
 /// The host is a fixed sentinel (`reader`), not per-frame: the reader
 /// document is app-authored, not untrusted. Untrusted package content is
 /// isolated by the per-frame `RendererFrameOriginToken` origins.
+///
+/// Each load's document URL carries a `?load=<uuid>` staging token so the
+/// scheme handler serves that navigation **its own** staged document (see
+/// `ReaderDocumentStaging`): overlapping loads cannot cross-consume each
+/// other's HTML, and a staging miss fails the navigation loudly instead of
+/// rendering a silent empty page. The origin (scheme + host + path) is
+/// unchanged by the token; only the query varies per load.
 ///
 /// This origin must never be stamped into any external URL: provider-hosted
 /// media is not embedded inline in the reader (operator decision of
@@ -22,29 +29,85 @@ enum WikiReaderDocumentOrigin {
     static let scheme = "wiki-reader"
     /// The fixed host for the reader parent document.
     static let host = "reader"
-    /// The baseURL for `loadHTMLString`. Pathless so relative fragment links
-    /// resolve against the document root.
-    static var url: URL? {
+    /// Query item name carrying a load's staging token.
+    static let loadTokenQueryItem = "load"
+    /// The document path. Shared by every load; the token lives in the query.
+    static let documentPath = "/document.html"
+
+    /// The document URL for one staged load. Non-optional: every component is
+    /// a constant, so construction cannot fail — the `precondition` pins that
+    /// invariant instead of pretending an impossible optional.
+    static func url(loadToken: UUID) -> URL {
         var components = URLComponents()
         components.scheme = scheme
         components.host = host
-        components.path = "/document.html"
-        return components.url
+        components.path = documentPath
+        components.queryItems = [
+            URLQueryItem(name: loadTokenQueryItem, value: loadToken.uuidString)
+        ]
+        guard let url = components.url else {
+            preconditionFailure("reader document URL construction failed with constant components")
+        }
+        return url
+    }
+
+    /// Extracts the staging token from a document URL, if the URL is a reader
+    /// document URL carrying exactly one syntactically valid `load` query
+    /// item. Anything else (no query, unrelated queries, malformed UUIDs,
+    /// duplicate items) yields `nil` and the scheme task fails loudly.
+    static func loadToken(from url: URL) -> UUID? {
+        guard url.scheme == scheme, url.host == host else { return nil }
+        guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems,
+            items.count == 1,
+            let item = items.first,
+            item.name == loadTokenQueryItem,
+            let value = item.value,
+            let token = UUID(uuidString: value)
+        else { return nil }
+        return token
     }
 
     /// Returns `true` for a fragment link within the reader document.
     ///
-    /// `WKWebView` resolves `href="#target"` against the baseURL. The
-    /// resulting URL must bypass relative source-link routing so WebKit can
-    /// scroll to the target.
+    /// `WKWebView` resolves `href="#target"` against the tokenized baseURL,
+    /// and the resolved URL retains the base's `?load=<uuid>` query. The link
+    /// is same-document exactly when its query is absent or is that one valid
+    /// staging token; unrelated or malformed queries are rejected so they
+    /// cannot masquerade as in-document anchors.
     static func isSameDocumentFragment(_ url: URL) -> Bool {
         guard url.scheme == scheme,
               url.host == host,
               url.fragment != nil,
-              url.query == nil else {
+              isOwnOrEmptyQuery(url),
+              url.path.isEmpty || url.path == documentPath else {
             return false
         }
-        return url.path.isEmpty || url.path == "/document.html"
+        return true
+    }
+
+    /// The query is either absent (a plain anchor) or exactly one
+    /// syntactically valid `load` token — what a fragment link resolved
+    /// against the current tokenized base carries.
+    ///
+    /// Foundation quirk (probed 2026-09-10): `URL(string: "#f", relativeTo:)`
+    /// against a base with a query yields a URL that retains the query in
+    /// `absoluteString`/`query`, but `URLComponents(url:resolvingAgainstBase
+    /// URL:)` returns `nil` for it. Parsing the same absolute string succeeds,
+    /// so fall back to that before treating the URL as query-less.
+    private static func isOwnOrEmptyQuery(_ url: URL) -> Bool {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            ?? URLComponents(string: url.absoluteString)
+        guard let items = components?.queryItems, items.isEmpty == false else {
+            return true
+        }
+        guard items.count == 1,
+              let item = items.first,
+              item.name == loadTokenQueryItem,
+              let value = item.value,
+              UUID(uuidString: value) != nil
+        else { return false }
+        return true
     }
 }
 #endif

--- a/Sources/WikiFS/Reader/WikiReaderDocumentOrigin.swift
+++ b/Sources/WikiFS/Reader/WikiReaderDocumentOrigin.swift
@@ -51,12 +51,14 @@ enum WikiReaderDocumentOrigin {
         return url
     }
 
-    /// Extracts the staging token from a document URL, if the URL is a reader
-    /// document URL carrying exactly one syntactically valid `load` query
-    /// item. Anything else (no query, unrelated queries, malformed UUIDs,
-    /// duplicate items) yields `nil` and the scheme task fails loudly.
+    /// Extracts the staging token from a reader **document** URL, if the URL
+    /// is exactly the document path carrying one syntactically valid `load`
+    /// query item. Anything else — no query, unrelated queries, malformed
+    /// UUIDs, duplicate items, or a different path on the same origin —
+    /// yields `nil` and the scheme task fails loudly; a token can only ever
+    /// be consumed through the exact document URL it was minted for.
     static func loadToken(from url: URL) -> UUID? {
-        guard url.scheme == scheme, url.host == host else { return nil }
+        guard url.scheme == scheme, url.host == host, url.path == documentPath else { return nil }
         guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?
             .queryItems,
             items.count == 1,

--- a/Sources/WikiFS/Reader/WikiReaderDocumentSchemeHandler.swift
+++ b/Sources/WikiFS/Reader/WikiReaderDocumentSchemeHandler.swift
@@ -4,15 +4,144 @@ import WikiFSCore
 
 // pattern: Imperative Shell — serves the app-authored reader document shell.
 
+/// Staging errors surfaced by the reader document scheme handler.
+enum WikiReaderDocumentError: Error {
+    /// A scheme task started for a token with no staged document. The task is
+    /// failed loudly (the navigation delegate then drives the reader's error
+    /// state); fallback bytes are never served.
+    case missingStagedDocument(URL)
+
+    /// A descriptive `NSError` in an app domain, for `didFailWithError`.
+    var nsError: NSError {
+        switch self {
+        case .missingStagedDocument(let url):
+            return NSError(
+                domain: "WikiReaderDocument",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "No staged reader document for \(url.absoluteString)",
+                    NSURLErrorKey: url,
+                ])
+        }
+    }
+}
+
+/// Process-wide, token-keyed staging store for reader documents.
+///
+/// Every load mints a `UUID`; the coordinator stages the converted HTML under
+/// that token and the document URL carries it
+/// (`wiki-reader://reader/document.html?load=<uuid>`), so a navigation can only
+/// ever consume **its own** document. This replaces a single process-wide
+/// pending slot, where two overlapping loads cross-consumed each other's HTML
+/// and the loser was served a silent empty document.
+///
+/// Retention contract (two-tier):
+/// - An entry is **pending** from `stage` until its scheme task first starts,
+///   then **served**. Pending entries are **never evicted** — a
+///   not-yet-dispatched navigation cannot be starved — and are retired by
+///   owner teardown (`forget`/`forgetAll`).
+/// - Served entries are kept for idempotent re-issue (a re-issued task
+///   re-serves the same bytes) and are bounded by an oldest-served LRU cap
+///   (`servedCapacity`). Evicting one downgrades only a hypothetical re-issue
+///   to a loud, logged miss.
+/// - There is deliberately **no forget-on-restage**: retiring a prior token
+///   when a newer load is staged can starve a superseded navigation whose
+///   scheme task dispatches late (`webView.load` returning does not prove
+///   WebKit has dispatched — or will never dispatch — the superseded
+///   navigation's scheme task).
+/// - A miss (`beginServing` returning `nil`) means the caller must fail the
+///   scheme task with `WikiReaderDocumentError.missingStagedDocument`. No code
+///   path serves fallback bytes.
+@MainActor
+enum ReaderDocumentStaging {
+    /// Maximum number of *served* entries retained for idempotent re-issue.
+    static let servedCapacity = 8
+
+    private struct Entry {
+        let bytes: Data
+        var isServed = false
+        var servedRecency = 0
+    }
+
+    private static var entries: [UUID: Entry] = [:]
+    private static var recencyClock = 0
+
+    /// Inserts a *pending* entry for `token`. Staging a newer load never
+    /// touches existing entries (no forget-on-restage).
+    static func stage(_ html: String, token: UUID) {
+        entries[token] = Entry(bytes: Data(html.utf8))
+    }
+
+    /// The single operation the scheme handler calls on task start: on a hit,
+    /// atomically transitions pending→served (refreshing LRU recency if the
+    /// entry was already served), applies oldest-served eviction, and returns
+    /// the bytes. On a miss, returns `nil` so the caller fails the task loudly.
+    ///
+    /// Re-issue is idempotent: a token already served re-serves the same bytes.
+    static func beginServing(token: UUID) -> Data? {
+        guard var entry = entries[token] else { return nil }
+        if entry.isServed == false {
+            entry.isServed = true
+        }
+        recencyClock += 1
+        entry.servedRecency = recencyClock
+        entries[token] = entry
+        evictOldestServed(excluding: token)
+        return entry.bytes
+    }
+
+    /// Removes one token (owner teardown, or nil-load-seam cleanup for a token
+    /// that can never be dispatched).
+    static func forget(token: UUID) {
+        entries.removeValue(forKey: token)
+    }
+
+    /// Removes every token in `tokens` (coordinator teardown retires its own).
+    static func forgetAll(_ tokens: some Sequence<UUID>) {
+        for token in tokens {
+            entries.removeValue(forKey: token)
+        }
+    }
+
+    /// Clears all staged state. Test seam only — production relies on owner
+    /// teardown; the LRU cap bounds growth.
+    static func resetForTesting() {
+        entries.removeAll()
+        recencyClock = 0
+    }
+
+    /// Bounds *served* entries at `servedCapacity`, evicting the least
+    /// recently served first. Pending entries are never touched. `protected`
+    /// (the token just served) is excluded as an eviction candidate so the
+    /// current serve always wins — but it still counts toward the cap.
+    private static func evictOldestServed(excluding protected: UUID) {
+        let servedCount = entries.values.filter(\.isServed).count
+        guard servedCount > servedCapacity else { return }
+        var evictable = entries.compactMap { token, entry -> (token: UUID, recency: Int)? in
+            guard entry.isServed, token != protected else { return nil }
+            return (token, entry.servedRecency)
+        }
+        evictable.sort { $0.recency < $1.recency }
+        for candidate in evictable.prefix(servedCount - servedCapacity) {
+            entries.removeValue(forKey: candidate.token)
+        }
+    }
+}
+
 /// Serves the reader parent document under the `wiki-reader:` scheme.
 ///
 /// WebKit only honors a custom-scheme `loadHTMLString(baseURL:)` when the
 /// scheme has a registered `WKURLSchemeHandler` (proven in hosted probes:
 /// without a handler the document silently falls back to `about:blank`).
 /// This handler exists to satisfy that requirement: the reader loads its
-/// app-authored HTML via `loadHTMLString`, and the handler answers the
-/// registration probe so WebKit treats `wiki-reader://reader/document.html`
-/// as a real document origin.
+/// app-authored HTML via a real navigation to
+/// `wiki-reader://reader/document.html?load=<uuid>`, and the handler answers
+/// the navigation with the HTML staged under that token (see
+/// `ReaderDocumentStaging` for the staging contract: token-keyed; two-tier
+/// pending/served retention — no forget-on-restage, pending never evicted,
+/// oldest-served LRU on served entries; retire-all on coordinator dismantle;
+/// a staging miss **fails the task**).
 ///
 /// The handler never serves untrusted bytes. Package content is isolated by
 /// per-frame token origins through `ReaderRendererPackageRouter`; blob bytes
@@ -22,17 +151,8 @@ final class WikiReaderDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
     /// The scheme string this handler serves.
     static let scheme = "wiki-reader"
 
-    /// The converted reader document body for the next navigation. The
-    /// coordinator sets this right before `load(request:)`; the handler
-    /// consumes it when WebKit starts the navigation task.
-    private static var pendingHTML: String?
-
-    static func setPendingHTML(_ html: String) {
-        pendingHTML = html
-    }
-
-    /// A shared instance: the handler answers the navigation with the
-    /// pending HTML set by the coordinator.
+    /// A shared instance: every reader webview registers this handler and the
+    /// token in the request URL selects the document.
     static let shared = WikiReaderDocumentSchemeHandler()
 
     override private init() {
@@ -40,22 +160,24 @@ final class WikiReaderDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
-        let body = Self.consumePendingHTML()
-            ?? Data("<!doctype html><html><body></body></html>".utf8)
+        let url = urlSchemeTask.request.url
+        let token = url.flatMap(WikiReaderDocumentOrigin.loadToken(from:))
+        guard let token,
+              let body = ReaderDocumentStaging.beginServing(token: token) else {
+            DebugLog.reader(
+                "reader document staging MISS for token \(token?.uuidString ?? "nil") (url \(url?.absoluteString ?? "nil"))")
+            urlSchemeTask.didFailWithError(
+                WikiReaderDocumentError.missingStagedDocument(url ?? URL(string: "about:blank")!).nsError)
+            return
+        }
         let response = URLResponse(
-            url: urlSchemeTask.request.url ?? URL(string: "about:blank")!,
+            url: url ?? URL(string: "about:blank")!,
             mimeType: "text/html",
             expectedContentLength: body.count,
             textEncodingName: "utf-8")
         urlSchemeTask.didReceive(response)
         urlSchemeTask.didReceive(body)
         urlSchemeTask.didFinish()
-    }
-
-    private static func consumePendingHTML() -> Data? {
-        guard let html = pendingHTML else { return nil }
-        pendingHTML = nil
-        return Data(html.utf8)
     }
 
     func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {}

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -2434,19 +2434,22 @@ internal struct WikiReaderRep: NSViewRepresentable {
             guard let identity = resolveTerminalNavigation(identity, phase: "didFail(\(phase))") else { return }
             navigationIdentities.removeValue(forKey: identity)
             DebugLog.reader("reader navigation failed (\(phase)): \(error.localizedDescription)")
+            beginLoadFailure("This page couldn't be loaded: \(error.localizedDescription)")
+        }
+
+        /// Single failure path for every load-failure shape (WebKit didFail in
+        /// either phase, or a load that never started via the nil-load seam):
+        /// resets the timing stamps, then records the failure and clears the
+        /// spinner. Both binding writes are deferred (next main-actor turn):
+        /// coordinator paths are reachable from `makeNSView`/`updateNSView`,
+        /// and a synchronous write inside SwiftUI's update pass is "Modifying
+        /// state during view update".
+        private func beginLoadFailure(_ message: String) {
             // A failed load emits no painted/html-load timing points, and
             // resetting the stamps keeps a late failure from poisoning a
             // subsequent load's timing split.
             loadStart = nil
             htmlLoadStart = nil
-            beginLoadFailure("This page couldn't be loaded: \(error.localizedDescription)")
-        }
-
-        /// Records the failure and clears the spinner. Both writes are
-        /// deferred (next main-actor turn): coordinator paths are reachable
-        /// from `makeNSView`/`updateNSView`, and a synchronous write inside
-        /// SwiftUI's update pass is "Modifying state during view update".
-        private func beginLoadFailure(_ message: String) {
             setLoadFailure(message)
             setLoading(false)
         }

--- a/Sources/WikiFS/Reader/WikiReaderView.swift
+++ b/Sources/WikiFS/Reader/WikiReaderView.swift
@@ -206,6 +206,13 @@ struct WikiReaderView: View {
     var rendererPackageInputs: RendererPackageEmbedInputs? = nil
     @AppStorage("reader.zoom") private var readerZoom = Double(ZoomScale.defaultScale)
     @State private var isLoading = true
+    /// Set when the document navigation fails (staging miss, load could not
+    /// start, or WebKit `didFail`). Loud by design: a failed load shows an
+    /// error notice with Try Again instead of a silent blank page.
+    @State private var loadFailure: String?
+    /// Incremented by the failure notice's Try Again button; the rep forwards
+    /// it to the coordinator's `applyRetryTrigger` seam.
+    @State private var retryTrigger = 0
 
     /// Find bar: when set, the matched text is passed to the web view for
     /// `window.find()` highlighting and scrolling.
@@ -225,7 +232,9 @@ struct WikiReaderView: View {
                           currentSelection: currentSelection,
                           documentIdentity: documentIdentity,
                           anchorVersion: store.pendingScrollAnchorVersion,
+                          retryTrigger: retryTrigger,
                           isLoading: $isLoading,
+                          loadFailure: $loadFailure,
                           addURLHandler: addURLHandler,
                           addBookmarkHandler: addBookmarkHandler,
                           onRendererActivation: onRendererActivation,
@@ -233,13 +242,40 @@ struct WikiReaderView: View {
                           inlineRendererDescriptors: inlineRendererDescriptors,
                           rendererPackageInputs: rendererPackageInputs,
                           findText: findText, findVersion: findVersion, findOccurrence: findOccurrence)
-            if isLoading {
+            if let loadFailure {
+                readerLoadFailureBanner(message: loadFailure)
+            } else if isLoading {
                 ProgressView()
                     .controlSize(.large)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(.regularMaterial)
             }
         }
+    }
+
+    /// Inline failure notice shown in place of the spinner overlay when the
+    /// document navigation fails. A failed load must never leave a silent
+    /// blank page. Try Again re-runs the load through the coordinator's
+    /// `applyRetryTrigger` seam (fresh token, fresh generation).
+    private func readerLoadFailureBanner(message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 30))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text("This page couldn't be loaded")
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Try Again") { retryTrigger += 1 }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 6)
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial)
     }
 
     nonisolated static func rendererActivationRoute(
@@ -1424,6 +1460,100 @@ private final class RendererAttachmentActionMessageHandler: NSObject, WKScriptMe
     }
 }
 
+// MARK: - Reader document staging + navigation identity
+
+/// Identity of one webview navigation, used to gate terminal navigation
+/// callbacks (`didFinish` / `didFail*`) by load generation. Production
+/// delegate adapters derive it from the `WKNavigation` a `load` call returned
+/// (via `ObjectIdentifier`); `WKNavigation` has no public initializer, so
+/// tests mint identities directly with `mint()` instead of fabricating
+/// WebKit objects.
+struct NavigationIdentity: Hashable, Sendable {
+    private enum Backend: Hashable, Sendable {
+        case navigation(ObjectIdentifier)
+        case minted(UUID)
+    }
+
+    private let backend: Backend
+
+    private init(backend: Backend) {
+        self.backend = backend
+    }
+
+    init(navigation: WKNavigation) {
+        backend = .navigation(ObjectIdentifier(navigation))
+    }
+
+    /// Mints a fresh identity for tests (and any non-WebKit caller).
+    static func mint() -> NavigationIdentity {
+        NavigationIdentity(backend: .minted(UUID()))
+    }
+}
+
+/// Owns the reader-document staging lifecycle for one `WikiReaderRep.Coordinator`:
+/// the full set of tokens this coordinator staged (never a single replaceable
+/// token), the fresh-token mint, and the load seam. Injectable so
+/// navigation-failure tests can drive the real stage→load→identity wiring
+/// without a real `WKWebView`.
+@MainActor
+final class ReaderDocumentStagingSession {
+    /// One staged load: the token it was staged under, plus the identity
+    /// returned by the load seam (`nil` when the load could not start).
+    struct StagedLoad {
+        let token: UUID
+        let identity: NavigationIdentity?
+    }
+
+    /// Tokens this session staged, in mint order. Removed by `forget` /
+    /// `retireAll` only — never by staging a newer load (no forget-on-restage:
+    /// a superseded navigation's scheme task may dispatch late).
+    private(set) var ownedTokens: [UUID] = []
+    /// How many times `retireAll` ran (test observation of teardown).
+    private(set) var retireAllCount = 0
+
+    private let tokenProvider: () -> UUID
+    /// The load seam: starts the document navigation, returning its identity
+    /// (`nil` when the navigation could not start). Defaults to a seam that
+    /// never starts a navigation; the coordinator assigns the production
+    /// `webView.load` wrapper after it is fully initialized (the closure
+    /// captures the coordinator, and Swift forbids `self` capture before
+    /// `super.init`).
+    var load: @MainActor (URLRequest) -> NavigationIdentity?
+
+    init(tokenProvider: @escaping () -> UUID = UUID.init,
+         load: (@MainActor (URLRequest) -> NavigationIdentity?)? = nil) {
+        self.tokenProvider = tokenProvider
+        self.load = load ?? { _ in nil }
+    }
+
+    /// Stages `html` under a fresh token and starts the document navigation.
+    /// The token stays owned regardless of the load outcome: a `nil` identity
+    /// means the navigation never started, and the caller retires that
+    /// never-dispatched token via `forget(token:)`; otherwise the token is
+    /// retired only at teardown (`retireAll`) or by served-LRU eviction in
+    /// the staging store.
+    func stageAndLoad(html: String) -> StagedLoad {
+        let token = tokenProvider()
+        ownedTokens.append(token)
+        ReaderDocumentStaging.stage(html, token: token)
+        let identity = load(URLRequest(url: WikiReaderDocumentOrigin.url(loadToken: token)))
+        return StagedLoad(token: token, identity: identity)
+    }
+
+    /// Retires one never-dispatched token (nil-load-seam cleanup).
+    func forget(token: UUID) {
+        ownedTokens.removeAll { $0 == token }
+        ReaderDocumentStaging.forget(token: token)
+    }
+
+    /// Coordinator teardown: retires every token this session owns.
+    func retireAll() {
+        retireAllCount += 1
+        ReaderDocumentStaging.forgetAll(ownedTokens)
+        ownedTokens.removeAll()
+    }
+}
+
 internal struct WikiReaderRep: NSViewRepresentable {
     let markdown: String
     let store: WikiStoreModel
@@ -1435,7 +1565,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
     /// Mirrors `store.pendingScrollAnchorVersion`; passed in so a bump causes an
     /// `updateNSView` (the Coordinator consumes + applies it once the page loads).
     let anchorVersion: Int
+    /// Bumped by the failure notice's Try Again button; forwarded to the
+    /// coordinator's `applyRetryTrigger` seam every update pass.
+    let retryTrigger: Int
     @Binding var isLoading: Bool
+    /// Failure message for the reader's inline error notice. `nil` = no failure.
+    @Binding var loadFailure: String?
     let addURLHandler: (@MainActor @Sendable (String) -> Void)?
     let addBookmarkHandler: (@MainActor @Sendable (BookmarkTargetPickerContext) -> Void)?
     let onRendererActivation: (@MainActor (RendererReference, RendererBridgeInput) -> Void)?
@@ -1508,7 +1643,8 @@ internal struct WikiReaderRep: NSViewRepresentable {
         context.coordinator.startLoad(
             markdown: markdown,
             documentIdentity: documentIdentity,
-            isLoading: $isLoading)
+            isLoading: $isLoading,
+            loadFailure: $loadFailure)
         return container
     }
 
@@ -1533,8 +1669,12 @@ internal struct WikiReaderRep: NSViewRepresentable {
             context.coordinator.startLoad(
                 markdown: markdown,
                 documentIdentity: documentIdentity,
-                isLoading: $isLoading)
+                isLoading: $isLoading,
+                loadFailure: $loadFailure)
         }
+        // Retry steering: no-op while the trigger is unchanged; a changed
+        // trigger (Try Again) re-runs the load with the current props.
+        context.coordinator.applyRetryTrigger(retryTrigger)
         // Consume + apply any pending scroll anchor (handles re-clicks on an
         // already-loaded doc; a fresh load is handled in `didFinish`). Reads the
         // store's version directly so it's robust to the view being re-created
@@ -1608,6 +1748,13 @@ internal struct WikiReaderRep: NSViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, WKNavigationDelegate {
+        /// The staging lifecycle owner: every token this coordinator stages,
+        /// the token mint, and the load seam. Production wires the
+        /// process-wide `ReaderDocumentStaging` store + `webView.load`;
+        /// tests inject their own session. Assigned exactly once in `init`
+        /// (after `super.init`, because the production load closure captures
+        /// `self`) and never reassigned afterwards.
+        private(set) var stagingSession: ReaderDocumentStagingSession
         weak var webView: WikiReaderWebView?
         weak var attachmentContainer: WikiReaderContainerView?
         /// The one DOM embed lifecycle owner: units, budgets, and frame
@@ -1642,7 +1789,36 @@ internal struct WikiReaderRep: NSViewRepresentable {
         /// the pure WKWebView parse/layout (loadHTMLString→didFinish).
         private var htmlLoadStart: DispatchTime?
         private var isLoadingBinding: Binding<Bool>?
+        private var loadFailureBinding: Binding<String?>?
+        /// Navigation identity → generation, recorded at load time. Each
+        /// terminal callback (`didFinish` / `didFail*`) resolves its own
+        /// identity here before mutating any state: current generation → apply;
+        /// mapped-stale or unknown/`nil` → log only. Mappings are removed at
+        /// each terminal callback and on teardown.
+        private var navigationIdentities: [NavigationIdentity: Int] = [:]
+        /// The last retry trigger this coordinator applied (`applyRetryTrigger`
+        /// no-ops while the view's trigger is unchanged).
+        private var appliedRetryTrigger = 0
         private var renderOptions: MarkdownRenderOptions?
+
+        /// Production wiring: stage into the process-wide `ReaderDocumentStaging`
+        /// store and load via this coordinator's webview. Tests inject a
+        /// session with their own token provider and load seam.
+        init(stagingSession: ReaderDocumentStagingSession? = nil) {
+            if let stagingSession {
+                self.stagingSession = stagingSession
+                super.init()
+            } else {
+                let session = ReaderDocumentStagingSession(tokenProvider: { UUID() })
+                self.stagingSession = session
+                super.init()
+                // Wire the production load seam only now that `self` exists.
+                session.load = { [weak self] request in
+                    guard let self, let webView = self.webView else { return nil }
+                    return webView.load(request).map(NavigationIdentity.init(navigation:))
+                }
+            }
+        }
 
         /// The generation-scoped DOM lifecycle owner. Created lazily so a
         /// teardown-only coordinator never mints state.
@@ -1656,7 +1832,8 @@ internal struct WikiReaderRep: NSViewRepresentable {
         func startLoad(
             markdown: String,
             documentIdentity: MarkdownDocumentIdentity?,
-            isLoading: Binding<Bool>
+            isLoading: Binding<Bool>,
+            loadFailure: Binding<String?>
         ) {
             convertTask?.cancel()  // drop any in-flight conversion for stale markdown
             cancelTransclusionTasks()
@@ -1671,6 +1848,16 @@ internal struct WikiReaderRep: NSViewRepresentable {
             loadedDocumentIdentity = documentIdentity
             pageLoaded = false
             isLoadingBinding = isLoading
+            loadFailureBinding = loadFailure
+            // Every fresh load clears any prior failure so a stale
+            // navigation's failure can never overwrite the fresh load's state.
+            // Deferred write (see below) — this runs inside SwiftUI's update
+            // pass when called from `makeNSView`/`updateNSView`.
+            setLoadFailure(nil)
+            // Reset the html-load timing stamp with loadStart: a stale
+            // navigation finishing later must not poison the fresh load's
+            // appear-to-painted / html-load split.
+            htmlLoadStart = nil
             // Never write this binding synchronously: `startLoad` is called from
             // `makeNSView` / `updateNSView`, i.e. from inside SwiftUI's update
             // pass, and a direct write there is "Modifying state during view
@@ -1781,7 +1968,7 @@ internal struct WikiReaderRep: NSViewRepresentable {
                 let convertMs = Self.elapsedMs(since: t0)
                 let convertDone = DispatchTime.now()
                 await MainActor.run { [weak self] in
-                    guard let self, let webView = self.webView,
+                    guard let self,
                           self.loadedMarkdown == markdown,
                           self.loadGeneration == generation,
                           self.isDismantled == false,
@@ -1797,21 +1984,46 @@ internal struct WikiReaderRep: NSViewRepresentable {
                     // frames) from an HTML-string parent never reach the
                     // registered scheme handlers, while handler-served
                     // navigations frame and load subresources normally. The
-                    // handler answers this navigation with the converted body.
-                    // All in-document links/images use absolute schemes (wiki://,
+                    // handler answers this navigation with the HTML staged
+                    // under this load's own token — overlapping loads cannot
+                    // cross-consume, and a staging miss fails the navigation
+                    // loudly instead of serving a silent empty document. All
+                    // in-document links/images use absolute schemes (wiki://,
                     // wiki-blob://, http[s]://), so base-relative resolution
                     // is unaffected. Provider-hosted media is never embedded
                     // inline, so no external player validates this origin
                     // (operator decision of 2026-09-03; see
                     // `WikiReaderDocumentOrigin`).
-                    WikiReaderDocumentSchemeHandler.setPendingHTML(html)
-                    guard let documentURL = WikiReaderDocumentOrigin.url else {
-                        DebugLog.reader("reader document origin URL construction failed")
-                        return
-                    }
-                    webView.load(URLRequest(url: documentURL))
+                    self.dispatchStagedDocument(html)
                 }
             }
+        }
+
+        /// Stage the converted document under a fresh token and start the
+        /// document navigation through the staging session's load seam,
+        /// recording the returned navigation identity for this generation.
+        ///
+        /// Internal (not private) so navigation-failure tests can drive the
+        /// real stage→load→identity-recording path without a `WKWebView`.
+        ///
+        /// A `nil` identity means the load never started (production:
+        /// `webView.load` returned `nil`). The never-dispatched token can
+        /// never be consumed — no terminal callback will arrive for it — so it
+        /// is retired immediately and the failure is surfaced loudly instead
+        /// of leaving a spinner forever.
+        @discardableResult
+        func dispatchStagedDocument(_ html: String) -> NavigationIdentity? {
+            guard isDismantled == false else { return nil }
+            let staged = stagingSession.stageAndLoad(html: html)
+            guard let identity = staged.identity else {
+                DebugLog.reader(
+                    "reader document load did not start; retiring never-dispatched token \(staged.token.uuidString)")
+                stagingSession.forget(token: staged.token)
+                beginLoadFailure("The page could not be loaded.")
+                return nil
+            }
+            navigationIdentities[identity] = loadGeneration
+            return identity
         }
 
         static func sourceRendererCandidates(
@@ -2022,6 +2234,11 @@ internal struct WikiReaderRep: NSViewRepresentable {
             // goes away.
             convertTask?.cancel()
             convertTask = nil
+            // Retire every token this coordinator staged; its navigation
+            // identity mappings die too, so late terminal callbacks for this
+            // coordinator's loads can only log.
+            stagingSession.retireAll()
+            navigationIdentities.removeAll()
             cancelTransclusionTasks()
             cancelInlineRetentionTasks()
             webView?.addURLHandler = nil
@@ -2029,6 +2246,8 @@ internal struct WikiReaderRep: NSViewRepresentable {
             webView?.onRendererActivation = nil
             webView?.rendererActivationAdmission = nil
             isLoadingBinding = nil
+            loadFailureBinding = nil
+            appliedRetryTrigger = 0
             renderOptions = nil
             domRendererCoordinator?.removeAll()
             domRendererCoordinator = nil
@@ -2143,12 +2362,52 @@ internal struct WikiReaderRep: NSViewRepresentable {
             """)
         }
 
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // MARK: - Navigation terminal events (identity-gated)
+        //
+        // WebKit's delegate protocol requires implicitly unwrapped navigation
+        // arguments; the `WKNavigation!` methods below are thin adapters that
+        // mint the load's `NavigationIdentity` and dispatch to internal
+        // terminal-event handlers. Each handler resolves its identity against
+        // the load-time mapping before mutating any state: the CURRENT
+        // generation applies its state changes; mapped-stale and unknown/nil
+        // identities log only. A superseded navigation finishing or failing
+        // out of order can therefore never clear a spinner, emit a timing
+        // point, or set failure state for the wrong generation.
+
+        /// Resolves a terminal event's identity to a current-generation
+        /// mapping. Returns `nil` (log only, no state change) for nil /
+        /// unknown identities, and removes the mapping for mapped-stale ones
+        /// (that navigation is terminal regardless of staleness).
+        private func resolveTerminalNavigation(
+            _ identity: NavigationIdentity?,
+            phase: String
+        ) -> NavigationIdentity? {
+            guard let identity else {
+                DebugLog.reader("reader \(phase) for nil navigation identity — ignored")
+                return nil
+            }
+            guard let generation = navigationIdentities[identity] else {
+                DebugLog.reader("reader \(phase) for unknown navigation identity — ignored")
+                return nil
+            }
+            guard generation == loadGeneration else {
+                navigationIdentities.removeValue(forKey: identity)
+                DebugLog.reader(
+                    "reader \(phase) for stale generation \(generation) (current \(loadGeneration)) — ignored")
+                return nil
+            }
+            return identity
+        }
+
+        /// Terminal-event handler for a successfully finished document load.
+        func didFinishDocumentLoad(_ identity: NavigationIdentity?, in webView: WKWebView) {
+            guard let identity = resolveTerminalNavigation(identity, phase: "didFinish") else { return }
+            navigationIdentities.removeValue(forKey: identity)
             if let start = loadStart {
                 ReaderTiming.point("webview.appear-to-painted", ms: Self.elapsedMs(since: start))
             }
-            // Split the WKWebView cost: async hop (startLoad→loadHTMLString) vs.
-            // pure WKWebView parse/layout (loadHTMLString→didFinish). Tells us
+            // Split the WKWebView cost: async hop (startLoad→load) vs.
+            // pure WKWebView parse/layout (load→didFinish). Tells us
             // whether a navigation-free innerHTML swap would actually help.
             if let html = htmlLoadStart {
                 ReaderTiming.point("webview.html-load", ms: Self.elapsedMs(since: html))
@@ -2164,6 +2423,78 @@ internal struct WikiReaderRep: NSViewRepresentable {
             isLoadingBinding?.wrappedValue = false
             webView.evaluateJavaScript("window.__sdwRendererAttachmentReport && window.__sdwRendererAttachmentReport(\(loadGeneration));")
             consumeAndApplyPendingAnchor(in: webView)
+        }
+
+        /// Terminal-event handler for a failed document load (either WebKit
+        /// phase, or a load that never started via the nil-load seam). Routes
+        /// by navigation identity: the current generation records the failure
+        /// and clears the spinner; mapped-stale and unknown/nil identities log
+        /// only.
+        func handleNavigationFailure(_ error: Error, identity: NavigationIdentity?, phase: String) {
+            guard let identity = resolveTerminalNavigation(identity, phase: "didFail(\(phase))") else { return }
+            navigationIdentities.removeValue(forKey: identity)
+            DebugLog.reader("reader navigation failed (\(phase)): \(error.localizedDescription)")
+            // A failed load emits no painted/html-load timing points, and
+            // resetting the stamps keeps a late failure from poisoning a
+            // subsequent load's timing split.
+            loadStart = nil
+            htmlLoadStart = nil
+            beginLoadFailure("This page couldn't be loaded: \(error.localizedDescription)")
+        }
+
+        /// Records the failure and clears the spinner. Both writes are
+        /// deferred (next main-actor turn): coordinator paths are reachable
+        /// from `makeNSView`/`updateNSView`, and a synchronous write inside
+        /// SwiftUI's update pass is "Modifying state during view update".
+        private func beginLoadFailure(_ message: String) {
+            setLoadFailure(message)
+            setLoading(false)
+        }
+
+        private func setLoadFailure(_ message: String?) {
+            guard let binding = loadFailureBinding else { return }
+            Task { @MainActor in binding.wrappedValue = message }
+        }
+
+        private func setLoading(_ value: Bool) {
+            guard let binding = isLoadingBinding else { return }
+            Task { @MainActor in binding.wrappedValue = value }
+        }
+
+        // WebKit's delegate protocol requires an implicitly unwrapped navigation argument.
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            didFinishDocumentLoad(NavigationIdentity(navigation: navigation), in: webView)
+        }
+
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            handleNavigationFailure(error, identity: NavigationIdentity(navigation: navigation), phase: "provisional")
+        }
+
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            handleNavigationFailure(error, identity: NavigationIdentity(navigation: navigation), phase: "committed")
+        }
+
+        /// Retry seam, called verbatim from `updateNSView`: no-ops while the
+        /// trigger is unchanged; a changed trigger (the Try Again button)
+        /// re-runs the load with the current props — a fresh token is staged
+        /// (the prior token remains until teardown or served-LRU retirement;
+        /// there is no forget-on-restage), the failure is cleared via the
+        /// deferred write in `startLoad`, and the generation advances so a
+        /// stale navigation can never overwrite the retry's state. Internal so
+        /// tests exercise the exact production path.
+        func applyRetryTrigger(_ trigger: Int) {
+            guard trigger != appliedRetryTrigger,
+                  let isLoading = isLoadingBinding,
+                  let loadFailure = loadFailureBinding else { return }
+            appliedRetryTrigger = trigger
+            startLoad(
+                markdown: loadedMarkdown ?? "",
+                documentIdentity: loadedDocumentIdentity,
+                isLoading: isLoading,
+                loadFailure: loadFailure)
         }
 
         // WebKit's delegate protocol requires an implicitly unwrapped navigation argument.

--- a/Tests/WikiFSAppTests/ReaderDocumentSchemeHandlerTests.swift
+++ b/Tests/WikiFSAppTests/ReaderDocumentSchemeHandlerTests.swift
@@ -1,0 +1,93 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WebKit
+@testable import WikiFS
+
+/// Tests for `WikiReaderDocumentSchemeHandler` serving from the token-keyed
+/// staging store. Encodes the operator requirement behind the blank-page fix:
+/// a task for a token with no staged document fails with an error and serves
+/// **no** bytes — there is no empty-document fallback in the serving path.
+@Suite(.serialized, .timeLimit(.minutes(3)))
+@MainActor
+struct ReaderDocumentSchemeHandlerTests {
+
+    /// A `WKURLSchemeTask` recorder capturing every callback the handler
+    /// makes, so tests can assert exact serving/failure behavior.
+    private final class FakeSchemeTask: NSObject, WKURLSchemeTask {
+        let request: URLRequest
+        private(set) var receivedResponse: URLResponse?
+        private(set) var body = Data()
+        private(set) var didFinishCalled = false
+        private(set) var failures: [any Error] = []
+
+        init(url: URL) {
+            self.request = URLRequest(url: url)
+            super.init()
+        }
+
+        func didReceive(_ response: URLResponse) { receivedResponse = response }
+        func didReceive(_ data: Data) { body.append(data) }
+        func didFinish() { didFinishCalled = true }
+        func didFailWithError(_ error: any Error) { failures.append(error) }
+    }
+
+    private func start(_ url: URL) -> FakeSchemeTask {
+        let task = FakeSchemeTask(url: url)
+        WikiReaderDocumentSchemeHandler.shared.webView(WKWebView(frame: .zero), start: task)
+        return task
+    }
+
+    /// AC.6 — the normal single-load flow is unchanged: the handler serves
+    /// the exact staged bytes as `text/html` and finishes the task.
+    @Test func servesStagedBytesForToken() {
+        ReaderDocumentStaging.resetForTesting()
+        let html = "<!doctype html><html><body>hello reader</body></html>"
+        let token = UUID()
+        ReaderDocumentStaging.stage(html, token: token)
+
+        let task = start(WikiReaderDocumentOrigin.url(loadToken: token))
+
+        #expect(task.failures.isEmpty)
+        #expect(task.body == Data(html.utf8))
+        #expect(task.didFinishCalled)
+        #expect(task.receivedResponse?.mimeType == "text/html")
+    }
+
+    /// AC.2 — a task for an unregistered token fails exactly once with an
+    /// error and never receives a response, bytes, or finish. No code path
+    /// may serve a silent empty document.
+    @Test func unknownTokenFailsTaskWithError() throws {
+        ReaderDocumentStaging.resetForTesting()
+        let token = UUID()  // never staged
+        let url = WikiReaderDocumentOrigin.url(loadToken: token)
+
+        let task = start(url)
+
+        #expect(task.failures.count == 1)
+        #expect(task.receivedResponse == nil)
+        #expect(task.body.isEmpty)
+        #expect(task.didFinishCalled == false)
+        let failure = try #require(task.failures.first as? NSError)
+        #expect(failure.domain == "WikiReaderDocument")
+    }
+
+    /// AC.3 — a served token re-serves identical bytes if the same navigation
+    /// task is re-issued (idempotent consume / re-request resilience).
+    @Test func sameTokenSecondTaskReservesIdempotently() {
+        ReaderDocumentStaging.resetForTesting()
+        let html = "<!doctype html><html><body>idempotent</body></html>"
+        let token = UUID()
+        ReaderDocumentStaging.stage(html, token: token)
+        let url = WikiReaderDocumentOrigin.url(loadToken: token)
+
+        let first = start(url)
+        let second = start(url)
+
+        #expect(first.failures.isEmpty && second.failures.isEmpty)
+        #expect(first.body == Data(html.utf8))
+        #expect(second.body == first.body)
+        #expect(first.didFinishCalled && second.didFinishCalled)
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ReaderDocumentStagingTests.swift
+++ b/Tests/WikiFSAppTests/ReaderDocumentStagingTests.swift
@@ -1,0 +1,139 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+
+/// Tests for `ReaderDocumentStaging` — the token-keyed staging store that
+/// replaced the single process-wide pending slot. The single slot let two
+/// overlapping reader loads cross-consume each other's HTML (one webview
+/// rendered the other's document; the loser got a silent empty page). These
+/// tests pin the deterministic interleavings that used to race, plus the
+/// two-tier retention contract: pending entries are never evicted, served
+/// entries are bounded by an oldest-served LRU cap, and there is no
+/// forget-on-restage.
+@Suite(.serialized, .timeLimit(.minutes(3)))
+@MainActor
+struct ReaderDocumentStagingTests {
+
+    private func html(_ name: String) -> String {
+        "<!doctype html><html><body>\(name)</body></html>"
+    }
+
+    /// AC.1 — the regression test for the reported bug: two documents staged
+    /// before either is consumed must each resolve to their own bytes.
+    /// Fails against the old single-slot store (stage B overwrote A, so
+    /// `beginServing(aToken)` returned B's bytes or missed).
+    @Test func interleavedStagingConsumesOwnDocument() {
+        ReaderDocumentStaging.resetForTesting()
+        let aToken = UUID()
+        let bToken = UUID()
+        let htmlA = html("A")
+        let htmlB = html("B")
+
+        ReaderDocumentStaging.stage(htmlA, token: aToken)
+        ReaderDocumentStaging.stage(htmlB, token: bToken)
+
+        #expect(ReaderDocumentStaging.beginServing(token: aToken) == Data(htmlA.utf8))
+        #expect(ReaderDocumentStaging.beginServing(token: bToken) == Data(htmlB.utf8))
+    }
+
+    /// AC.6 — the no-forget-on-restage contract: staging a newer document
+    /// must not retire a prior token. A superseded navigation's scheme task
+    /// may dispatch late; forget-on-restage would starve it back into the
+    /// silent-blank failure mode.
+    @Test func supersededTokenStillServes() {
+        ReaderDocumentStaging.resetForTesting()
+        let aToken = UUID()
+        let bToken = UUID()
+        let htmlA = html("A")
+        let htmlB = html("B")
+
+        ReaderDocumentStaging.stage(htmlA, token: aToken)
+        // No retire between: the newer load replaces the older one in flight.
+        ReaderDocumentStaging.stage(htmlB, token: bToken)
+
+        #expect(ReaderDocumentStaging.beginServing(token: aToken) == Data(htmlA.utf8))
+        #expect(ReaderDocumentStaging.beginServing(token: bToken) == Data(htmlB.utf8))
+    }
+
+    /// AC.6 — the teardown contract: `retireAll()` on the owning session
+    /// makes `beginServing` miss for every owned token, and nothing else.
+    @Test func retireAllRemovesOwnedTokens() {
+        ReaderDocumentStaging.resetForTesting()
+        var nextToken = 0
+        let tokens = [UUID(), UUID()]
+        let session = ReaderDocumentStagingSession(
+            tokenProvider: {
+                defer { nextToken += 1 }
+                return tokens[nextToken]
+            },
+            load: { _ in NavigationIdentity.mint() })
+
+        let stagedA = session.stageAndLoad(html: html("A"))
+        let stagedB = session.stageAndLoad(html: html("B"))
+        #expect(session.ownedTokens.count == 2)
+
+        session.retireAll()
+
+        #expect(session.ownedTokens.isEmpty)
+        #expect(session.retireAllCount == 1)
+        #expect(ReaderDocumentStaging.beginServing(token: stagedA.token) == nil)
+        #expect(ReaderDocumentStaging.beginServing(token: stagedB.token) == nil)
+    }
+
+    /// AC.6 — pending entries are never evicted, even beyond the served LRU
+    /// cap: a not-yet-dispatched navigation cannot be starved. Serving each
+    /// in turn must return every document's exact bytes.
+    @Test func pendingLoadsBeyondCapRemainServiceable() {
+        ReaderDocumentStaging.resetForTesting()
+        let count = ReaderDocumentStaging.servedCapacity + 4
+        var tokens: [UUID] = []
+        var bodies: [Data] = []
+        for index in 0..<count {
+            let body = Data(html("doc-\(index)").utf8)
+            let token = UUID()
+            ReaderDocumentStaging.stage(html("doc-\(index)"), token: token)
+            tokens.append(token)
+            bodies.append(body)
+        }
+
+        for (token, body) in zip(tokens, bodies) {
+            #expect(ReaderDocumentStaging.beginServing(token: token) == body)
+        }
+    }
+
+    /// AC.6 — served entries are bounded by an oldest-served LRU cap, driven
+    /// through `beginServing` itself (the real pending→served transition, not
+    /// a test-only mutation). The oldest served entry's re-serve misses after
+    /// eviction; pending entries are untouched; newer served entries survive.
+    @Test func servedLruCapEvictsOldestServed() {
+        ReaderDocumentStaging.resetForTesting()
+        let count = ReaderDocumentStaging.servedCapacity + 4
+        var tokens: [UUID] = []
+        var bodies: [Data] = []
+        for index in 0..<count {
+            let body = html("doc-\(index)")
+            let token = UUID()
+            ReaderDocumentStaging.stage(body, token: token)
+            tokens.append(token)
+            bodies.append(Data(body.utf8))
+        }
+
+        // Serve capacity + 1 entries: the oldest served (tokens[0]) is evicted.
+        for token in tokens[...(ReaderDocumentStaging.servedCapacity)] {
+            #expect(ReaderDocumentStaging.beginServing(token: token) != nil)
+        }
+
+        // The oldest served entry is gone; its re-serve misses loudly.
+        #expect(ReaderDocumentStaging.beginServing(token: tokens[0]) == nil)
+        // The remaining served entries still re-serve identical bytes.
+        for index in 1...ReaderDocumentStaging.servedCapacity {
+            #expect(ReaderDocumentStaging.beginServing(token: tokens[index]) == bodies[index])
+        }
+        // Entries never served are still pending and untouched by eviction.
+        for index in (ReaderDocumentStaging.servedCapacity + 1)..<count {
+            #expect(ReaderDocumentStaging.beginServing(token: tokens[index]) == bodies[index])
+        }
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ReaderDocumentStagingTests.swift
+++ b/Tests/WikiFSAppTests/ReaderDocumentStagingTests.swift
@@ -11,6 +11,11 @@ import Testing
 /// two-tier retention contract: pending entries are never evicted, served
 /// entries are bounded by an oldest-served LRU cap, and there is no
 /// forget-on-restage.
+///
+/// These tests are synchronous `@MainActor` functions, so each runs
+/// atomically on the main actor: `resetForTesting()` at the start cannot
+/// interleave with another suite mid-test, which is what makes the
+/// served-cap determinism safe despite the process-global store.
 @Suite(.serialized, .timeLimit(.minutes(3)))
 @MainActor
 struct ReaderDocumentStagingTests {

--- a/Tests/WikiFSAppTests/ReaderNavigationFailureTests.swift
+++ b/Tests/WikiFSAppTests/ReaderNavigationFailureTests.swift
@@ -17,6 +17,14 @@ import WebKit
 /// Per repo rules (#1051): no blocking waits — every wait races a bounded
 /// `Task.sleep` poll, and deferred binding writes are awaited before
 /// assertions.
+///
+/// Global `ReaderDocumentStaging` state is deliberately NOT reset here: this
+/// suite `await`s, and another suite could run `resetForTesting()` in that
+/// window. Every assertion is therefore session-scoped (`ownedTokens`,
+/// captured identities, miss-tolerant `beginServing` checks) so concurrent
+/// staging suites cannot flip an outcome. The staging/handler suites reset
+/// the store, but they are synchronous `@MainActor` tests — they run
+/// atomically and cannot interleave with these awaits mid-test.
 @Suite(.serialized, .timeLimit(.minutes(3)))
 @MainActor
 struct ReaderNavigationFailureTests {
@@ -109,7 +117,6 @@ struct ReaderNavigationFailureTests {
     /// AC.4 — the CURRENT identity's failure, for both WebKit phases, sets
     /// the failure message and clears the spinner.
     @Test func provisionalAndCommittedDidFailSetFailureState() async throws {
-        ReaderDocumentStaging.resetForTesting()
         let loader = MintingLoader()
         let coordinator = WikiReaderRep.Coordinator(
             stagingSession: ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam))
@@ -139,7 +146,6 @@ struct ReaderNavigationFailureTests {
     /// AC.4 — a mapped-stale identity's failure changes nothing (log only):
     /// no failure message, no spinner write, no page-loaded flip.
     @Test func staleNavigationFailureIgnored() async throws {
-        ReaderDocumentStaging.resetForTesting()
         let loader = MintingLoader()
         let coordinator = WikiReaderRep.Coordinator(
             stagingSession: ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam))
@@ -169,7 +175,6 @@ struct ReaderNavigationFailureTests {
     /// change nothing (log only): the page is not marked loaded and the
     /// spinner is not cleared by a navigation that is not the current load.
     @Test func staleDidFinishIgnored() async throws {
-        ReaderDocumentStaging.resetForTesting()
         let loader = MintingLoader()
         let coordinator = WikiReaderRep.Coordinator(
             stagingSession: ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam))
@@ -196,7 +201,6 @@ struct ReaderNavigationFailureTests {
     /// failure state is set (deferred write), the spinner is cleared, and the
     /// never-dispatched token is retired (staging misses afterwards).
     @Test func nilLoaderSurfacesFailure() async throws {
-        ReaderDocumentStaging.resetForTesting()
         let loader = NilLoader()
         let session = ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam)
         let coordinator = WikiReaderRep.Coordinator(stagingSession: session)
@@ -217,7 +221,6 @@ struct ReaderNavigationFailureTests {
     /// trigger re-runs the load with the current props: fresh token staged,
     /// failure cleared (deferred write), generation advanced.
     @Test func retryAppliesTriggerAndRestages() async throws {
-        ReaderDocumentStaging.resetForTesting()
         let loader = MintingLoader()
         let session = ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam)
         let coordinator = WikiReaderRep.Coordinator(stagingSession: session)
@@ -267,7 +270,6 @@ struct ReaderNavigationFailureTests {
     /// AC.5 (separate teardown assertion) — `Coordinator.teardown()` invokes
     /// the session's `retireAll()`, and the retired tokens then miss.
     @Test func teardownRetiresAllOwnedTokens() async throws {
-        ReaderDocumentStaging.resetForTesting()
         let loader = MintingLoader()
         let session = ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam)
         let coordinator = WikiReaderRep.Coordinator(stagingSession: session)

--- a/Tests/WikiFSAppTests/ReaderNavigationFailureTests.swift
+++ b/Tests/WikiFSAppTests/ReaderNavigationFailureTests.swift
@@ -1,0 +1,290 @@
+#if os(macOS)
+import Foundation
+import SwiftUI
+import Testing
+import WebKit
+@testable import WikiFS
+
+/// Tests for the reader coordinator's identity-gated navigation terminal
+/// events, the nil-load-seam failure path, and the retry trigger seam.
+///
+/// Hermetic by design: identities are MINTED directly as `NavigationIdentity`
+/// values (`WKNavigation` has no public initializer), the load seam is
+/// injected, and the internal terminal-event handlers are driven exactly as
+/// the production `WKNavigation!` delegate adapters would. Only the thin
+/// `WKNavigation` → identity conversion is excluded.
+///
+/// Per repo rules (#1051): no blocking waits — every wait races a bounded
+/// `Task.sleep` poll, and deferred binding writes are awaited before
+/// assertions.
+@Suite(.serialized, .timeLimit(.minutes(3)))
+@MainActor
+struct ReaderNavigationFailureTests {
+
+    private let documentHTML = "<!doctype html><html><body>nav-failure-test</body></html>"
+
+    /// Mutable box standing in for SwiftUI `@State` under a test `Binding`.
+    private final class ValueBox<T> {
+        var value: T
+        init(_ value: T) { self.value = value }
+    }
+
+    /// Load seam that records every request and mints a fresh identity per
+    /// call — the success shape of the production `webView.load` wrapper.
+    @MainActor
+    private final class MintingLoader {
+        private(set) var requestURLs: [URL] = []
+        private(set) var identities: [NavigationIdentity] = []
+
+        var seam: @MainActor (URLRequest) -> NavigationIdentity? {
+            { [self] request in
+                if let url = request.url { requestURLs.append(url) }
+                let identity = NavigationIdentity.mint()
+                identities.append(identity)
+                return identity
+            }
+        }
+    }
+
+    /// Load seam that records requests but never starts a navigation — the
+    /// production shape of `webView.load` returning `nil`.
+    @MainActor
+    private final class NilLoader {
+        private(set) var requestURLs: [URL] = []
+
+        var seam: @MainActor (URLRequest) -> NavigationIdentity? {
+            { [self] request in
+                if let url = request.url { requestURLs.append(url) }
+                return nil
+            }
+        }
+    }
+
+    private func binding<T>(_ box: ValueBox<T>) -> Binding<T> {
+        Binding(get: { box.value }, set: { box.value = $0 })
+    }
+
+    /// Wires the coordinator's bindings exactly as `makeNSView` does and
+    /// waits for the initial convert's dispatch through the injected seam.
+    private func wireCoordinator(
+        _ coordinator: WikiReaderRep.Coordinator,
+        spinner: ValueBox<Bool>,
+        failure: ValueBox<String?>
+    ) async throws {
+        coordinator.startLoad(
+            markdown: "",
+            documentIdentity: nil,
+            isLoading: binding(spinner),
+            loadFailure: binding(failure))
+    }
+
+    /// Bounded, non-blocking wait for a main-actor condition. The default
+    /// budget is generous (the normal path resolves in milliseconds) so a
+    /// fully loaded parallel test run cannot starve a deferred write past the
+    /// deadline.
+    @discardableResult
+    private func waitFor(
+        _ description: String,
+        timeout: Duration = .seconds(15),
+        _ condition: @MainActor () -> Bool
+    ) async throws -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if condition() { return true }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Timed out waiting for \(description)")
+        return false
+    }
+
+    /// Yields to the main actor a few times so any deferred binding writes
+    /// land before assertions.
+    private func settle() async {
+        for _ in 0..<5 {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    /// AC.4 — the CURRENT identity's failure, for both WebKit phases, sets
+    /// the failure message and clears the spinner.
+    @Test func provisionalAndCommittedDidFailSetFailureState() async throws {
+        ReaderDocumentStaging.resetForTesting()
+        let loader = MintingLoader()
+        let coordinator = WikiReaderRep.Coordinator(
+            stagingSession: ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam))
+        let spinner = ValueBox(true)
+        let failure = ValueBox<String?>(nil)
+        try await wireCoordinator(coordinator, spinner: spinner, failure: failure)
+        try await waitFor("initial dispatch registered") { loader.identities.count >= 1 }
+
+        // Two identities at the current generation, registered through the
+        // injected loader seam (as the load-time recording does in production).
+        let provisionalID = try #require(coordinator.dispatchStagedDocument(documentHTML))
+        let committedID = try #require(coordinator.dispatchStagedDocument(documentHTML))
+        #expect(provisionalID != committedID)
+
+        coordinator.handleNavigationFailure(
+            NSError(domain: "test", code: 1), identity: provisionalID, phase: "provisional")
+        try await waitFor("provisional failure surfaced") { failure.value != nil }
+        try await waitFor("spinner cleared") { spinner.value == false }
+
+        failure.value = nil
+        coordinator.handleNavigationFailure(
+            NSError(domain: "test", code: 2), identity: committedID, phase: "committed")
+        try await waitFor("committed failure surfaced") { failure.value != nil }
+        #expect(spinner.value == false)
+    }
+
+    /// AC.4 — a mapped-stale identity's failure changes nothing (log only):
+    /// no failure message, no spinner write, no page-loaded flip.
+    @Test func staleNavigationFailureIgnored() async throws {
+        ReaderDocumentStaging.resetForTesting()
+        let loader = MintingLoader()
+        let coordinator = WikiReaderRep.Coordinator(
+            stagingSession: ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam))
+        let spinner = ValueBox(true)
+        let failure = ValueBox<String?>(nil)
+        try await wireCoordinator(coordinator, spinner: spinner, failure: failure)
+
+        // Mapped at the current generation, then superseded by a fresh load.
+        let staleID = try #require(coordinator.dispatchStagedDocument(documentHTML))
+        coordinator.applyRetryTrigger(1)
+        try await waitFor("superseding load dispatched") { loader.identities.count >= 2 }
+
+        let failureBefore = failure.value
+        let spinnerBefore = spinner.value
+        let pageLoadedBefore = coordinator.pageLoaded
+
+        coordinator.handleNavigationFailure(
+            NSError(domain: "test", code: 3), identity: staleID, phase: "provisional")
+        await settle()
+
+        #expect(failure.value == failureBefore)
+        #expect(spinner.value == spinnerBefore)
+        #expect(coordinator.pageLoaded == pageLoadedBefore)
+    }
+
+    /// AC.4 — mapped-stale, unknown, and `nil` identities' finish events
+    /// change nothing (log only): the page is not marked loaded and the
+    /// spinner is not cleared by a navigation that is not the current load.
+    @Test func staleDidFinishIgnored() async throws {
+        ReaderDocumentStaging.resetForTesting()
+        let loader = MintingLoader()
+        let coordinator = WikiReaderRep.Coordinator(
+            stagingSession: ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam))
+        let spinner = ValueBox(true)
+        let failure = ValueBox<String?>(nil)
+        try await wireCoordinator(coordinator, spinner: spinner, failure: failure)
+
+        let staleID = try #require(coordinator.dispatchStagedDocument(documentHTML))
+        coordinator.applyRetryTrigger(1)
+        try await waitFor("superseding load dispatched") { loader.identities.count >= 2 }
+
+        let webView = WKWebView(frame: .zero)
+        coordinator.didFinishDocumentLoad(staleID, in: webView)
+        coordinator.didFinishDocumentLoad(NavigationIdentity.mint(), in: webView)
+        coordinator.didFinishDocumentLoad(nil, in: webView)
+        await settle()
+
+        #expect(coordinator.pageLoaded == false)
+        #expect(spinner.value == true)
+        #expect(failure.value == nil)
+    }
+
+    /// AC.4 — a `nil` load result is an immediate visible failure: the
+    /// failure state is set (deferred write), the spinner is cleared, and the
+    /// never-dispatched token is retired (staging misses afterwards).
+    @Test func nilLoaderSurfacesFailure() async throws {
+        ReaderDocumentStaging.resetForTesting()
+        let loader = NilLoader()
+        let session = ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam)
+        let coordinator = WikiReaderRep.Coordinator(stagingSession: session)
+        let spinner = ValueBox(true)
+        let failure = ValueBox<String?>(nil)
+        try await wireCoordinator(coordinator, spinner: spinner, failure: failure)
+
+        try await waitFor("load-initiation failure surfaced") { failure.value != nil }
+        try await waitFor("spinner cleared") { spinner.value == false }
+
+        let firstURL = try #require(loader.requestURLs.first)
+        let token = try #require(WikiReaderDocumentOrigin.loadToken(from: firstURL))
+        #expect(session.ownedTokens.isEmpty)
+        #expect(ReaderDocumentStaging.beginServing(token: token) == nil)
+    }
+
+    /// AC.5 — `applyRetryTrigger` no-ops on an unchanged trigger; a changed
+    /// trigger re-runs the load with the current props: fresh token staged,
+    /// failure cleared (deferred write), generation advanced.
+    @Test func retryAppliesTriggerAndRestages() async throws {
+        ReaderDocumentStaging.resetForTesting()
+        let loader = MintingLoader()
+        let session = ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam)
+        let coordinator = WikiReaderRep.Coordinator(stagingSession: session)
+        let spinner = ValueBox(true)
+        let failure = ValueBox<String?>(nil)
+        try await wireCoordinator(coordinator, spinner: spinner, failure: failure)
+        try await waitFor("initial dispatch registered") { loader.identities.count >= 1 }
+
+        // Current-generation failure first, so the retry visibly recovers.
+        let failedID = loader.identities[0]
+        coordinator.handleNavigationFailure(
+            NSError(domain: "test", code: 6), identity: failedID, phase: "committed")
+        try await waitFor("failure surfaced") { failure.value != nil }
+        try await waitFor("spinner cleared") { spinner.value == false }
+
+        // Unchanged trigger: a no-op.
+        coordinator.applyRetryTrigger(0)
+        await settle()
+        #expect(loader.identities.count == 1)
+
+        // Changed trigger: fresh token staged, failure cleared, spinner up.
+        coordinator.applyRetryTrigger(1)
+        try await waitFor("retry dispatched") { loader.identities.count >= 2 }
+        try await waitFor("failure cleared by retry") { failure.value == nil }
+        try await waitFor("spinner up again") { spinner.value == true }
+
+        let ownedTokens = session.ownedTokens
+        #expect(ownedTokens.count == 2)
+        let firstURL = try #require(loader.requestURLs.first)
+        let firstToken = try #require(WikiReaderDocumentOrigin.loadToken(from: firstURL))
+        let lastURL = try #require(loader.requestURLs.last)
+        let retryToken = try #require(WikiReaderDocumentOrigin.loadToken(from: lastURL))
+        #expect(ownedTokens.contains(firstToken) && ownedTokens.contains(retryToken))
+        #expect(firstToken != retryToken)
+
+        // Generation advanced: the superseded load's identity can no longer
+        // mutate state, while the retry's identity applies.
+        coordinator.didFinishDocumentLoad(failedID, in: WKWebView(frame: .zero))
+        await settle()
+        #expect(coordinator.pageLoaded == false)
+
+        let retryID = try #require(loader.identities.last)
+        coordinator.didFinishDocumentLoad(retryID, in: WKWebView(frame: .zero))
+        try await waitFor("retry identity marked the page loaded") { coordinator.pageLoaded == true }
+    }
+
+    /// AC.5 (separate teardown assertion) — `Coordinator.teardown()` invokes
+    /// the session's `retireAll()`, and the retired tokens then miss.
+    @Test func teardownRetiresAllOwnedTokens() async throws {
+        ReaderDocumentStaging.resetForTesting()
+        let loader = MintingLoader()
+        let session = ReaderDocumentStagingSession(tokenProvider: { UUID() }, load: loader.seam)
+        let coordinator = WikiReaderRep.Coordinator(stagingSession: session)
+        try await wireCoordinator(
+            coordinator, spinner: ValueBox(true), failure: ValueBox<String?>(nil))
+        try await waitFor("initial dispatch registered") { loader.identities.count >= 1 }
+
+        let firstURL = try #require(loader.requestURLs.first)
+        let token = try #require(WikiReaderDocumentOrigin.loadToken(from: firstURL))
+        #expect(session.ownedTokens.isEmpty == false)
+        #expect(session.retireAllCount == 0)
+
+        coordinator.teardown()
+
+        #expect(session.retireAllCount == 1)
+        #expect(session.ownedTokens.isEmpty)
+        #expect(ReaderDocumentStaging.beginServing(token: token) == nil)
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
+++ b/Tests/WikiFSAppTests/RendererAttachmentSpikeHostedTests.swift
@@ -624,7 +624,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         currentSnapshot = nil
         currentRevision = 0
         webView.pageZoom = Double(ZoomScale.defaultScale)
-        webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderDocumentOrigin.url)
+        webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderDocumentOrigin.url(loadToken: UUID()))
         try await Self.waitFor(description: "reader web view load") { [weak self] in
             self?.didFinishLoad == true
         }
@@ -637,7 +637,7 @@ private final class RendererAttachmentSpikeHarness: NSObject, WKNavigationDelega
         currentGeometry = nil
         currentSnapshot = nil
         currentRevision = 0
-        webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderDocumentOrigin.url)
+        webView.loadHTMLString(Self.html(for: markdown, documentIdentity: documentIdentity), baseURL: WikiReaderDocumentOrigin.url(loadToken: UUID()))
         try await Self.waitFor(description: "reader web view reload") { [weak self] in
             self?.didFinishLoad == true
         }

--- a/Tests/WikiFSAppTests/WikiReaderDocumentOriginTests.swift
+++ b/Tests/WikiFSAppTests/WikiReaderDocumentOriginTests.swift
@@ -84,6 +84,13 @@ struct WikiReaderDocumentOriginTests {
         let foreign = try #require(URL(string: "https://example.com/document.html?load=\(token.uuidString)"))
         #expect(WikiReaderDocumentOrigin.loadToken(from: foreign) == nil)
 
+        // Same origin, wrong path: a token may only be consumed through the
+        // exact document URL it was minted for.
+        let wrongPath = try #require(URL(string: "wiki-reader://reader/other.html?load=\(token.uuidString)"))
+        #expect(WikiReaderDocumentOrigin.loadToken(from: wrongPath) == nil)
+        let noPath = try #require(URL(string: "wiki-reader://reader?load=\(token.uuidString)"))
+        #expect(WikiReaderDocumentOrigin.loadToken(from: noPath) == nil)
+
         // Missing query, unrelated query, malformed UUID, duplicate items.
         #expect(WikiReaderDocumentOrigin.loadToken(from: try #require(URL(string: "wiki-reader://reader/document.html"))) == nil)
         #expect(WikiReaderDocumentOrigin.loadToken(from: try #require(URL(string: "wiki-reader://reader/document.html?src=notes"))) == nil)

--- a/Tests/WikiFSAppTests/WikiReaderDocumentOriginTests.swift
+++ b/Tests/WikiFSAppTests/WikiReaderDocumentOriginTests.swift
@@ -1,0 +1,94 @@
+#if os(macOS)
+import Foundation
+import Testing
+@testable import WikiFS
+
+/// Tests for `WikiReaderDocumentOrigin` — the tokenized reader document URL
+/// and the same-document fragment classification. The `?load=<uuid>` staging
+/// token must not break footnote/heading anchor links: `href="#target"`
+/// resolved against the tokenized base *retains* the `load` query, so
+/// `isSameDocumentFragment` accepts exactly that query and rejects unrelated
+/// or malformed ones.
+@Suite(.serialized, .timeLimit(.minutes(3)))
+@MainActor
+struct WikiReaderDocumentOriginTests {
+
+    /// AC.9 — a fragment link resolved against the tokenized base is
+    /// same-document (pins the anchor-link fix). The resolved URL retains the
+    /// base's `load` query, though `URLComponents(url:)` fails to parse that
+    /// inconsistent result (see `isOwnOrEmptyQuery`).
+    @Test func fragmentLinkResolvesAgainstTokenizedBase() {
+        let base = WikiReaderDocumentOrigin.url(loadToken: UUID())
+        let fragment = URL(string: "#wiki-fn-n10", relativeTo: base)!
+
+        #expect(fragment.fragment == "wiki-fn-n10")
+        #expect(fragment.query != nil)
+        #expect(WikiReaderDocumentOrigin.isSameDocumentFragment(fragment) == true)
+    }
+
+    /// AC.9 — WHATWG resolution (WebKit's) *retains* the base's `load` query;
+    /// a fragment URL carrying exactly the document's valid token is also
+    /// same-document.
+    @Test func fragmentWithOwnValidLoadQueryAccepted() throws {
+        let token = UUID()
+        let url = try #require(URL(string:
+            "wiki-reader://reader/document.html?load=\(token.uuidString)#wiki-fn-n10"))
+
+        #expect(WikiReaderDocumentOrigin.isSameDocumentFragment(url) == true)
+    }
+
+    /// AC.9 — a relative source link (`[Back](../README.md)`) is NOT a
+    /// same-document fragment (no fragment component).
+    @Test func relativeSourceLinkIsNotFragment() {
+        let base = WikiReaderDocumentOrigin.url(loadToken: UUID())
+        let link = URL(string: "../README.md", relativeTo: base)!
+
+        #expect(WikiReaderDocumentOrigin.isSameDocumentFragment(link) == false)
+    }
+
+    /// AC.9 — a fragment URL with an unrelated query is rejected.
+    @Test func fragmentWithUnrelatedQueryRejected() throws {
+        let url = try #require(URL(string: "wiki-reader://reader/document.html?src=notes#section"))
+
+        #expect(WikiReaderDocumentOrigin.isSameDocumentFragment(url) == false)
+    }
+
+    /// AC.9 — a fragment URL with a malformed `load` value is rejected.
+    @Test func fragmentWithMalformedLoadQueryRejected() throws {
+        let url = try #require(URL(string: "wiki-reader://reader/document.html?load=not-a-uuid#section"))
+
+        #expect(WikiReaderDocumentOrigin.isSameDocumentFragment(url) == false)
+    }
+
+    /// AC.9 — a fragment URL with an extra query item alongside `load` is
+    /// rejected (only exactly the document's own token qualifies).
+    @Test func fragmentWithExtraQueryItemsRejected() throws {
+        let token = UUID()
+        let url = try #require(URL(string:
+            "wiki-reader://reader/document.html?load=\(token.uuidString)&extra=1#section"))
+
+        #expect(WikiReaderDocumentOrigin.isSameDocumentFragment(url) == false)
+    }
+
+    /// The document URL round-trips through `loadToken(from:)`, and the
+    /// parser rejects non-document URLs and malformed queries so the scheme
+    /// handler misses loudly instead of serving the wrong document.
+    @Test func loadTokenRoundTripAndRejection() throws {
+        let token = UUID()
+        let documentURL = WikiReaderDocumentOrigin.url(loadToken: token)
+
+        #expect(WikiReaderDocumentOrigin.loadToken(from: documentURL) == token)
+        #expect(documentURL.path == "/document.html")
+
+        // Not a reader document URL.
+        let foreign = try #require(URL(string: "https://example.com/document.html?load=\(token.uuidString)"))
+        #expect(WikiReaderDocumentOrigin.loadToken(from: foreign) == nil)
+
+        // Missing query, unrelated query, malformed UUID, duplicate items.
+        #expect(WikiReaderDocumentOrigin.loadToken(from: try #require(URL(string: "wiki-reader://reader/document.html"))) == nil)
+        #expect(WikiReaderDocumentOrigin.loadToken(from: try #require(URL(string: "wiki-reader://reader/document.html?src=notes"))) == nil)
+        #expect(WikiReaderDocumentOrigin.loadToken(from: try #require(URL(string: "wiki-reader://reader/document.html?load=nope"))) == nil)
+        #expect(WikiReaderDocumentOrigin.loadToken(from: try #require(URL(string: "wiki-reader://reader/document.html?load=\(token.uuidString)&load=\(token.uuidString)"))) == nil)
+    }
+}
+#endif


### PR DESCRIPTION
## Diagnosis

`WikiReaderDocumentSchemeHandler` staged the converted reader HTML in a single process-wide static slot (`setPendingHTML`), and every `WikiReaderWebView` registers the same `.shared` handler. When two reader loads overlapped — launch, multiple wiki windows, a queue deep-link window opening the home page and the deep link, or a fast tab retarget while a navigation was in flight — the second `setPendingHTML` overwrote the first. One webview consumed the other's HTML; the loser found the slot empty and was served the silent fallback `<!doctype html><html><body></body></html>`. That navigation still completed: `didFinish` fired and cleared the spinner, and because `startLoad` records `loadedMarkdown` and `updateNSView` only reloads when the prop changes, the broken webview never retried. Result: a blank white page until the user closed and reopened it.

## Fix

**Token-keyed staging (removes the race).** Each load mints a `UUID`; the document URL carries it as `wiki-reader://reader/document.html?load=<uuid>`; staging is a dictionary keyed by token. A navigation can only consume its own document. Retention is two-tier: entries are *pending* until their scheme task first starts, then *served*. Pending entries are never evicted (a not-yet-dispatched navigation cannot be starved) and are retired by owner teardown. Served entries are kept for idempotent re-issue and bounded by an oldest-served LRU cap of 8. There is deliberately no forget-on-restage — retiring a prior token when a newer load is staged can starve a superseded navigation whose scheme task dispatches late. The empty-document fallback is deleted.

**Loud failure on miss (defense in depth).** A scheme task for a token with no staged document logs via `DebugLog.reader` and fails the task with `WikiReaderDocumentError.missingStagedDocument` (`didFailWithError`); no path serves fallback bytes. The coordinator implements `didFailProvisionalNavigation`/`didFail`, and all terminal callbacks (`didFinish` included) are gated by navigation identity: each load's `WKNavigation` is mapped to its generation at load time, current-generation events apply state, and mapped-stale/unknown/`nil` identities log only. Failures clear the spinner and set a message the reader renders as an inline error banner with **Try Again**, which re-runs the load through a `retryTrigger` → `applyRetryTrigger` seam (fresh token, fresh generation, failure cleared via deferred write). A `nil` return from the load seam is an immediate visible failure that retires the never-dispatched token.

**Anchor links preserved.** `isSameDocumentFragment` now accepts a fragment URL whose query is exactly one valid `load` UUID (or no query), so footnote/heading anchors resolved against the tokenized base still classify as same-document; unrelated or malformed queries are rejected. (Probed Foundation quirk, documented in-code: `URLComponents(url:resolvingAgainstBaseURL:)` returns `nil` for a fragment-only resolution against a base with a query, so the classifier falls back to parsing the absolute string.)

## Test plan

- 21 new hermetic Swift Testing tests in 4 suites (all `@MainActor`, non-blocking bounded waits per #1051):
  - `ReaderDocumentStagingTests` — interleaved loads cannot cross-consume (regression for the reported bug); superseded tokens keep serving; teardown `retireAll`; pending entries never evicted beyond the cap; served-LRU eviction driven through `beginServing` itself.
  - `ReaderDocumentSchemeHandlerTests` — exact staged bytes served as `text/html`; unknown token fails the task exactly once and never receives bytes (no fallback); same-token re-issue serves identical bytes.
  - `WikiReaderDocumentOriginTests` — fragment links resolve against the tokenized base; unrelated/malformed/extra queries rejected; token round-trip and wrong-path/pathless rejections.
  - `ReaderNavigationFailureTests` — both failure phases set failure state and clear the spinner; mapped-stale/unknown/`nil` identities are no-ops on failure *and* finish; nil loader surfaces an immediate failure and retires the token; retry no-ops on unchanged trigger and otherwise restages with a fresh token, clears failure, and advances the generation; teardown retires all owned tokens.
- `make test` (default graph): 4289 tests, all passing.
- CI-gated app suites (`RendererPackageSchemeHandlerTests|RendererContentWorldBridgeTests|RendererExternalLinkRedemptionGateTests|WikiAppWebViewSessionTests|WikiAppWebViewTests`): 51/51.
- New suites verified stable across repeated runs.

## Review

Implementation review by an independent agent over the full branch diff returned no critical/high findings; three medium findings were fixed in 52974c7f: nil-load failures now share the single failure path that resets `ReaderTiming` stamps, `loadToken(from:)` requires the exact document path (wrong-path negative tests added), and the async test suite no longer resets process-global staging state mid-await.

## Known limitations

- AC.8 (banner pixels + Console.app log lines) is verified manually — the repo has no SwiftUI snapshot harness, and the state transitions driving the banner are unit-covered. Manual smoke: force a staging miss in a debug build → error banner appears, `reader document staging MISS` is visible in Console.app (subsystem `com.selfdrivingwiki.debug`), Try Again recovers.
- A separate blank-page path exists when `store.getPage` fails at selection time and `loadDrafts` sets `draftBody = ""` — the reader legitimately renders an empty document and the banner does not trigger for it. The staging-miss log disambiguates the two if blank pages persist.
