### PR TITLE
feat(deletion): protect page and source deletion at the store boundary

### DIFF
--- a/Sources/WikiCtlCore/ArgumentParser.swift
+++ b/Sources/WikiCtlCore/ArgumentParser.swift
@@ -215,7 +215,7 @@ public enum ArgumentParser {
             guard let id = options.value("--id") else {
                 throw Failure.usage("page delete: --id is required")
             }
-            return .page(.delete(id: PageID(rawValue: id)))
+            return .page(.delete(id: PageID(rawValue: id), unlinkIncoming: options.flag("--unlink-incoming")))
 
         case "search":
             guard let query = options.value("--query") else {

--- a/Sources/WikiCtlCore/CLIReference.swift
+++ b/Sources/WikiCtlCore/CLIReference.swift
@@ -265,9 +265,17 @@ public enum CLIReference {
                         "wikictl page add --title Draft --body-file - --expect-head 01ABC --author chat:01XYZ",
                     ]),
                 CLILeaf(
-                    "delete", summary: "delete a page",
-                    commandLine: "delete --id Y",
-                    options: [CLIOption("--id <page-id>", required: true, summary: "the page to delete")]),
+                    "delete", summary: "delete a page (removes bookmarks targeting it)",
+                    commandLine: "delete --id Y [--unlink-incoming]",
+                    options: [
+                        CLIOption("--id <page-id>", required: true, summary: "the page to delete"),
+                        CLIOption("--unlink-incoming", summary: "convert incoming links to plain text instead of leaving ghost links"),
+                    ],
+                    details: [
+                        "Bookmarks pointing at the page are always removed.",
+                        "Without --unlink-incoming, incoming [[links]] keep their text and render as ghost links; with it, they become plain display text.",
+                        "The cleanup counts are printed on stderr; stdout stays the deleted page id.",
+                    ]),
                 CLILeaf(
                     "search", summary: "semantic search (cosine similarity); falls back to LIKE title match",
                     commandLine: "search --query X [--limit N]",

--- a/Sources/WikiCtlCore/PageCommand.swift
+++ b/Sources/WikiCtlCore/PageCommand.swift
@@ -40,7 +40,11 @@ public enum PageCommand {
         /// `appendPageVersion` and a mismatch throws `PageConflictError`
         /// (Phase 1: agent CAS writes).
         case add(id: PageID?, title: String, body: BodySource, expectHead: PageVersionID? = nil, workspace: String? = nil, author: String? = nil, provenance: [PageVersionSourceInput] = [])
-        case delete(id: PageID)
+        /// Delete the page through the store's protected contract (issue #219
+        /// hardening): bookmarks targeting the page are ALWAYS removed, and
+        /// `unlinkIncoming` picks whether incoming `[[link]]` spans become
+        /// plain text (true) or stay as ghost links (false, the default).
+        case delete(id: PageID, unlinkIncoming: Bool = false)
         /// Semantic search: find pages by meaning (cosine similarity via
         /// Swift-side `VectorCosine`), falling back to LIKE title match.
         case search(query: String, limit: Int)
@@ -103,8 +107,8 @@ public enum PageCommand {
             let body = try resolveBodySource(bodySource)
             return try upsert(id: id, title: title, body: body, expectHead: expectHead, workspace: workspace, author: author,
                               provenance: mergedAgentIngestProvenance(provenance), in: store, validator: validator, linter: linter)
-        case .delete(let id):
-            return try delete(id: id, in: store)
+        case .delete(let id, let unlinkIncoming):
+            return try delete(id: id, unlinkIncoming: unlinkIncoming, in: store)
         case .search(let query, let limit):
             return try search(query: query, limit: limit, bm25Leg: bm25Leg, in: store)
         case .history(let selector):
@@ -401,9 +405,24 @@ public enum PageCommand {
 
     // MARK: - delete
 
-    private static func delete(id: PageID, in store: WikiStore) throws -> Result {
-        try store.deletePage(id: id)
-        return Result(output: id.rawValue, didCommit: true)
+    /// Deletes through the shared protected contract. The stdout contract is
+    /// unchanged (the page id); a concise stderr notice reports the mandatory
+    /// bookmark cleanup and what happened to the incoming links. `didCommit`
+    /// reflects actual committed change: a missing target with no stale
+    /// bookmarks is an idempotent no-op and posts no change notification.
+    private static func delete(id: PageID, unlinkIncoming: Bool, in store: WikiStore) throws -> Result {
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            target: .page(id),
+            linkPolicy: unlinkIncoming ? .unlink : .preserve))
+        let bookmarkCount = result.removedBookmarkIDs.count
+        let linkCount = result.incomingLinkCount
+        let linkDisposition = unlinkIncoming ? "unlinked" : "preserved as ghost links"
+        let notice = "removed \(bookmarkCount) bookmark\(bookmarkCount == 1 ? "" : "s"); "
+            + "\(linkCount) incoming link\(linkCount == 1 ? "" : "s") \(linkDisposition)"
+        let didCommit = !result.deletedTargets.isEmpty
+            || !result.removedBookmarkIDs.isEmpty
+            || !result.rewrittenPageIDs.isEmpty
+        return Result(output: id.rawValue, didCommit: didCommit, stderrOutput: notice)
     }
 
     // MARK: - search

--- a/Sources/WikiFS/Deletion/DeletionConfirmationCoordinator.swift
+++ b/Sources/WikiFS/Deletion/DeletionConfirmationCoordinator.swift
@@ -39,11 +39,16 @@ struct DeletionDialogPresentation: Equatable {
     }
 }
 
-/// Presentation for the provenance-blocked state: the blocking pages are
-/// named and the only action is acknowledgment — deletion is not offered.
+/// Presentation for the provenance-blocked state. The dialog stays a delete
+/// confirmation, but instead of a dead end it names the blocking pages as
+/// clickable entries the user can open to remove the reference.
 struct DeletionBlockedPresentation: Equatable {
     let title: String
-    let message: String
+    /// The explanatory intro (why deletion is blocked).
+    let intro: String
+    /// The distinct blocking pages with resolved titles, in deterministic
+    /// order — each renders as a clickable "Open …" action.
+    let blockingPages: [DeletionLinkingPage]
 }
 
 /// Presentation for a failed impact read (or any deletion-surface error the
@@ -79,7 +84,7 @@ enum DeletionConfirmationOutcome: Equatable {
         switch self {
         case .deleteImmediately: return ""
         case .confirm(let p): return p.message
-        case .blocked(let p): return p.message
+        case .blocked(let p): return p.intro
         case .failed(let p): return p.message
         }
     }
@@ -92,9 +97,17 @@ enum DeletionConfirmationOutcome: Equatable {
         }
     }
 
+    /// The pages named by the blocked state, for the clickable "Open …"
+    /// actions. Empty for every other state.
+    var blockingPages: [DeletionLinkingPage] {
+        if case .blocked(let p) = self { return p.blockingPages }
+        return []
+    }
+
     /// The destructive actions this outcome may invoke. Only `.confirm`
     /// exposes any — blocked and failed states can never route a deletion
-    /// through a dialog action.
+    /// through a dialog action. (The blocked state's "Open …" actions are
+    /// navigation, not deletion.)
     var availableActions: [DeletionDialogAction] {
         switch self {
         case .confirm(let p): return p.actions
@@ -116,13 +129,19 @@ enum DeletionResourceKind {
         }
     }
 
-    var blockedTitle: String { "Can't Delete Source" }
-
     var failureTitle: String {
         switch self {
         case .page: return "Couldn't Delete Page"
         case .source: return "Couldn't Delete Source"
         }
+    }
+
+    /// Title for the provenance-blocked dialog. Provenance blockers only
+    /// exist for sources (a page version citing the source as evidence), so
+    /// both kind branches use the same source wording; the count picks the
+    /// plural.
+    func blockedTitle(blockedSourceCount: Int) -> String {
+        blockedSourceCount == 1 ? "Source Is In Use" : "Sources Are In Use"
     }
 
     func failureMessage(for error: Error) -> String {
@@ -217,16 +236,24 @@ struct DeletionConfirmationCoordinator {
     }
 
     private func blockedPresentation(for impact: DeletionImpact) -> DeletionBlockedPresentation {
-        let pageIDs = Set(impact.provenanceBlockers.map(\.pageID))
-        let names = pageIDs.compactMap { id in
-            pageTitle?(id) ?? impact.linkingPages.first { $0.pageID == id }?.title
-        }.sorted()
-        let namesText = names.isEmpty
-            ? "\(pageIDs.count) page\(pageIDs.count == 1 ? "" : "s")"
-            : names.joined(separator: ", ")
+        // Distinct blocking sources set the plural; distinct blocking pages
+        // become the clickable entries (titled only — an untitled row cannot
+        // be opened).
+        let sourceCount = Set(impact.provenanceBlockers.map(\.sourceID)).count
+        var seen = Set<PageID>()
+        var pages: [DeletionLinkingPage] = []
+        for blocker in impact.provenanceBlockers where seen.insert(blocker.pageID).inserted {
+            let title = pageTitle?(blocker.pageID)
+                ?? impact.linkingPages.first { $0.pageID == blocker.pageID }?.title
+            if let title {
+                pages.append(DeletionLinkingPage(pageID: blocker.pageID, title: title))
+            }
+        }
         return DeletionBlockedPresentation(
-            title: kind.blockedTitle,
-            message: "This source is referenced as evidence by page versions (\(namesText)). Remove those references before deleting.")
+            title: kind.blockedTitle(blockedSourceCount: sourceCount),
+            intro: "This source is referenced as evidence by page versions. "
+                + "Remove those references before deleting:",
+            blockingPages: pages)
     }
 }
 
@@ -273,11 +300,15 @@ extension DeletionImpact {
 
 /// Renders the coordinator's outcome as the one confirmationDialog both the
 /// pages and the sources containers show. Each outcome surfaces exactly its
-/// own action set: confirm → the presentation's actions, blocked/failed → OK
+/// own action set: confirm → the presentation's actions, blocked → the
+/// blocking pages as clickable "Open …" actions plus Cancel, failed → OK
 /// only, immediate → nothing (the caller deletes without a dialog).
 struct DeletionOutcomeDialog: ViewModifier {
     @Binding var outcome: DeletionConfirmationOutcome?
     let onAction: (DeletionDialogAction) -> Void
+    /// Opens one of the blocked state's blocking pages (the containers route
+    /// this to a page tab). Nil where blockers cannot occur (pages).
+    var onOpenPage: ((PageID) -> Void)? = nil
 
     func body(content: Content) -> some View {
         content.confirmationDialog(
@@ -303,7 +334,17 @@ struct DeletionOutcomeDialog: ViewModifier {
             ForEach(presentation.actions, id: \.self) { action in
                 actionButton(action)
             }
-        case .blocked, .failed:
+        case .blocked(let presentation):
+            // The blocking pages as clickable entries: opening one dismisses
+            // the dialog so the user can remove the reference, then retry.
+            ForEach(presentation.blockingPages, id: \.pageID) { page in
+                Button("Open “\(page.title ?? page.pageID.rawValue)”") {
+                    onOpenPage?(page.pageID)
+                    outcome = nil
+                }
+            }
+            Button("Cancel", role: .cancel) { outcome = nil }
+        case .failed:
             Button("OK", role: .cancel) { outcome = nil }
         case .deleteImmediately, .none:
             EmptyView()
@@ -330,11 +371,15 @@ struct DeletionOutcomeDialog: ViewModifier {
 
 extension View {
     /// Attach the shared delete-confirmation surface driven by the
-    /// `DeletionConfirmationCoordinator` outcome.
+    /// `DeletionConfirmationCoordinator` outcome. `onOpenPage` handles the
+    /// blocked state's clickable blocking pages (pass nil where blockers
+    /// cannot occur).
     func deletionOutcomeDialog(
         _ outcome: Binding<DeletionConfirmationOutcome?>,
-        onAction: @escaping (DeletionDialogAction) -> Void
+        onAction: @escaping (DeletionDialogAction) -> Void,
+        onOpenPage: ((PageID) -> Void)? = nil
     ) -> some View {
-        modifier(DeletionOutcomeDialog(outcome: outcome, onAction: onAction))
+        modifier(DeletionOutcomeDialog(
+            outcome: outcome, onAction: onAction, onOpenPage: onOpenPage))
     }
 }

--- a/Sources/WikiFS/Deletion/DeletionConfirmationCoordinator.swift
+++ b/Sources/WikiFS/Deletion/DeletionConfirmationCoordinator.swift
@@ -1,0 +1,340 @@
+import Foundation
+import SwiftUI
+import WikiFSCore
+
+// MARK: - Shared delete-confirmation flow (issue #219 hardening)
+//
+// One coordinator owns the decision both the pages and the sources containers
+// make when the user deletes items: load the deletion impact (throwing — a
+// failed read NEVER reads as "nothing references this"), then route to one of
+// four typed states. The containers render only these states and invoke only
+// the typed decisions this coordinator maps, so both surfaces stay in lockstep.
+
+/// How the user chose to handle incoming links. The typed decision the
+/// containers pass back to the model — never a raw Bool.
+enum DeletionDecision: Equatable {
+    /// Convert matching incoming links/embeds to plain display text.
+    case unlink
+    /// Keep incoming Markdown as ghost links (bookmarks still go).
+    case preserve
+}
+
+/// The action set a confirmation dialog offers, in display order.
+enum DeletionDialogAction: Hashable, CaseIterable {
+    case unlinkAndDelete
+    case delete
+    case cancel
+}
+
+/// Presentation for the "what still references these items?" dialog.
+struct DeletionDialogPresentation: Equatable {
+    let title: String
+    let message: String
+    /// True when incoming links exist, so Unlink and Delete is offered.
+    let offersUnlink: Bool
+
+    /// The exact action set for this presentation, in display order.
+    var actions: [DeletionDialogAction] {
+        offersUnlink ? [.unlinkAndDelete, .delete, .cancel] : [.delete, .cancel]
+    }
+}
+
+/// Presentation for the provenance-blocked state: the blocking pages are
+/// named and the only action is acknowledgment — deletion is not offered.
+struct DeletionBlockedPresentation: Equatable {
+    let title: String
+    let message: String
+}
+
+/// Presentation for a failed impact read (or any deletion-surface error the
+/// user must see before anything was touched).
+struct DeletionFailurePresentation: Equatable {
+    let title: String
+    let message: String
+}
+
+/// The finite typed state of a delete confirmation (issue #219 hardening).
+enum DeletionConfirmationOutcome: Equatable {
+    /// Nothing references the selection and nothing blocks it — delete now,
+    /// no dialog.
+    case deleteImmediately
+    /// Show the confirmation dialog with the given action set.
+    case confirm(DeletionDialogPresentation)
+    /// A provenance blocker forbids deletion; only OK is offered.
+    case blocked(DeletionBlockedPresentation)
+    /// The impact read failed (or the store rejected the request); show the
+    /// store error and never invoke deletion.
+    case failed(DeletionFailurePresentation)
+
+    var dialogTitle: String {
+        switch self {
+        case .deleteImmediately: return ""
+        case .confirm(let p): return p.title
+        case .blocked(let p): return p.title
+        case .failed(let p): return p.title
+        }
+    }
+
+    var dialogMessage: String {
+        switch self {
+        case .deleteImmediately: return ""
+        case .confirm(let p): return p.message
+        case .blocked(let p): return p.message
+        case .failed(let p): return p.message
+        }
+    }
+
+    /// True while a dialog surface should be on screen.
+    var isDialogVisible: Bool {
+        switch self {
+        case .deleteImmediately: return false
+        case .confirm, .blocked, .failed: return true
+        }
+    }
+
+    /// The destructive actions this outcome may invoke. Only `.confirm`
+    /// exposes any — blocked and failed states can never route a deletion
+    /// through a dialog action.
+    var availableActions: [DeletionDialogAction] {
+        switch self {
+        case .confirm(let p): return p.actions
+        case .deleteImmediately, .blocked, .failed: return []
+        }
+    }
+}
+
+/// Which resource family a coordinator drives — carries the user-facing
+/// wording so pages and sources stay grammatical without duplicated logic.
+enum DeletionResourceKind {
+    case page
+    case source
+
+    func dialogTitle(count: Int) -> String {
+        switch self {
+        case .page: return count == 1 ? "Delete Page?" : "Delete \(count) Pages?"
+        case .source: return count == 1 ? "Delete Source?" : "Delete \(count) Sources?"
+        }
+    }
+
+    var blockedTitle: String { "Can't Delete Source" }
+
+    var failureTitle: String {
+        switch self {
+        case .page: return "Couldn't Delete Page"
+        case .source: return "Couldn't Delete Source"
+        }
+    }
+
+    func failureMessage(for error: Error) -> String {
+        switch self {
+        case .page: return "Could not check the page: \(error.localizedDescription)"
+        case .source: return "Could not check the source: \(error.localizedDescription)"
+        }
+    }
+}
+
+/// Shared, testable delete-confirmation coordinator. A value type: the
+/// container constructs one per deletion request with an impact loader and a
+/// delete callback, evaluates it once, and renders the outcome. Tests drive
+/// `evaluate()` and `perform(_:)` directly with stub loaders and record
+/// whether deletion was invoked.
+struct DeletionConfirmationCoordinator {
+    let kind: DeletionResourceKind
+    /// Loads one impact per selected id. Throwing — a failed load routes to
+    /// `.failed` and can never reach `onDelete`.
+    let loadImpacts: () throws -> [DeletionImpact]
+    /// The typed decision sink — called ONLY for `.deleteImmediately` and
+    /// `perform(.unlinkAndDelete / .delete)`. Never for blocked, failed, or
+    /// canceled flows.
+    let onDelete: (DeletionDecision) -> Void
+    /// Optional live-title resolver for provenance-blocking pages (they are
+    /// not necessarily linking pages, so the impact may not carry their
+    /// titles). Containers pass a summaries lookup; tests may pass nil.
+    var pageTitle: ((PageID) -> String?)? = nil
+    /// Number of selected items — for the dialog title's pluralization.
+    let selectionCount: Int
+
+    /// Evaluate the current references and produce the typed state.
+    func evaluate() -> DeletionConfirmationOutcome {
+        let impact: DeletionImpact
+        do {
+            impact = DeletionImpact.aggregated(try loadImpacts())
+        } catch {
+            // An impact-read failure must never read as "no references"
+            // (AC.10): produce the failed state; deletion stays unreachable.
+            return .failed(DeletionFailurePresentation(
+                title: kind.failureTitle,
+                message: kind.failureMessage(for: error)))
+        }
+        if impact.isProvenanceBlocked {
+            return .blocked(blockedPresentation(for: impact))
+        }
+        guard impact.hasReferences else { return .deleteImmediately }
+        return .confirm(confirmPresentation(for: impact))
+    }
+
+    /// Map a dialog action to the typed decision and invoke deletion. Cancel
+    /// invokes nothing.
+    func perform(_ action: DeletionDialogAction) {
+        switch action {
+        case .unlinkAndDelete: onDelete(.unlink)
+        case .delete: onDelete(.preserve)
+        case .cancel: break
+        }
+    }
+
+    // MARK: - Presentation builders
+
+    private func confirmPresentation(for impact: DeletionImpact) -> DeletionDialogPresentation {
+        var lines: [String] = []
+        switch kind {
+        case .page:
+            if !impact.linkingPages.isEmpty {
+                let names = impact.linkingPages.compactMap(\.title).joined(separator: ", ")
+                let noun = impact.linkingPages.count == 1 ? "page" : "pages"
+                lines.append("Linked from \(impact.linkingPages.count) \(noun): \(names).")
+            }
+        case .source:
+            if !impact.linkingPages.isEmpty {
+                let names = impact.linkingPages.compactMap(\.title).joined(separator: ", ")
+                let noun = impact.linkingPages.count == 1 ? "page" : "pages"
+                lines.append("Cited by \(impact.linkingPages.count) \(noun): \(names).")
+            }
+        }
+        if !impact.bookmarks.isEmpty {
+            let noun = impact.bookmarks.count == 1 ? "bookmark" : "bookmarks"
+            let paths = Set(impact.bookmarks.map(\.folderPath)).sorted().joined(separator: ", ")
+            lines.append("\(impact.bookmarks.count) \(noun) point to this and will be removed (\(paths)).")
+        }
+        if !impact.linkingPages.isEmpty {
+            let noun = kind == .page ? "links" : "citations"
+            lines.append("Unlink and Delete converts the \(noun) to plain text.")
+        }
+        return DeletionDialogPresentation(
+            title: kind.dialogTitle(count: selectionCount),
+            message: lines.joined(separator: "\n"),
+            offersUnlink: !impact.linkingPages.isEmpty)
+    }
+
+    private func blockedPresentation(for impact: DeletionImpact) -> DeletionBlockedPresentation {
+        let pageIDs = Set(impact.provenanceBlockers.map(\.pageID))
+        let names = pageIDs.compactMap { id in
+            pageTitle?(id) ?? impact.linkingPages.first { $0.pageID == id }?.title
+        }.sorted()
+        let namesText = names.isEmpty
+            ? "\(pageIDs.count) page\(pageIDs.count == 1 ? "" : "s")"
+            : names.joined(separator: ", ")
+        return DeletionBlockedPresentation(
+            title: kind.blockedTitle,
+            message: "This source is referenced as evidence by page versions (\(namesText)). Remove those references before deleting.")
+    }
+}
+
+// MARK: - Impact aggregation (batch semantics)
+
+extension DeletionImpact {
+    /// Merge the per-id impacts of a batch deletion into one: distinct
+    /// linking pages (first title wins), distinct bookmark nodes, all
+    /// provenance blockers deduplicated, and summed incoming-link edge
+    /// counts. Deterministic — every list keeps its raw-ULID order.
+    static func aggregated(_ impacts: [DeletionImpact]) -> DeletionImpact {
+        guard impacts.count > 1 else { return impacts.first ?? DeletionImpact(
+            linkingPages: [], bookmarks: [], provenanceBlockers: [], incomingLinkCount: 0) }
+
+        var linkingByID: [PageID: DeletionLinkingPage] = [:]
+        var bookmarksByID: [BookmarkID: DeletionBookmarkImpact] = [:]
+        var blockers = Set<ProvenanceDeletionBlocker>()
+        var incomingLinkCount = 0
+        for impact in impacts {
+            for page in impact.linkingPages where linkingByID[page.pageID] == nil {
+                linkingByID[page.pageID] = page
+            }
+            for bookmark in impact.bookmarks where bookmarksByID[bookmark.nodeID] == nil {
+                bookmarksByID[bookmark.nodeID] = bookmark
+            }
+            blockers.formUnion(impact.provenanceBlockers)
+            incomingLinkCount += impact.incomingLinkCount
+        }
+        return DeletionImpact(
+            linkingPages: linkingByID.values.sorted { $0.pageID.rawValue < $1.pageID.rawValue },
+            bookmarks: bookmarksByID.values.sorted { $0.nodeID.rawValue < $1.nodeID.rawValue },
+            provenanceBlockers: blockers.sorted { a, b in
+                if a.pageID.rawValue != b.pageID.rawValue { return a.pageID.rawValue < b.pageID.rawValue }
+                if a.pageVersionID.rawValue != b.pageVersionID.rawValue {
+                    return a.pageVersionID.rawValue < b.pageVersionID.rawValue
+                }
+                return a.sourceID.rawValue < b.sourceID.rawValue
+            },
+            incomingLinkCount: incomingLinkCount)
+    }
+}
+
+// MARK: - Shared dialog surface (both containers)
+
+/// Renders the coordinator's outcome as the one confirmationDialog both the
+/// pages and the sources containers show. Each outcome surfaces exactly its
+/// own action set: confirm → the presentation's actions, blocked/failed → OK
+/// only, immediate → nothing (the caller deletes without a dialog).
+struct DeletionOutcomeDialog: ViewModifier {
+    @Binding var outcome: DeletionConfirmationOutcome?
+    let onAction: (DeletionDialogAction) -> Void
+
+    func body(content: Content) -> some View {
+        content.confirmationDialog(
+            outcome?.dialogTitle ?? "",
+            isPresented: Binding(
+                get: { outcome?.isDialogVisible ?? false },
+                set: { if !$0 { outcome = nil } }
+            ),
+            titleVisibility: (outcome?.dialogTitle.isEmpty == false) ? .visible : .automatic
+        ) {
+            dialogActions
+        } message: {
+            if let message = outcome?.dialogMessage, !message.isEmpty {
+                Text(message)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var dialogActions: some View {
+        switch outcome {
+        case .confirm(let presentation):
+            ForEach(presentation.actions, id: \.self) { action in
+                actionButton(action)
+            }
+        case .blocked, .failed:
+            Button("OK", role: .cancel) { outcome = nil }
+        case .deleteImmediately, .none:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func actionButton(_ action: DeletionDialogAction) -> some View {
+        switch action {
+        case .unlinkAndDelete:
+            Button("Unlink and Delete", role: .destructive) { fire(action) }
+        case .delete:
+            Button("Delete", role: .destructive) { fire(action) }
+        case .cancel:
+            Button("Cancel", role: .cancel) { fire(action) }
+        }
+    }
+
+    private func fire(_ action: DeletionDialogAction) {
+        onAction(action)
+        outcome = nil
+    }
+}
+
+extension View {
+    /// Attach the shared delete-confirmation surface driven by the
+    /// `DeletionConfirmationCoordinator` outcome.
+    func deletionOutcomeDialog(
+        _ outcome: Binding<DeletionConfirmationOutcome?>,
+        onAction: @escaping (DeletionDialogAction) -> Void
+    ) -> some View {
+        modifier(DeletionOutcomeDialog(outcome: outcome, onAction: onAction))
+    }
+}

--- a/Sources/WikiFS/Pages/PagesContainerView.swift
+++ b/Sources/WikiFS/Pages/PagesContainerView.swift
@@ -20,10 +20,12 @@ struct PagesContainerView: View {
     @State private var renameText = ""
     /// Non-nil while the bookmark-target picker is open for a page selection.
     @State private var addToBookmarksContext: BookmarkTargetPickerContext?
-    /// Non-nil while the incoming-reference delete confirmation is open. Set
-    /// when the user deletes a page that other pages link to or bookmarks point
-    /// at (issue #219).
-    @State private var pendingDeletion: PendingPageDeletion?
+    /// Non-nil while a delete-confirmation surface is on screen (issue #219
+    /// hardening): the typed outcome produced by the shared
+    /// `DeletionConfirmationCoordinator`.
+    @State private var deletionOutcome: DeletionConfirmationOutcome?
+    /// The page ids behind `deletionOutcome` — what the action handler deletes.
+    @State private var pendingDeletionIDs: [PageID] = []
 
     private var visible: [WikiPageSummary] {
         store.searchQuery.isEmpty ? store.summaries : store.searchResults
@@ -74,15 +76,8 @@ struct PagesContainerView: View {
                 }
             )
         }
-        .confirmationDialog(
-            pendingDeletion.map { deletionDialogTitle(ids: $0.ids) } ?? "",
-            isPresented: deletionDialogPresented,
-            titleVisibility: .visible,
-            presenting: pendingDeletion
-        ) { pending in
-            deletionDialogActions(for: pending)
-        } message: { pending in
-            Text(deletionDialogMessage(for: pending))
+        .deletionOutcomeDialog($deletionOutcome) { action in
+            handleDeletionAction(action)
         }
     }
 
@@ -236,106 +231,58 @@ struct PagesContainerView: View {
         )
     }
 
-    // MARK: - Delete with incoming-reference warning (issue #219)
+    // MARK: - Delete with incoming-reference warning (issue #219 hardening)
 
-    /// Aggregate the incoming links + bookmarks for the selected pages, then
-    /// either delete immediately (nothing references them) or open the
-    /// confirmation dialog so the user can see and choose how to handle them.
+    /// Aggregate the incoming links + bookmarks for the selected pages via the
+    /// shared coordinator, then either delete immediately (nothing references
+    /// them) or route to the typed confirmation state.
     private func requestPageDeletion(_ ids: [PageID]) {
-        let deletedIDs = Set(ids)
-        var linkingIDs: [PageID] = []
-        var bookmarkFolders: Set<String> = []
-        var bookmarkCount = 0
-        for id in ids {
-            let impact = store.deletionImpact(forPage: id)
-            linkingIDs.append(contentsOf: impact.linkingPageIDs)
-            bookmarkCount += impact.bookmarkLabels.count
-            bookmarkFolders.formUnion(impact.bookmarkLabels)
-        }
-        // Drop pages that are themselves being deleted (they vanish with the
-        // batch), then dedupe for display.
-        let displayTitles = Array(Set(linkingIDs))
-            .filter { !deletedIDs.contains($0) }
-            .compactMap { id in store.summaries.first { $0.id == id }?.title }
-            .sorted()
-
-        if displayTitles.isEmpty && bookmarkCount == 0 {
-            confirmPageDeletion(ids: ids, unlink: false)
+        pendingDeletionIDs = ids
+        let coordinator = DeletionConfirmationCoordinator(
+            kind: .page,
+            loadImpacts: {
+                try ids.map { try store.deletionImpact(forPage: $0) }
+            },
+            onDelete: { decision in
+                performPageDeletion(ids: ids, decision: decision)
+            },
+            pageTitle: { id in
+                store.summaries.first { $0.id == id }?.title
+            },
+            selectionCount: ids.count)
+        let outcome = coordinator.evaluate()
+        if case .deleteImmediately = outcome {
+            // No references, no blockers — delete without a dialog.
+            coordinator.perform(.delete)
         } else {
-            pendingDeletion = PendingPageDeletion(
-                ids: ids,
-                linkingPageTitles: displayTitles,
-                bookmarkCount: bookmarkCount,
-                bookmarkFolders: bookmarkFolders.sorted())
+            deletionOutcome = outcome
         }
     }
 
-    private func confirmPageDeletion(ids: [PageID], unlink: Bool) {
-        for id in ids { store.delete(id, unlinkIncomingLinks: unlink) }
-        // If a deleted page was the home page, clear the stale homePageID so the
-        // Home button doesn't linger as dead UI.
-        if let homeID = session.descriptor.homePageID, ids.contains(homeID) {
+    private func performPageDeletion(ids: [PageID], decision: DeletionDecision) {
+        // ONE protected transaction for the whole selection; on failure the
+        // model surfaces the store error and returns nil (nothing changed).
+        guard let result = store.performPageDeletion(
+            ids, unlinkIncomingLinks: decision == .unlink) else { return }
+        // If a deleted page was the home page, clear the stale homePageID so
+        // the Home button doesn't linger as dead UI. Runs only for pages the
+        // store reports as actually deleted.
+        let deletedIDs = result.deletedTargets.compactMap(\.pageID)
+        if let homeID = session.descriptor.homePageID, deletedIDs.contains(homeID) {
             registry.setHomePage(id: session.wikiID, pageID: nil)
             var d = session.descriptor
             d.homePageID = nil
             session.updateDescriptor(d)
         }
-        pendingDeletion = nil
     }
 
-    private var deletionDialogPresented: Binding<Bool> {
-        Binding(
-            get: { pendingDeletion != nil },
-            set: { if !$0 { pendingDeletion = nil } }
-        )
-    }
-
-    private func deletionDialogTitle(ids: [PageID]) -> String {
-        ids.count == 1 ? "Delete Page?" : "Delete \(ids.count) Pages?"
-    }
-
-    private func deletionDialogMessage(for pending: PendingPageDeletion) -> String {
-        var lines: [String] = []
-        if !pending.linkingPageTitles.isEmpty {
-            let names = pending.linkingPageTitles.joined(separator: ", ")
-            let noun = pending.linkingPageTitles.count == 1 ? "page" : "pages"
-            lines.append("Linked from \(pending.linkingPageTitles.count) \(noun): \(names).")
+    private func handleDeletionAction(_ action: DeletionDialogAction) {
+        let ids = pendingDeletionIDs
+        switch action {
+        case .unlinkAndDelete: performPageDeletion(ids: ids, decision: .unlink)
+        case .delete: performPageDeletion(ids: ids, decision: .preserve)
+        case .cancel: break
         }
-        if pending.bookmarkCount > 0 {
-            let noun = pending.bookmarkCount == 1 ? "bookmark" : "bookmarks"
-            let where_ = pending.bookmarkFolders.joined(separator: ", ")
-            lines.append("\(pending.bookmarkCount) \(noun) point to this and will be removed (\(where_)).")
-        }
-        if !pending.linkingPageTitles.isEmpty {
-            lines.append("Unlink and Delete converts the links to plain text.")
-        }
-        return lines.joined(separator: "\n")
+        pendingDeletionIDs = []
     }
-
-    @ViewBuilder
-    private func deletionDialogActions(for pending: PendingPageDeletion) -> some View {
-        if !pending.linkingPageTitles.isEmpty {
-            Button("Unlink and Delete", role: .destructive) {
-                confirmPageDeletion(ids: pending.ids, unlink: true)
-            }
-            Button("Delete", role: .destructive) {
-                confirmPageDeletion(ids: pending.ids, unlink: false)
-            }
-        } else {
-            Button("Delete", role: .destructive) {
-                confirmPageDeletion(ids: pending.ids, unlink: false)
-            }
-        }
-        Button("Cancel", role: .cancel) { pendingDeletion = nil }
-    }
-}
-
-/// State carried by the incoming-reference delete-confirmation dialog
-/// (issue #219).
-private struct PendingPageDeletion: Identifiable {
-    let id = UUID()
-    let ids: [PageID]
-    let linkingPageTitles: [String]
-    let bookmarkCount: Int
-    let bookmarkFolders: [String]
 }

--- a/Sources/WikiFS/Sources/SourcesContainerView.swift
+++ b/Sources/WikiFS/Sources/SourcesContainerView.swift
@@ -118,9 +118,17 @@ struct SourcesContainerView: View {
                 }
             )
         }
-        .deletionOutcomeDialog($deletionOutcome) { action in
-            handleDeletionAction(action)
-        }
+        .deletionOutcomeDialog(
+            $deletionOutcome,
+            onAction: { action in
+                handleDeletionAction(action)
+            },
+            onOpenPage: { pageID in
+                // A clickable blocking page: open it so the user can remove
+                // the provenance reference, then retry the delete.
+                store.openTab(.page(pageID))
+            }
+        )
     }
 
     private var sourcesHeader: some View {

--- a/Sources/WikiFS/Sources/SourcesContainerView.swift
+++ b/Sources/WikiFS/Sources/SourcesContainerView.swift
@@ -32,8 +32,12 @@ struct SourcesContainerView: View {
     @State private var pendingReingestNames: [String] = []
     /// Non-nil while the bookmark-target picker is open for a source selection.
     @State private var addToBookmarksContext: BookmarkTargetPickerContext?
-    /// Non-nil while the incoming-reference delete confirmation is open (issue #219).
-    @State private var pendingDeletion: PendingSourceDeletion?
+    /// Non-nil while a delete-confirmation surface is on screen (issue #219
+    /// hardening): the typed outcome produced by the shared
+    /// `DeletionConfirmationCoordinator`.
+    @State private var deletionOutcome: DeletionConfirmationOutcome?
+    /// The source ids behind `deletionOutcome` — what the action handler deletes.
+    @State private var pendingDeletionIDs: [SourceID] = []
 
     enum SourceFilter: String, CaseIterable {
         case all = "All"
@@ -114,15 +118,8 @@ struct SourcesContainerView: View {
                 }
             )
         }
-        .confirmationDialog(
-            pendingDeletion.map { deletionDialogTitle(for: $0) } ?? "",
-            isPresented: deletionDialogPresented,
-            titleVisibility: .visible,
-            presenting: pendingDeletion
-        ) { pending in
-            deletionDialogActions(for: pending)
-        } message: { pending in
-            Text(deletionDialogMessage(for: pending))
+        .deletionOutcomeDialog($deletionOutcome) { action in
+            handleDeletionAction(action)
         }
     }
 
@@ -288,107 +285,47 @@ struct SourcesContainerView: View {
         )
     }
 
-    // MARK: - Delete with incoming-reference warning (issue #219)
+    // MARK: - Delete with incoming-reference warning (issue #219 hardening)
 
+    /// Aggregate the incoming citations + bookmarks + provenance blockers for
+    /// the selected sources via the shared coordinator, then either delete
+    /// immediately (nothing references them) or route to the typed state.
     private func requestSourceDeletion(_ ids: [SourceID]) {
-        var linkingIDs: [PageID] = []
-        var bookmarkFolders: Set<String> = []
-        var bookmarkCount = 0
-        var blockedPageIDs = Set<PageID>()
-        for id in ids {
-            let impact = store.deletionImpact(forSource: id)
-            linkingIDs.append(contentsOf: impact.linkingPageIDs)
-            bookmarkCount += impact.bookmarkLabels.count
-            bookmarkFolders.formUnion(impact.bookmarkLabels)
-            blockedPageIDs.formUnion(impact.provenanceBlockers.map(\.pageID))
-        }
-        let displayTitles = Array(Set(linkingIDs))
-            .compactMap { id in store.summaries.first { $0.id == id }?.title }
-            .sorted()
-        let blockedTitles = blockedPageIDs
-            .compactMap { id in store.summaries.first { $0.id == id }?.title }
-            .sorted()
-
-        if blockedTitles.isEmpty && displayTitles.isEmpty && bookmarkCount == 0 {
-            confirmSourceDeletion(ids: ids, unlink: false)
+        pendingDeletionIDs = ids
+        let coordinator = DeletionConfirmationCoordinator(
+            kind: .source,
+            loadImpacts: {
+                try ids.map { try store.deletionImpact(forSource: $0) }
+            },
+            onDelete: { decision in
+                performSourceDeletion(ids: ids, decision: decision)
+            },
+            pageTitle: { id in
+                store.summaries.first { $0.id == id }?.title
+            },
+            selectionCount: ids.count)
+        let outcome = coordinator.evaluate()
+        if case .deleteImmediately = outcome {
+            // No references, no blockers — delete without a dialog.
+            coordinator.perform(.delete)
         } else {
-            pendingDeletion = PendingSourceDeletion(
-                ids: ids,
-                linkingPageTitles: displayTitles,
-                bookmarkCount: bookmarkCount,
-                bookmarkFolders: bookmarkFolders.sorted(),
-                blockedPageTitles: blockedTitles)
+            deletionOutcome = outcome
         }
     }
 
-    private func confirmSourceDeletion(ids: [SourceID], unlink: Bool) {
-        for id in ids { store.deleteSource(id, unlinkIncomingLinks: unlink) }
-        pendingDeletion = nil
+    private func performSourceDeletion(ids: [SourceID], decision: DeletionDecision) {
+        // ONE protected transaction for the whole selection; on failure the
+        // model surfaces the store error and returns nil (nothing changed).
+        _ = store.performSourceDeletion(ids, unlinkIncomingLinks: decision == .unlink)
     }
 
-    private var deletionDialogPresented: Binding<Bool> {
-        Binding(
-            get: { pendingDeletion != nil },
-            set: { if !$0 { pendingDeletion = nil } }
-        )
+    private func handleDeletionAction(_ action: DeletionDialogAction) {
+        let ids = pendingDeletionIDs
+        switch action {
+        case .unlinkAndDelete: performSourceDeletion(ids: ids, decision: .unlink)
+        case .delete: performSourceDeletion(ids: ids, decision: .preserve)
+        case .cancel: break
+        }
+        pendingDeletionIDs = []
     }
-
-    private func deletionDialogTitle(for pending: PendingSourceDeletion) -> String {
-        if !pending.blockedPageTitles.isEmpty { return "Can't Delete Source" }
-        return pending.ids.count == 1 ? "Delete Source?" : "Delete \(pending.ids.count) Sources?"
-    }
-
-    private func deletionDialogMessage(for pending: PendingSourceDeletion) -> String {
-        if !pending.blockedPageTitles.isEmpty {
-            let names = pending.blockedPageTitles.joined(separator: ", ")
-            return "This source is referenced as evidence by page versions (\(names)). Remove those references before deleting."
-        }
-        var lines: [String] = []
-        if !pending.linkingPageTitles.isEmpty {
-            let names = pending.linkingPageTitles.joined(separator: ", ")
-            let noun = pending.linkingPageTitles.count == 1 ? "page" : "pages"
-            lines.append("Cited by \(pending.linkingPageTitles.count) \(noun): \(names).")
-        }
-        if pending.bookmarkCount > 0 {
-            let noun = pending.bookmarkCount == 1 ? "bookmark" : "bookmarks"
-            let where_ = pending.bookmarkFolders.joined(separator: ", ")
-            lines.append("\(pending.bookmarkCount) \(noun) point to this and will be removed (\(where_)).")
-        }
-        if !pending.linkingPageTitles.isEmpty {
-            lines.append("Unlink and Delete converts the citations to plain text.")
-        }
-        return lines.joined(separator: "\n")
-    }
-
-    @ViewBuilder
-    private func deletionDialogActions(for pending: PendingSourceDeletion) -> some View {
-        if !pending.blockedPageTitles.isEmpty {
-            Button("OK", role: .cancel) { pendingDeletion = nil }
-        } else if !pending.linkingPageTitles.isEmpty {
-            Button("Unlink and Delete", role: .destructive) {
-                confirmSourceDeletion(ids: pending.ids, unlink: true)
-            }
-            Button("Delete", role: .destructive) {
-                confirmSourceDeletion(ids: pending.ids, unlink: false)
-            }
-            Button("Cancel", role: .cancel) { pendingDeletion = nil }
-        } else {
-            Button("Delete", role: .destructive) {
-                confirmSourceDeletion(ids: pending.ids, unlink: false)
-            }
-            Button("Cancel", role: .cancel) { pendingDeletion = nil }
-        }
-    }
-}
-
-/// State carried by the incoming-reference delete-confirmation dialog
-/// (issue #219). When `blockedPageTitles` is non-empty, the source can't be
-/// deleted at all (provenance-restricted) and only an OK button is shown.
-private struct PendingSourceDeletion: Identifiable {
-    let id = UUID()
-    let ids: [SourceID]
-    let linkingPageTitles: [String]
-    let bookmarkCount: Int
-    let bookmarkFolders: [String]
-    let blockedPageTitles: [String]
 }

--- a/Sources/WikiFSCore/Core/DeletionImpact.swift
+++ b/Sources/WikiFSCore/Core/DeletionImpact.swift
@@ -1,41 +1,228 @@
 import Foundation
 
-/// A snapshot of what references a page or source that the user is about to
-/// delete (issue #219). The model computes this before showing the
-/// delete-confirmation dialog so the user can see incoming links, bookmarks,
-/// and (for sources) provenance blockers, then choose how to proceed.
-public struct DeletionImpact: Sendable, Equatable {
-    /// Pages that link to the target (excludes the target itself). The UI maps
-    /// these to titles via `summaries`; the unlink path uses the ids directly.
-    public let linkingPageIDs: [PageID]
-    /// Where each referencing bookmark lives, as a folder display path
-    /// (e.g. `"Research / Papers"`; `"Bookmarks"` for a root-level node).
-    public let bookmarkLabels: [String]
-    /// Page versions whose provenance cites this resource, making deletion
-    /// impossible. Always empty for pages; populated for sources the agent has
-    /// used to author pages (issue #219).
-    public let provenanceBlockers: [ProvenanceDeletionBlocker]
+/// How a protected deletion treats the incoming Markdown links that point at
+/// the deleted targets (issue #219). Bookmarks are NOT policy-governed — every
+/// protected deletion removes matching bookmark leaves unconditionally, because
+/// a bookmark to a missing page or source is invalid.
+public enum ResourceDeletionLinkPolicy: Equatable, Hashable, Sendable {
+    /// Keep the Markdown link text unchanged. After the target row is deleted
+    /// the link renders as a "ghost link" (its target no longer resolves).
+    case preserve
+    /// Convert every matching link and embed to its plain display text before
+    /// the target rows are deleted, so no ghost links survive. Unrelated links
+    /// and protected code ranges are left untouched.
+    case unlink
+}
 
-    public init(
-        linkingPageIDs: [PageID],
-        bookmarkLabels: [String],
-        provenanceBlockers: [ProvenanceDeletionBlocker] = []
-    ) {
-        self.linkingPageIDs = linkingPageIDs
-        self.bookmarkLabels = bookmarkLabels
-        self.provenanceBlockers = provenanceBlockers
+/// One deletion target. `PageID` and `SourceID` are separate id namespaces;
+/// the case tag keeps a page ULID from ever comparing equal to a source ULID
+/// (the same discipline as `BookmarkNode.Content`).
+public enum ResourceDeletionTarget: Hashable, Sendable {
+    case page(PageID)
+    case source(SourceID)
+
+    /// The page row ids carried by this target set (empty when none).
+    public var pageID: PageID? {
+        switch self {
+        case .page(let id): return id
+        case .source: return nil
+        }
     }
 
+    /// The source row ids carried by this target set (empty when none).
+    public var sourceID: SourceID? {
+        switch self {
+        case .page: return nil
+        case .source(let id): return id
+        }
+    }
+
+    /// Deterministic sort key: pages before sources, then raw ULID ascending.
+    private var sortKey: (kind: Int, raw: String) {
+        switch self {
+        case .page(let id): return (0, id.rawValue)
+        case .source(let id): return (1, id.rawValue)
+        }
+    }
+
+    /// The members of `targets` in the canonical deterministic order (pages
+    /// before sources, raw ULID ascending within each kind). Every result and
+    /// impact collection downstream of a request uses this order.
+    public static func sorted(_ targets: Set<ResourceDeletionTarget>) -> [ResourceDeletionTarget] {
+        targets.sorted { a, b in
+            let (ka, ra) = a.sortKey
+            let (kb, rb) = b.sortKey
+            return ka != kb ? ka < kb : ra < rb
+        }
+    }
+}
+
+/// A normalized, policy-carrying deletion request — the single input to
+/// `WikiStore.deleteResources(_:)`. Duplicate ids collapse into one effect and
+/// one result entry (the stored value is a typed set).
+public struct ResourceDeletionRequest: Equatable, Sendable {
+    /// The distinct targets to delete, across both id namespaces.
+    public let targets: Set<ResourceDeletionTarget>
+    /// How incoming Markdown links to these targets are treated.
+    public let linkPolicy: ResourceDeletionLinkPolicy
+
+    public init(targets: Set<ResourceDeletionTarget>, linkPolicy: ResourceDeletionLinkPolicy) {
+        self.targets = targets
+        self.linkPolicy = linkPolicy
+    }
+
+    /// Convenience: accepts any order, tolerates duplicates (normalized to a set).
+    public init(targets: [ResourceDeletionTarget], linkPolicy: ResourceDeletionLinkPolicy) {
+        self.init(targets: Set(targets), linkPolicy: linkPolicy)
+    }
+
+    /// Convenience: a single-target request (the compatibility forwarder shape).
+    public init(target: ResourceDeletionTarget, linkPolicy: ResourceDeletionLinkPolicy) {
+        self.init(targets: [target], linkPolicy: linkPolicy)
+    }
+
+    /// The page members in deterministic order.
+    public var pageIDs: [PageID] {
+        ResourceDeletionTarget.sorted(targets).compactMap(\.pageID)
+    }
+
+    /// The source members in deterministic order.
+    public var sourceIDs: [SourceID] {
+        ResourceDeletionTarget.sorted(targets).compactMap(\.sourceID)
+    }
+}
+
+/// One page whose body links to a deletion target — the stable identity plus
+/// its presentation title. `title` is presentation data only; `pageID` is the
+/// key every decision and rewrite routes through.
+public struct DeletionLinkingPage: Equatable, Hashable, Sendable {
+    public let pageID: PageID
+    /// The live `pages.title`, or `nil` when the row has vanished.
+    public let title: String?
+
+    public init(pageID: PageID, title: String?) {
+        self.pageID = pageID
+        self.title = title
+    }
+}
+
+/// One bookmark leaf that points at a deletion target — the stable node
+/// identity plus where it lives. `folderPath` is presentation data (e.g.
+/// `"Research / Papers"`; `"Bookmarks"` for a root-level node); `nodeID` is
+/// the key the protected delete uses to remove the row.
+public struct DeletionBookmarkImpact: Equatable, Hashable, Sendable {
+    public let nodeID: BookmarkID
+    public let folderPath: String
+
+    public init(nodeID: BookmarkID, folderPath: String) {
+        self.nodeID = nodeID
+        self.folderPath = folderPath
+    }
+}
+
+/// A snapshot of what references the page(s) and/or source(s) the user is
+/// about to delete (issue #219). The store computes this — both for the
+/// pre-delete confirmation (`deletionImpact(for:)`) and again inside the
+/// protected write transaction — so the UI decides on the same data the write
+/// revalidates.
+///
+/// Ordering contract: `linkingPages`, `bookmarks`, and `provenanceBlockers`
+/// are each deterministically ordered (linking pages and bookmarks by raw
+/// ULID; blockers by page, then version, then source), so the same store
+/// state always produces an equal impact value.
+public struct DeletionImpact: Sendable, Equatable {
+    /// Pages whose bodies link to any target (excludes targets themselves).
+    public let linkingPages: [DeletionLinkingPage]
+    /// Bookmarks that point at any target. Every one of these rows is removed
+    /// by the protected delete — there is no keep-bookmarks option.
+    public let bookmarks: [DeletionBookmarkImpact]
+    /// Page versions whose provenance cites a selected source, making the
+    /// deletion impossible. Always empty for page-only requests; the store
+    /// throws `WikiStoreError.deletionRestricted` before any write when set.
+    public let provenanceBlockers: [ProvenanceDeletionBlocker]
+    /// The number of link edges (`page_links` + `source_links`) pointing at
+    /// the target set. This is the count a `.preserve` delete leaves as ghost
+    /// links and an `.unlink` delete converts to plain text.
+    public let incomingLinkCount: Int
+
+    public init(
+        linkingPages: [DeletionLinkingPage],
+        bookmarks: [DeletionBookmarkImpact],
+        provenanceBlockers: [ProvenanceDeletionBlocker] = [],
+        incomingLinkCount: Int = 0
+    ) {
+        self.linkingPages = linkingPages
+        self.bookmarks = bookmarks
+        self.provenanceBlockers = provenanceBlockers
+        self.incomingLinkCount = incomingLinkCount
+    }
+
+    /// The linking pages' stable identities, in impact order.
+    public var linkingPageIDs: [PageID] { linkingPages.map(\.pageID) }
+
+    /// The bookmarks' folder paths, in impact order (presentation projection).
+    public var bookmarkLabels: [String] { bookmarks.map(\.folderPath) }
+
     /// True when a provenance edge prevents deletion — the dialog must NOT
-    /// offer to delete (the store would throw).
+    /// offer to delete (the store throws before any write).
     public var isProvenanceBlocked: Bool { !provenanceBlockers.isEmpty }
 
     /// True when there is at least one incoming link or bookmark.
     public var hasReferences: Bool {
-        !linkingPageIDs.isEmpty || !bookmarkLabels.isEmpty
+        !linkingPages.isEmpty || !bookmarks.isEmpty
     }
 
     /// True when the delete-confirmation dialog should be shown at all — any
     /// incoming reference OR a provenance block.
     public var showsDialog: Bool { hasReferences || isProvenanceBlocked }
+}
+
+/// The committed outcome of one protected deletion
+/// (`WikiStore.deleteResources(_:)`). Everything here is post-commit truth:
+/// the rows are gone, the rewrites are durable, and the emitted events
+/// correspond exactly to these identities.
+public struct ResourceDeletionResult: Equatable, Sendable {
+    /// Targets whose rows were actually deleted, in deterministic order. A
+    /// missing (already-gone) target does NOT appear here — its deletion is an
+    /// idempotent no-op.
+    public let deletedTargets: [ResourceDeletionTarget]
+    /// Pages whose bodies were rewritten (`.unlink` policy only), in
+    /// deterministic order.
+    public let rewrittenPageIDs: [PageID]
+    /// Bookmark leaves removed because they pointed at a deleted target, in
+    /// deterministic order.
+    public let removedBookmarkIDs: [BookmarkID]
+    /// The number of incoming link edges that pointed at the deleted targets:
+    /// the ghost links preserved (`.preserve`) or the spans unlinked
+    /// (`.unlink`).
+    public let incomingLinkCount: Int
+
+    public init(
+        deletedTargets: [ResourceDeletionTarget],
+        rewrittenPageIDs: [PageID],
+        removedBookmarkIDs: [BookmarkID],
+        incomingLinkCount: Int
+    ) {
+        self.deletedTargets = deletedTargets
+        self.rewrittenPageIDs = rewrittenPageIDs
+        self.removedBookmarkIDs = removedBookmarkIDs
+        self.incomingLinkCount = incomingLinkCount
+    }
+}
+
+/// Where a protected deletion should deterministically fail. This is a TEST
+/// seam for the transaction rollback contract (issue #219 hardening): every
+/// non-`none` case throws inside the outer write transaction, so the whole
+/// operation rolls back as one unit. Production always uses `.none` — the
+/// value lives on the concrete store as an internal var defaulted to `.none`
+/// and is never set by app or CLI code.
+enum ProtectedDeletionFailurePoint: Equatable, Sendable {
+    /// No injected failure (the only production value).
+    case none
+    /// Throw after the link rewrites have been staged.
+    case afterRewrite
+    /// Throw after the bookmark cleanup has been staged.
+    case afterBookmarkCleanup
+    /// Throw immediately before the target rows are deleted.
+    case beforeTargetDeletion
 }

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -4241,25 +4241,10 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
         }
     }
 
+    /// Compatibility forwarder — the protected contract under `.preserve`.
+    /// See `deleteResources(_:)` for the atomicity + event guarantees.
     public func deletePage(id: PageID) throws {
-        try mutate(event: { _ in
-            self.localEvent(.page, id: id.rawValue, change: .deleted)
-        }) { db in
-            // FK safety: page_links, attachments, source_links all have FKs
-            // onto pages(id) WITHOUT ON DELETE CASCADE (unlike page_chunks).
-            // Clear every dependent row first, then delete the page — all in
-            // ONE transaction (dbWriter.write provides this).
-            try db.execute(sql: "DELETE FROM page_links WHERE from_page_id = ? OR to_page_id = ?;",
-                           arguments: [id.rawValue, id.rawValue])
-            try db.execute(sql: "DELETE FROM source_links WHERE from_page_id = ?;",
-                           arguments: [id.rawValue])
-            try db.execute(sql: "DELETE FROM attachments WHERE page_id = ?;",
-                           arguments: [id.rawValue])
-            try db.execute(sql: "DELETE FROM refs WHERE owner_id = ? AND kind = 'page-content';",
-                           arguments: [id.rawValue])
-            try db.execute(sql: "DELETE FROM pages WHERE id = ?;",
-                           arguments: [id.rawValue])
-        }
+        try deleteResources(ResourceDeletionRequest(target: .page(id), linkPolicy: .preserve))
     }
 
     public func resolveTitleToID(_ title: String) throws -> PageID? {
@@ -4287,63 +4272,73 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
         try mutate(event: { _ in
             self.localEvent(.page, id: pageID.rawValue, change: .updated)
         }) { db in
-            // Delete all existing outgoing page + source links, then insert the
-            // resolved subset. Faithful port of `SQLiteWikiStore.replaceLinks`:
-            // canonical-ULID targets validate by id (direct row fetch); legacy
-            // and forward links resolve by name via `resolveLinkTarget`. All
-            // resolvers used here are the `*Locked` variants that take the
-            // in-transaction `db` — the public `resolveTitleToID` /
-            // `resolveSourceByName` open their own `dbWriter.read`, which would
-            // re-enter the DatabasePool's serial queue and hit GRDB's fatal
-            // "Database methods are not reentrant".
-            try db.execute(sql: "DELETE FROM page_links WHERE from_page_id = ?;",
-                           arguments: [pageID.rawValue])
-            try db.execute(sql: "DELETE FROM source_links WHERE from_page_id = ?;",
-                           arguments: [pageID.rawValue])
-            for link in parsedLinks {
-                switch link.linkType {
-                case .page:
-                    let resolved: PageID?
-                    if let id = try self.canonicalLinkID(link, in: db) {
-                        resolved = id
-                    } else {
-                        resolved = try self.resolveLinkTarget(
-                            link, using: self.resolveTitleToIDLocked, in: db)
-                    }
-                    guard let resolved else { continue }
-                    try db.execute(sql: """
-                    INSERT OR IGNORE INTO page_links (from_page_id, to_page_id, link_text)
-                    VALUES (?, ?, ?);
-                    """, arguments: [pageID.rawValue, resolved.rawValue, link.linkText])
-                case .source:
-                    let resolved: SourceID?
-                    if let id = try self.canonicalLinkID(link, in: db) {
-                        resolved = SourceID(rawValue: id.rawValue)
-                    } else {
-                        resolved = try self.resolveLinkTarget(
-                            link, using: self.resolveSourceByNameLocked, in: db)
-                    }
-                    guard let resolved else { continue }
-                    // Resolve the `@vN` ordinal (1-based) to a concrete smv id;
-                    // NULL when unpinned or out-of-range (follows the active ref).
-                    let pinID = try link.versionPin.flatMap {
-                        try self.resolveVersionPin($0, sourceID: resolved, in: db)
-                    }
-                    // Embed source links (`![[source:…]]`) write a DISTINCT edge
-                    // with role='embed' — the `source_links_edge` unique index
-                    // treats (from, to, role, pin) as distinct, so a cite + embed
-                    // to the same source coexist as separate rows (Phase 4a, AC.3).
-                    let role = link.isEmbed ? "embed" : "cite"
-                    try db.execute(sql: """
-                    INSERT OR IGNORE INTO source_links
-                        (from_page_id, to_source_id, link_text, role, pinned_version_id)
-                    VALUES (?, ?, ?, ?, ?);
-                    """, arguments: [pageID.rawValue, resolved.rawValue, link.linkText,
-                                     role, pinID?.rawValue])
-                case .chat:
-                    // Chat links resolve at render time (no persisted graph edge).
-                    continue
+            try self.replaceLinksLocked(from: pageID, parsedLinks: parsedLinks, on: db)
+        }
+    }
+
+    /// The db-handle core of `replaceLinks` — same resolution rules, no
+    /// transaction, no event. Callers already inside a write transaction (the
+    /// protected deletion's unlink rewrites) route through this instead of the
+    /// public mutator, which would re-enter the writer queue and deadlock.
+    private func replaceLinksLocked(
+        from pageID: PageID, parsedLinks: [ParsedLink], on db: Database
+    ) throws {
+        // Delete all existing outgoing page + source links, then insert the
+        // resolved subset. Faithful port of `SQLiteWikiStore.replaceLinks`:
+        // canonical-ULID targets validate by id (direct row fetch); legacy
+        // and forward links resolve by name via `resolveLinkTarget`. All
+        // resolvers used here are the `*Locked` variants that take the
+        // in-transaction `db` — the public `resolveTitleToID` /
+        // `resolveSourceByName` open their own `dbWriter.read`, which would
+        // re-enter the DatabasePool's serial queue and hit GRDB's fatal
+        // "Database methods are not reentrant".
+        try db.execute(sql: "DELETE FROM page_links WHERE from_page_id = ?;",
+                       arguments: [pageID.rawValue])
+        try db.execute(sql: "DELETE FROM source_links WHERE from_page_id = ?;",
+                       arguments: [pageID.rawValue])
+        for link in parsedLinks {
+            switch link.linkType {
+            case .page:
+                let resolved: PageID?
+                if let id = try self.canonicalLinkID(link, in: db) {
+                    resolved = id
+                } else {
+                    resolved = try self.resolveLinkTarget(
+                        link, using: self.resolveTitleToIDLocked, in: db)
                 }
+                guard let resolved else { continue }
+                try db.execute(sql: """
+                INSERT OR IGNORE INTO page_links (from_page_id, to_page_id, link_text)
+                VALUES (?, ?, ?);
+                """, arguments: [pageID.rawValue, resolved.rawValue, link.linkText])
+            case .source:
+                let resolved: SourceID?
+                if let id = try self.canonicalLinkID(link, in: db) {
+                    resolved = SourceID(rawValue: id.rawValue)
+                } else {
+                    resolved = try self.resolveLinkTarget(
+                        link, using: self.resolveSourceByNameLocked, in: db)
+                }
+                guard let resolved else { continue }
+                // Resolve the `@vN` ordinal (1-based) to a concrete smv id;
+                // NULL when unpinned or out-of-range (follows the active ref).
+                let pinID = try link.versionPin.flatMap {
+                    try self.resolveVersionPin($0, sourceID: resolved, in: db)
+                }
+                // Embed source links (`![[source:…]]`) write a DISTINCT edge
+                // with role='embed' — the `source_links_edge` unique index
+                // treats (from, to, role, pin) as distinct, so a cite + embed
+                // to the same source coexist as separate rows (Phase 4a, AC.3).
+                let role = link.isEmbed ? "embed" : "cite"
+                try db.execute(sql: """
+                INSERT OR IGNORE INTO source_links
+                    (from_page_id, to_source_id, link_text, role, pinned_version_id)
+                VALUES (?, ?, ?, ?, ?);
+                """, arguments: [pageID.rawValue, resolved.rawValue, link.linkText,
+                                 role, pinID?.rawValue])
+            case .chat:
+                // Chat links resolve at render time (no persisted graph edge).
+                continue
             }
         }
     }
@@ -4854,18 +4849,479 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
         }
     }
 
+    /// Compatibility forwarder — the protected contract under `.preserve`.
+    /// Provenance blockers throw the typed restriction before any write.
+    /// See `deleteResources(_:)` for the atomicity + event guarantees.
     public func deleteSource(id: SourceID) throws {
-        try mutate(event: { _ in
-            self.localEvent(.source, id: id.rawValue, change: .deleted)
-        }) { db in
-            if let blockers = try self.provenanceDeletionBlockers(sourceID: id, on: db) {
-                throw WikiStoreError.deletionRestricted(.provenance(blockers))
-            }
-            // source_versions cascade on DELETE, but blobs and activities do
-            // not — they're left for lazy GC (vacuumBlobs/vacuumActivities).
-            try db.execute(sql: "DELETE FROM sources WHERE id = ?;",
-                           arguments: [id.rawValue])
+        try deleteResources(ResourceDeletionRequest(target: .source(id), linkPolicy: .preserve))
+    }
+
+    // MARK: - Protected deletion (issue #219 hardening)
+    //
+    // One write transaction owns impact discovery, provenance validation,
+    // optional link rewrites, mandatory bookmark cleanup, and target deletion.
+    // Events are buffered by `mutateBatch` and emitted strictly after commit —
+    // a rollback emits nothing, and a missing target emits no false
+    // target-deleted event.
+
+    /// TEST SEAM — never passed by production code. `deleteResources` offers
+    /// an internal overload taking a `ProtectedDeletionFailurePoint` so tests
+    /// can throw at a deterministic stage (default `.none`, the only value
+    /// production uses). A parameter, not stored state: nothing to reset, no
+    /// unsynchronized access.
+    public func deletionImpact(for targets: Set<ResourceDeletionTarget>) throws -> DeletionImpact {
+        try dbWriter.read { db in
+            try self.deletionImpact(for: targets, on: db)
         }
+    }
+
+    @discardableResult
+    public func deleteResources(_ request: ResourceDeletionRequest) throws -> ResourceDeletionResult {
+        try deleteResources(request, failurePoint: .none)
+    }
+
+    /// Internal overload backing the test seam. Internal to the module; app
+    /// and CLI code only ever see the public single-argument form.
+    func deleteResources(
+        _ request: ResourceDeletionRequest,
+        failurePoint: ProtectedDeletionFailurePoint
+    ) throws -> ResourceDeletionResult {
+        try mutateBatch(events: { result in
+            var events: [ResourceChangeEvent] = []
+            // Rewritten linking pages first …
+            for pageID in result.rewrittenPageIDs {
+                events.append(self.localEvent(.page, id: pageID.rawValue, change: .updated))
+            }
+            // … then every removed bookmark leaf (one tree invalidation per
+            // leaf — subscribers reload the complete tree, which also picks
+            // up renumbered siblings, so no per-sibling position events) …
+            for bookmarkID in result.removedBookmarkIDs {
+                events.append(self.localEvent(.bookmark, id: bookmarkID.rawValue, change: .deleted))
+            }
+            // … and finally one deleted event per target row that actually
+            // existed (never a false event for a missing id).
+            for target in ResourceDeletionTarget.sorted(Set(result.deletedTargets)) {
+                switch target {
+                case .page(let id):
+                    events.append(self.localEvent(.page, id: id.rawValue, change: .deleted))
+                case .source(let id):
+                    events.append(self.localEvent(.source, id: id.rawValue, change: .deleted))
+                }
+            }
+            return events
+        }) { db in
+            try self.deleteResourcesLocked(request, failurePoint: failurePoint, on: db)
+        }
+    }
+
+    /// The db-handle core of the protected deletion. Runs entirely inside the
+    /// caller's `mutateBatch` savepoint; never opens a transaction or emits an
+    /// event.
+    private func deleteResourcesLocked(
+        _ request: ResourceDeletionRequest,
+        failurePoint: ProtectedDeletionFailurePoint,
+        on db: Database
+    ) throws -> ResourceDeletionResult {
+        let pageIDs = request.pageIDs
+        let sourceIDs = request.sourceIDs
+
+        // 1. Recheck the impact INSIDE the write transaction. The pre-delete
+        //    snapshot the UI showed is advisory — this re-read is authoritative.
+        let impact = try deletionImpact(for: request.targets, on: db)
+
+        // 2. Provenance validation BEFORE the first mutation (AC.6): any
+        //    blocker — even one whose citing page is itself selected for
+        //    deletion — stops the complete batch with zero writes.
+        if let blockers = NonEmptyProvenanceDeletionBlockers(impact.provenanceBlockers) {
+            throw WikiStoreError.deletionRestricted(.provenance(blockers))
+        }
+
+        // 3. Optional link rewrites (AC.4, AC.5): each distinct linking page
+        //    is rewritten at most once, and pages in the deletion set are
+        //    excluded (their bodies vanish with them).
+        var rewrittenPageIDs: [PageID] = []
+        if request.linkPolicy == .unlink {
+            for linkingPage in impact.linkingPages {
+                if try rewritePageUnlinkingTargets(
+                    pageID: linkingPage.pageID,
+                    deletedPageIDs: pageIDs,
+                    deletedSourceIDs: sourceIDs,
+                    on: db)
+                {
+                    rewrittenPageIDs.append(linkingPage.pageID)
+                }
+            }
+        }
+        try throwIfFailureInjected(failurePoint, at: .afterRewrite)
+
+        // 4. Mandatory bookmark cleanup (AC.1, AC.2, AC.14): every leaf
+        //    pointing at a deleted target goes, with sibling renumbering —
+        //    even when the target row itself is already gone (stale rows).
+        let removedBookmarkIDs = try deleteBookmarksMatching(
+            pageIDs: pageIDs, sourceIDs: sourceIDs, on: db)
+        try throwIfFailureInjected(failurePoint, at: .afterBookmarkCleanup)
+
+        // 5. Target rows + dependent graph rows (AC.14: a missing target is an
+        //    idempotent no-op and produces no result entry).
+        try throwIfFailureInjected(failurePoint, at: .beforeTargetDeletion)
+        var deletedTargets: [ResourceDeletionTarget] = []
+        for id in pageIDs {
+            if try deletePageTargetRow(id, on: db) { deletedTargets.append(.page(id)) }
+        }
+        for id in sourceIDs {
+            if try deleteSourceTargetRow(id, on: db) { deletedTargets.append(.source(id)) }
+        }
+
+        return ResourceDeletionResult(
+            deletedTargets: deletedTargets,
+            rewrittenPageIDs: rewrittenPageIDs,
+            removedBookmarkIDs: removedBookmarkIDs,
+            incomingLinkCount: impact.incomingLinkCount)
+    }
+
+    /// Throws when the test seam names exactly `expected`. Production runs
+    /// with `.none`, which matches nothing.
+    private func throwIfFailureInjected(
+        _ failurePoint: ProtectedDeletionFailurePoint,
+        at expected: ProtectedDeletionFailurePoint
+    ) throws {
+        guard failurePoint == expected else { return }
+        throw WikiStoreError.unexpected(
+            "protected deletion failure injected at \(expected) (test seam)")
+    }
+
+    /// Computes the deletion impact on an open database handle — shared by the
+    /// read-side `deletionImpact(for:)` and the in-transaction recheck inside
+    /// `deleteResourcesLocked`, so the preflight snapshot and the write-time
+    /// truth can never drift in shape.
+    private func deletionImpact(
+        for targets: Set<ResourceDeletionTarget>, on db: Database
+    ) throws -> DeletionImpact {
+        let pageIDs = ResourceDeletionTarget.sorted(targets).compactMap(\.pageID)
+        let sourceIDs = ResourceDeletionTarget.sorted(targets).compactMap(\.sourceID)
+        let pageStrings = pageIDs.map(\.rawValue)
+        let sourceStrings = sourceIDs.map(\.rawValue)
+
+        // Incoming linking pages (both link kinds), excluding pages that are
+        // themselves in the deletion set.
+        var linkingIDStrings: Set<String> = []
+        if !pageStrings.isEmpty {
+            let rows = try String.fetchAll(db, sql: """
+            SELECT DISTINCT from_page_id FROM page_links
+            WHERE to_page_id IN (\(Self.placeholders(pageStrings.count)));
+            """, arguments: StatementArguments(pageStrings))
+            linkingIDStrings.formUnion(rows)
+        }
+        if !sourceStrings.isEmpty {
+            let rows = try String.fetchAll(db, sql: """
+            SELECT DISTINCT from_page_id FROM source_links
+            WHERE to_source_id IN (\(Self.placeholders(sourceStrings.count)));
+            """, arguments: StatementArguments(sourceStrings))
+            linkingIDStrings.formUnion(rows)
+        }
+        linkingIDStrings.subtract(pageStrings)
+        let linkingIDs = linkingIDStrings.sorted().map(PageID.init(rawValue:))
+
+        // Presentation titles for the linking pages (nil when the row vanished).
+        var titles: [String: String] = [:]
+        if !linkingIDs.isEmpty {
+            let linkingStrings = linkingIDs.map(\.rawValue)
+            let rows = try Row.fetchAll(db, sql: """
+            SELECT id, title FROM pages WHERE id IN (\(Self.placeholders(linkingStrings.count)));
+            """, arguments: StatementArguments(linkingStrings))
+            for row in rows {
+                let rowID: String = row["id"]
+                let title: String? = row["title"]
+                if let title { titles[rowID] = title }
+            }
+        }
+        let linkingPages = linkingIDs.map { id in
+            DeletionLinkingPage(pageID: id, title: titles[id.rawValue])
+        }
+
+        // Incoming link EDGE count, excluding edges that start on a page in
+        // the deletion set (those spans vanish with their page — they neither
+        // survive as ghost links nor get unlinked).
+        var incomingLinkCount = 0
+        if !pageStrings.isEmpty {
+            incomingLinkCount += try Int.fetchOne(db, sql: """
+            SELECT COUNT(*) FROM page_links
+            WHERE to_page_id IN (\(Self.placeholders(pageStrings.count)))
+              AND from_page_id NOT IN (\(Self.placeholders(pageStrings.count)));
+            """, arguments: StatementArguments(pageStrings + pageStrings)) ?? 0
+        }
+        if !sourceStrings.isEmpty {
+            incomingLinkCount += try Int.fetchOne(db, sql: """
+            SELECT COUNT(*) FROM source_links
+            WHERE to_source_id IN (\(Self.placeholders(sourceStrings.count)))
+              AND from_page_id NOT IN (\(Self.placeholders(pageStrings.count)));
+            """, arguments: StatementArguments(sourceStrings + pageStrings)) ?? 0
+        }
+
+        // Matching bookmark leaves. Only page/source REF kinds match — folders
+        // and chat refs are untouched by construction.
+        var matchedNodes: [(id: String, parentID: String?)] = []
+        if !pageStrings.isEmpty || !sourceStrings.isEmpty {
+            var conditions: [String] = []
+            var values: [String] = []
+            if !pageStrings.isEmpty {
+                conditions.append("(kind = ? AND target_id IN (\(Self.placeholders(pageStrings.count))))")
+                values.append(BookmarkNodeKind.pageRef.rawValue)
+                values.append(contentsOf: pageStrings)
+            }
+            if !sourceStrings.isEmpty {
+                conditions.append("(kind = ? AND target_id IN (\(Self.placeholders(sourceStrings.count))))")
+                values.append(BookmarkNodeKind.sourceRef.rawValue)
+                values.append(contentsOf: sourceStrings)
+            }
+            let rows = try Row.fetchAll(db, sql: """
+            SELECT id, parent_id FROM bookmark_nodes
+            WHERE \(conditions.joined(separator: " OR "))
+            ORDER BY id ASC;
+            """, arguments: StatementArguments(values))
+            for row in rows {
+                let parentID: String? = row["parent_id"]
+                matchedNodes.append((row["id"], parentID))
+            }
+        }
+
+        // Folder display paths (presentation): walk each matched node's parent
+        // chain through the folder-label map. Same spelling as the model's
+        // `bookmarkDisplayPath` — `"Bookmarks"` for root-level nodes.
+        let folderMap = try Self.folderLabels(on: db)
+        let matchedBookmarks: [DeletionBookmarkImpact] = matchedNodes.map { node in
+            let path = Self.bookmarkFolderPath(
+                parentID: node.parentID, folderLabels: folderMap) ?? "Bookmarks"
+            return DeletionBookmarkImpact(
+                nodeID: BookmarkID(rawValue: node.id),
+                folderPath: path)
+        }
+
+        // Provenance blockers for the selected sources, in the raw
+        // (page, version, source) SQL order, deduplicated across sources.
+        var blockers: [ProvenanceDeletionBlocker] = []
+        var seenBlockers = Set<ProvenanceDeletionBlocker>()
+        for sourceID in sourceIDs {
+            for blocker in try provenanceDeletionBlockers(sourceID: sourceID, on: db)?.values ?? [] {
+                if seenBlockers.insert(blocker).inserted {
+                    blockers.append(blocker)
+                }
+            }
+        }
+
+        return DeletionImpact(
+            linkingPages: linkingPages,
+            bookmarks: matchedBookmarks,
+            provenanceBlockers: blockers,
+            incomingLinkCount: incomingLinkCount)
+    }
+
+    /// `(?, ?, …)` with `count` placeholders — the expanded IN-clause form.
+    /// The store binds IN lists by explicit placeholders (GRDB expands each
+    /// bound value), which keeps every argument a plain `String` at the type
+    /// level instead of a nested array.
+    private static func placeholders(_ count: Int) -> String {
+        Array(repeating: "?", count: count).joined(separator: ", ")
+    }
+
+    /// All folder nodes as `(id → (parent, label))`, for display-path walks.
+    private static func folderLabels(on db: Database) throws -> [String: (parent: String?, label: String)] {
+        let rows = try Row.fetchAll(db, sql: """
+        SELECT id, parent_id, label FROM bookmark_nodes WHERE kind = ?;
+        """, arguments: [BookmarkNodeKind.folder.rawValue])
+        var map: [String: (parent: String?, label: String)] = [:]
+        for row in rows {
+            let parentID: String? = row["parent_id"]
+            let label: String? = row["label"]
+            map[row["id"]] = (parentID, label ?? "")
+        }
+        return map
+    }
+
+    /// The slash-delimited folder path above `parentID` (`"Bookmarks"` when
+    /// the node sits at the root or the chain can't be resolved). Mirrors
+    /// `BookmarkNode.displayPath` + the model's `bookmarkDisplayPath`.
+    private static func bookmarkFolderPath(
+        parentID: String?, folderLabels: [String: (parent: String?, label: String)]
+    ) -> String? {
+        guard let parentID else { return nil } // root-level → caller says "Bookmarks"
+        var segments: [String] = []
+        var current: String? = parentID
+        var depth = 0
+        let maxDepth = 64
+        while let id = current, depth < maxDepth {
+            depth += 1
+            guard let folder = folderLabels[id] else { break }
+            if !folder.label.isEmpty { segments.insert(folder.label, at: 0) }
+            current = folder.parent
+        }
+        let path = segments.joined(separator: " / ")
+        return path.isEmpty ? nil : path
+    }
+
+    /// Rewrites one linking page's body so every span pointing at a deleted
+    /// target becomes plain text, then persists the rewrite (new immutable
+    /// version + rebuilt link rows) inside the caller's transaction. Returns
+    /// `false` when the page was skipped (in the deletion set, missing, or
+    /// nothing matched). Only the MATCHING spans change — unrelated links and
+    /// protected code ranges stay byte-identical (AC.4) — and the page's
+    /// `page_links` / `source_links` rows are rebuilt from the final body in
+    /// the same transaction.
+    private func rewritePageUnlinkingTargets(
+        pageID: PageID,
+        deletedPageIDs: [PageID],
+        deletedSourceIDs: [SourceID],
+        on db: Database
+    ) throws -> Bool {
+        // Never rewrite a page that is itself being deleted (AC.5).
+        guard !deletedPageIDs.contains(pageID) else { return false }
+        guard let row = try Row.fetchOne(db, sql: """
+        SELECT title, body_markdown FROM pages WHERE id = ?;
+        """, arguments: [pageID.rawValue]) else { return false }
+        let title: String = row["title"]
+        let body: String = row["body_markdown"]
+
+        // Name-based links still resolve here because the target rows are
+        // deleted LATER in this same transaction.
+        guard let rewritten = try LinkUnlinker.unlink(
+            in: body,
+            unlinkPageIDs: Set(deletedPageIDs),
+            unlinkSourceIDs: Set(deletedSourceIDs),
+            resolvePageName: { try self.resolveTitleToIDLocked($0, in: db) },
+            resolveSourceName: { try self.resolveSourceByNameLocked($0, in: db) }
+        ) else { return false }
+
+        try persistPageRewrite(pageID: pageID, title: title, body: rewritten, on: db)
+        return true
+    }
+
+    /// Persists one rewritten page through the internal version-write helper —
+    /// the same page-version + provenance + mirror + ref rules as `updatePage`
+    /// (minus amend coalescing, so a batch rewrite is always a deterministic
+    /// new version) — and rebuilds the page's link rows from the final body,
+    /// all on the caller's database handle. Emits nothing; the outer
+    /// `mutateBatch` owns the event batch.
+    private func persistPageRewrite(
+        pageID: PageID, title: String, body: String, on db: Database
+    ) throws {
+        let bodyData = Data(body.utf8)
+        let hash = portableSHA256(bodyData)
+            .map { String(format: "%02x", $0) }.joined()
+        let now = Date()
+        let slug = try uniqueSlug(from: title, id: pageID, on: db)
+        let head = try Self.pageHeadVersionIDLocked(pageID: pageID, on: db)
+        _ = try createPageVersionWithProvenance(on: db, request: .init(
+            pageID: pageID, head: head, mergeParentID: nil, title: title, body: body,
+            bodyData: bodyData, hash: hash,
+            activityAgent: .pageAuthor(PageAuthor.agent("unlink").rawValue),
+            activityKind: "edit", now: now, nowTS: now.timeIntervalSince1970,
+            provenance: [],
+            publication: .main(slug: slug, mirrorMutation: .append)))
+        try replaceLinksLocked(
+            from: pageID, parsedLinks: WikiLinkParser.parse(body), on: db)
+    }
+
+    /// Deletes every bookmark leaf whose (kind, target_id) matches the given
+    /// page/source ids, renumbers each affected sibling group, and returns the
+    /// removed node ids in deterministic (raw ULID) order.
+    private func deleteBookmarksMatching(
+        pageIDs: [PageID], sourceIDs: [SourceID], on db: Database
+    ) throws -> [BookmarkID] {
+        let pageStrings = pageIDs.map(\.rawValue)
+        let sourceStrings = sourceIDs.map(\.rawValue)
+        guard !pageStrings.isEmpty || !sourceStrings.isEmpty else { return [] }
+
+        var conditions: [String] = []
+        var values: [String] = []
+        if !pageStrings.isEmpty {
+            conditions.append("(kind = ? AND target_id IN (\(Self.placeholders(pageStrings.count))))")
+            values.append(BookmarkNodeKind.pageRef.rawValue)
+            values.append(contentsOf: pageStrings)
+        }
+        if !sourceStrings.isEmpty {
+            conditions.append("(kind = ? AND target_id IN (\(Self.placeholders(sourceStrings.count))))")
+            values.append(BookmarkNodeKind.sourceRef.rawValue)
+            values.append(contentsOf: sourceStrings)
+        }
+        let rows = try Row.fetchAll(db, sql: """
+        SELECT id, parent_id FROM bookmark_nodes
+        WHERE \(conditions.joined(separator: " OR "))
+        ORDER BY id ASC;
+        """, arguments: StatementArguments(values))
+        guard !rows.isEmpty else { return [] }
+
+        var removedIDs: [String] = []
+        var affectedParents: Set<String?> = []
+        for row in rows {
+            let id: String = row["id"]
+            let parentID: String? = row["parent_id"]
+            removedIDs.append(id)
+            affectedParents.insert(parentID)
+        }
+        try db.execute(
+            sql: "DELETE FROM bookmark_nodes WHERE id IN (\(Self.placeholders(removedIDs.count)));",
+            arguments: StatementArguments(removedIDs))
+        for parent in affectedParents {
+            try Self.renumberBookmarkSiblings(parentID: parent, on: db)
+        }
+        return removedIDs.map(BookmarkID.init(rawValue:))
+    }
+
+    /// Makes one sibling group's positions contiguous (0, 1, 2, …), oldest
+    /// first. Shared by `deleteBookmarkNode` and the protected deletion's
+    /// batch cleanup.
+    private static func renumberBookmarkSiblings(parentID: String?, on db: Database) throws {
+        let parentColumn = parentID != nil ? "parent_id = ?" : "parent_id IS NULL"
+        let sibRows = try Row.fetchAll(
+            db,
+            sql: "SELECT id FROM bookmark_nodes WHERE \(parentColumn) ORDER BY position ASC;",
+            arguments: parentID.map { [$0] } ?? []
+        )
+        for (i, row) in sibRows.enumerated() {
+            let childID: String = row["id"]
+            try db.execute(
+                sql: "UPDATE bookmark_nodes SET position = ? WHERE id = ?;",
+                arguments: [i, childID]
+            )
+        }
+    }
+
+    /// Deletes one page row and its dependent graph rows (the FK sweep the
+    /// legacy `deletePage` owned). Returns `false` when the page row is
+    /// already gone (idempotent no-op).
+    private func deletePageTargetRow(_ id: PageID, on db: Database) throws -> Bool {
+        let exists = try Int.fetchOne(
+            db, sql: "SELECT 1 FROM pages WHERE id = ?;",
+            arguments: [id.rawValue]) ?? 0
+        guard exists == 1 else { return false }
+        // FK safety: page_links, attachments, source_links all have FKs
+        // onto pages(id) WITHOUT ON DELETE CASCADE (unlike page_chunks).
+        // Clear every dependent row first, then delete the page.
+        try db.execute(sql: "DELETE FROM page_links WHERE from_page_id = ? OR to_page_id = ?;",
+                       arguments: [id.rawValue, id.rawValue])
+        try db.execute(sql: "DELETE FROM source_links WHERE from_page_id = ?;",
+                       arguments: [id.rawValue])
+        try db.execute(sql: "DELETE FROM attachments WHERE page_id = ?;",
+                       arguments: [id.rawValue])
+        try db.execute(sql: "DELETE FROM refs WHERE owner_id = ? AND kind = 'page-content';",
+                       arguments: [id.rawValue])
+        try db.execute(sql: "DELETE FROM pages WHERE id = ?;",
+                       arguments: [id.rawValue])
+        return true
+    }
+
+    /// Deletes one source row (its versions cascade; blobs and activities fall
+    /// to lazy GC). Returns `false` when the source row is already gone
+    /// (idempotent no-op). Provenance validation already ran for the whole
+    /// batch before the first mutation.
+    private func deleteSourceTargetRow(_ id: SourceID, on db: Database) throws -> Bool {
+        let exists = try Int.fetchOne(
+            db, sql: "SELECT 1 FROM sources WHERE id = ?;",
+            arguments: [id.rawValue]) ?? 0
+        guard exists == 1 else { return false }
+        try db.execute(sql: "DELETE FROM sources WHERE id = ?;",
+                       arguments: [id.rawValue])
+        return true
     }
 
     /// The page-version provenance edges that prevent `sourceID` from being
@@ -8356,28 +8812,9 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
                 sql: "DELETE FROM bookmark_nodes WHERE id = ?;",
                 arguments: [id.rawValue]
             )
-            // Renumber old siblings to be contiguous.
-            let parentColumn: String
-            let parentArg: String?
-            if let oldParent {
-                parentColumn = "parent_id = ?"
-                parentArg = oldParent
-            } else {
-                parentColumn = "parent_id IS NULL"
-                parentArg = nil
-            }
-            let sibRows = try Row.fetchAll(
-                db,
-                sql: "SELECT id FROM bookmark_nodes WHERE \(parentColumn) ORDER BY position ASC;",
-                arguments: parentArg.map { [$0] } ?? []
-            )
-            for (i, row) in sibRows.enumerated() {
-                let childID: String = row["id"]
-                try db.execute(
-                    sql: "UPDATE bookmark_nodes SET position = ? WHERE id = ?;",
-                    arguments: [i, childID]
-                )
-            }
+            // Renumber old siblings to be contiguous (shared with the
+            // protected deletion's batch cleanup).
+            try Self.renumberBookmarkSiblings(parentID: oldParent, on: db)
         }
     }
 

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -277,7 +277,40 @@ public protocol WikiStore: AnyObject, Sendable {
     ) throws -> WikiPage
     func createPage(title: String, createdBy: String?, provenance: [PageVersionSourceInput]) throws -> WikiPage
     func updatePage(id: PageID, title: String, body: String, lastEditedBy: String?, provenance: [PageVersionSourceInput]) throws
+    /// Compatibility forwarder: deletes one page through the protected
+    /// contract with the `.preserve` link policy (ghost links stay, matching
+    /// bookmarks are always removed). Equivalent to
+    /// `deleteResources(ResourceDeletionRequest(target: .page(id), linkPolicy: .preserve))`.
     func deletePage(id: PageID) throws
+
+    // MARK: - Protected deletion (issue #219 hardening)
+    //
+    // The single deletion seam for supported writers (app model, `wikictl`).
+    // Impact discovery, provenance validation, optional link rewrites, bookmark
+    // cleanup, and target deletion all happen in ONE write transaction, and the
+    // post-commit event batch is emitted only after that transaction commits.
+    // The legacy single-target methods below forward through the `.preserve`
+    // request so no supported caller can bypass mandatory bookmark cleanup.
+
+    /// Compute what references the given targets — linking pages, matching
+    /// bookmarks, provenance blockers, and the incoming-link edge count — as
+    /// one deterministic snapshot. Throwing (never an empty result on failure):
+    /// a failed read surfaces as an error so callers cannot mistake it for
+    /// "nothing references these targets". Read-only; emits nothing.
+    func deletionImpact(for targets: Set<ResourceDeletionTarget>) throws -> DeletionImpact
+
+    /// Delete the request's targets under its link policy in ONE transaction:
+    /// rechecked impact → provenance validation (any blocker throws the typed
+    /// restriction before the first mutation) → optional `.unlink` rewrites →
+    /// mandatory bookmark-leaf removal (with sibling renumbering) → target-row
+    /// deletion with dependent graph cleanup. Any failure rolls back the whole
+    /// operation and emits nothing; a commit emits `.page .updated` per
+    /// rewritten page, `.bookmark .deleted` per removed bookmark, and one
+    /// `.deleted` event per target row that actually existed. Missing targets
+    /// are idempotent no-ops (stale matching bookmarks are still removed, but
+    /// no target-deleted event is emitted for a row that wasn't there).
+    @discardableResult
+    func deleteResources(_ request: ResourceDeletionRequest) throws -> ResourceDeletionResult
 
     /// Resolve a page *title* to its id, or nil if no page has that title.
     /// On duplicate titles, the lowest ULID (oldest page) wins. Used by
@@ -392,7 +425,11 @@ public protocol WikiStore: AnyObject, Sendable {
     /// resolves the active version for the source that owns it.
     func sourceVersion(id: SourceVersionID) throws -> SourceVersion?
 
-    /// Remove a source by id.
+    /// Compatibility forwarder: deletes one source through the protected
+    /// contract with the `.preserve` link policy (citations stay as ghost
+    /// links, matching bookmarks are always removed). Provenance blockers
+    /// still throw the typed deletion restriction before any write. Equivalent
+    /// to `deleteResources(ResourceDeletionRequest(target: .source(id), linkPolicy: .preserve))`.
     func deleteSource(id: SourceID) throws
 
     /// The page versions whose provenance cites `sourceID`, making the source

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -2052,62 +2052,66 @@ public final class WikiStoreModel {
         }
     }
 
-    public func delete(_ id: PageID) {
-        do {
-            try store.deletePage(id: id)
+    /// What references `id` right now — pages that link to it and bookmarks
+    /// that point at it (issue #219). Throwing: a failed impact read surfaces
+    /// as an error (the UI shows a failure and never offers deletion) instead
+    /// of an empty impact that would read as "nothing references this".
+    public func deletionImpact(forPage id: PageID) throws -> DeletionImpact {
+        try store.deletionImpact(for: [.page(id)])
+    }
+
+    /// Delete pages through the store's protected contract (issue #219
+    /// hardening). The WHOLE selection goes to the store in ONE
+    /// `deleteResources` transaction: bookmarks targeting them are ALWAYS
+    /// removed, `unlinkIncomingLinks` picks the link policy, a provenance
+    /// blocker or write failure rolls back everything, and each linking page
+    /// rewrites at most once. History and tab cleanup run only for targets
+    /// the store reports as actually deleted, and only after the operation
+    /// succeeds. Returns the committed result so callers can react to the
+    /// exact deleted set (e.g. home-page cleanup).
+    @discardableResult
+    public func delete(
+        _ ids: [PageID], unlinkIncomingLinks: Bool
+    ) throws -> ResourceDeletionResult {
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: ids.map { .page($0) },
+            linkPolicy: unlinkIncomingLinks ? .unlink : .preserve))
+        for target in result.deletedTargets {
+            guard case .page(let id) = target else { continue }
             removeFromHistory(.page(id))
             // Close any tab showing this deleted page.
             if let tab = tabs.first(where: { $0.selection == .page(id) }) {
                 closeTab(id: tab.id)
             }
-            // No manual reload — the bus fires reloadFromStore() async after the
-            // delete. History and tab cleanup happen explicitly above.
+        }
+        // No manual reload — the bus fires reloadFromStore() async after
+        // the committed event batch.
+        return result
+    }
+
+    /// Single-page spelling of ``delete(_:unlinkIncomingLinks:)``.
+    @discardableResult
+    public func delete(
+        _ id: PageID, unlinkIncomingLinks: Bool
+    ) throws -> ResourceDeletionResult {
+        try delete([id], unlinkIncomingLinks: unlinkIncomingLinks)
+    }
+
+    /// UI entry point for the pages containers: deletes the selection in ONE
+    /// protected transaction and surfaces any failure through `storeError`.
+    /// Returns the committed result, or `nil` when the deletion did not
+    /// happen (nothing was changed in that case).
+    public func performPageDeletion(
+        _ ids: [PageID], unlinkIncomingLinks: Bool
+    ) -> ResourceDeletionResult? {
+        do {
+            return try delete(ids, unlinkIncomingLinks: unlinkIncomingLinks)
         } catch {
             DebugLog.store("WikiStoreModel.delete failed: \(error)")
             storeError = StoreError(
                 title: "Couldn't Delete Page",
                 message: "Could not delete the page: \(error.localizedDescription)")
-        }
-    }
-
-    /// What references `id` right now — pages that link to it and bookmarks that
-    /// point at it (issue #219). The UI shows this before deleting so the user
-    /// can decide whether to convert the incoming links to plain text.
-    public func deletionImpact(forPage id: PageID) -> DeletionImpact {
-        let linkingIDs = (DebugLog.trying("pageLinkingPages", operation: {
-            try store.pageLinkingPages(to: id)
-        }) ?? []).filter { $0 != id }
-        return DeletionImpact(
-            linkingPageIDs: linkingIDs,
-            bookmarkLabels: bookmarkLabelsReferencing { content in
-                if case .page(let pid) = content { return pid == id }
-                return false
-            })
-    }
-
-    /// Delete a page, optionally converting every incoming `[[link]]` in other
-    /// pages to plain text first. Bookmarks pointing at the page are ALWAYS
-    /// removed — a bookmark to a missing page is invalid (issue #219). Use this
-    /// path when `deletionImpact(forPage:)` reported references; use
-    /// ``delete(_:)`` for the no-ceremony immediate delete.
-    public func delete(_ id: PageID, unlinkIncomingLinks: Bool) {
-        do {
-            if unlinkIncomingLinks {
-                try unlinkIncomingLinksTo(pageIDs: [id], sourceIDs: [])
-            }
-            removeBookmarksReferencingPage(id)
-            try store.deletePage(id: id)
-            removeFromHistory(.page(id))
-            if let tab = tabs.first(where: { $0.selection == .page(id) }) {
-                closeTab(id: tab.id)
-            }
-            // No manual reload — the bus fires reloadFromStore() async after the
-            // delete + bookmark removals + (optional) linking-page rewrites.
-        } catch {
-            DebugLog.store("WikiStoreModel.delete(unlink:) failed: \(error)")
-            storeError = StoreError(
-                title: "Couldn't Delete Page",
-                message: "Could not delete the page: \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -2990,88 +2994,78 @@ public final class WikiStoreModel {
         return (imported: imported, errors: errorMessages)
     }
 
-    /// Remove an ingested file from the list and the store, then signal so the
-    /// `sources/` tree drops it.
-    public func deleteSource(_ id: SourceID) {
-        do {
-            try store.deleteSource(id: id)
+    /// What references `id` right now — pages that cite it and bookmarks that
+    /// point at it (issue #219). Throwing, same contract as
+    /// `deletionImpact(forPage:)`.
+    public func deletionImpact(forSource id: SourceID) throws -> DeletionImpact {
+        try store.deletionImpact(for: [.source(id)])
+    }
+
+    /// Delete sources through the store's protected contract (issue #219
+    /// hardening). The WHOLE selection goes to the store in ONE
+    /// `deleteResources` transaction: bookmarks targeting them are ALWAYS
+    /// removed, `unlinkIncomingLinks` picks the link policy, and a provenance
+    /// blocker on ANY source stops the complete batch before the first
+    /// mutation. History and tab cleanup run only for targets the store
+    /// reports as actually deleted. Returns the committed result.
+    @discardableResult
+    public func deleteSources(
+        _ ids: [SourceID], unlinkIncomingLinks: Bool
+    ) throws -> ResourceDeletionResult {
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: ids.map { .source($0) },
+            linkPolicy: unlinkIncomingLinks ? .unlink : .preserve))
+        for target in result.deletedTargets {
+            guard case .source(let id) = target else { continue }
             removeFromHistory(.source(id))
             // Close any tab showing this deleted file.
             if let tab = tabs.first(where: { $0.selection == .source(id) }) {
                 closeTab(id: tab.id)
             }
-            // No manual reload — the bus fires reloadFromStore() async after the
-            // delete. History and tab cleanup happen explicitly above.
-        } catch {
-            DebugLog.store("WikiStoreModel.deleteSource failed: \(error)")
-            storeError = StoreError(
-                title: "Couldn't Delete Source",
-                message: "Could not delete the source: \(error.localizedDescription)")
         }
+        // No manual reload — the bus fires reloadFromStore() async after
+        // the committed event batch.
+        return result
     }
 
-    /// What references `id` right now — pages that cite it and bookmarks that
-    /// point at it (issue #219). The UI shows this before deleting so the user
-    /// can decide whether to convert the incoming citations to plain text.
-    public func deletionImpact(forSource id: SourceID) -> DeletionImpact {
-        let linkingIDs = (DebugLog.trying("sourceLinkingPages", operation: {
-            try store.sourceLinkingPages(to: id)
-        }) ?? [])
-        let blockers = DebugLog.trying("sourceProvenanceBlockers", operation: {
-            try store.sourceProvenanceBlockers(sourceID: id)
-        }) ?? []
-        return DeletionImpact(
-            linkingPageIDs: linkingIDs,
-            bookmarkLabels: bookmarkLabelsReferencing { content in
-                if case .source(let sid) = content { return sid == id }
-                return false
-            },
-            provenanceBlockers: blockers)
+    /// Single-source spelling of ``deleteSources(_:unlinkIncomingLinks:)``.
+    /// A provenance blocker stops the store before ANY write and surfaces in
+    /// the typed catch; use the throwing batch spelling for full control.
+    @discardableResult
+    public func deleteSource(_ id: SourceID, unlinkIncomingLinks: Bool) throws -> ResourceDeletionResult {
+        try deleteSources([id], unlinkIncomingLinks: unlinkIncomingLinks)
     }
 
-    /// Delete a source, optionally converting every incoming `[[source:…]]`
-    /// citation in other pages to plain text first. Bookmarks pointing at the
-    /// source are ALWAYS removed — a bookmark to a missing source is invalid
-    /// (issue #219). Use this path when `deletionImpact(forSource:)` reported
-    /// references; use ``deleteSource(_:)`` for the no-ceremony immediate
-    /// delete.
-    public func deleteSource(_ id: SourceID, unlinkIncomingLinks: Bool) {
-        // A provenance blocker makes deletion impossible (the store throws).
-        // Bail BEFORE any destructive cleanup so we don't unlink citations or
-        // remove bookmarks for a source that stays in place (issue #219).
-        let blockers = DebugLog.trying("sourceProvenanceBlockers", operation: {
-            try store.sourceProvenanceBlockers(sourceID: id)
-        }) ?? []
-        if !blockers.isEmpty {
-            let titles = Set(blockers.map(\.pageID)).compactMap { pid in
+    /// UI entry point for the sources containers: deletes the selection in
+    /// ONE protected transaction and surfaces any failure — including the
+    /// provenance restriction's friendly "Can't Delete Source" alert —
+    /// through `storeError`. Returns the committed result, or `nil` when the
+    /// deletion did not happen (nothing was changed in that case).
+    public func performSourceDeletion(
+        _ ids: [SourceID], unlinkIncomingLinks: Bool
+    ) -> ResourceDeletionResult? {
+        do {
+            return try deleteSources(ids, unlinkIncomingLinks: unlinkIncomingLinks)
+        } catch WikiStoreError.deletionRestricted(.provenance(let blockers)) {
+            // The store stopped before the first mutation — nothing was
+            // unlinked and no bookmark was removed.
+            let titles = Set(blockers.values.map(\.pageID)).compactMap { pid in
                 summaries.first { $0.id == pid }?.title
             }.sorted()
-            let noun = blockers.count == 1 ? "page version" : "page versions"
-            var message = "This source is referenced as evidence by \(blockers.count) \(noun)"
+            let noun = blockers.values.count == 1 ? "page version" : "page versions"
+            var message = "This source is referenced as evidence by \(blockers.values.count) \(noun)"
             if !titles.isEmpty {
                 message += " (\(titles.joined(separator: ", ")))"
             }
             message += ". Remove those references first."
             storeError = StoreError(title: "Can't Delete Source", message: message)
-            return
-        }
-        do {
-            if unlinkIncomingLinks {
-                try unlinkIncomingLinksTo(pageIDs: [], sourceIDs: [id])
-            }
-            removeBookmarksReferencingSource(id)
-            try store.deleteSource(id: id)
-            removeFromHistory(.source(id))
-            if let tab = tabs.first(where: { $0.selection == .source(id) }) {
-                closeTab(id: tab.id)
-            }
-            // No manual reload — the bus fires reloadFromStore() async after the
-            // delete + bookmark removals + (optional) linking-page rewrites.
+            return nil
         } catch {
-            DebugLog.store("WikiStoreModel.deleteSource(unlink:) failed: \(error)")
+            DebugLog.store("WikiStoreModel.deleteSource failed: \(error)")
             storeError = StoreError(
                 title: "Couldn't Delete Source",
                 message: "Could not delete the source: \(error.localizedDescription)")
+            return nil
         }
     }
 
@@ -4349,78 +4343,6 @@ public final class WikiStoreModel {
             DebugLog.store("WikiStoreModel.moveBookmarkNode failed: \(error)")
             return false
         }
-    }
-
-    // MARK: - Deletion-impact helpers (issue #219)
-
-    /// Folder display paths for bookmarks whose content satisfies `matches`.
-    /// A root-level node is reported as `"Bookmarks"`.
-    private func bookmarkLabelsReferencing(
-        matches: (BookmarkNode.Content) -> Bool
-    ) -> [String] {
-        bookmarkNodes
-            .filter { matches($0.content) }
-            .map { bookmarkDisplayPath(for: $0) }
-    }
-
-    private func bookmarkDisplayPath(for node: BookmarkNode) -> String {
-        guard let parentID = node.parentID else { return "Bookmarks" }
-        let path = BookmarkNode.displayPath(id: parentID, in: bookmarkNodes)
-        return path.isEmpty ? "Bookmarks" : path
-    }
-
-    /// Remove every bookmark leaf pointing at `id`. Called on every page delete
-    /// that goes through the confirmation path — a bookmark to a missing page is
-    /// invalid (issue #219).
-    private func removeBookmarksReferencingPage(_ id: PageID) {
-        let nodes = bookmarkNodes.filter { node in
-            if case .page(let pid) = node.content { return pid == id }
-            return false
-        }
-        for node in nodes { deleteBookmarkNode(id: node.id) }
-    }
-
-    /// Remove every bookmark leaf pointing at `id` (the source-side mirror).
-    private func removeBookmarksReferencingSource(_ id: SourceID) {
-        let nodes = bookmarkNodes.filter { node in
-            if case .source(let sid) = node.content { return sid == id }
-            return false
-        }
-        for node in nodes { deleteBookmarkNode(id: node.id) }
-    }
-
-    /// Rewrite the bodies of every page that links to one of `pageIDs` /
-    /// `sourceIDs`, converting the matching `[[…]]` spans to plain text. Runs
-    /// BEFORE the target rows are deleted so name-based links still resolve to
-    /// the about-to-be-deleted id. Each rewrite routes through `PageUpsert` so
-    /// the link graph (`page_links` / `source_links`) drops the now-removed
-    /// edge in the same write the app and `wikictl` share.
-    private func unlinkIncomingLinksTo(pageIDs: Set<PageID>, sourceIDs: Set<SourceID>) throws {
-        guard !pageIDs.isEmpty || !sourceIDs.isEmpty else { return }
-        var linkingPageIDs = Set<PageID>()
-        for id in pageIDs { linkingPageIDs.formUnion(try store.pageLinkingPages(to: id)) }
-        for id in sourceIDs { linkingPageIDs.formUnion(try store.sourceLinkingPages(to: id)) }
-        // Never rewrite a page that is itself being deleted.
-        linkingPageIDs.subtract(pageIDs)
-        for linkingID in linkingPageIDs {
-            try rewritePageBodyUnlinkingTargets(
-                pageID: linkingID, pageIDs: pageIDs, sourceIDs: sourceIDs)
-        }
-    }
-
-    private func rewritePageBodyUnlinkingTargets(
-        pageID: PageID, pageIDs: Set<PageID>, sourceIDs: Set<SourceID>
-    ) throws {
-        let page = try store.getPage(id: pageID)
-        guard let rewritten = try LinkUnlinker.unlink(
-            in: page.bodyMarkdown,
-            unlinkPageIDs: pageIDs,
-            unlinkSourceIDs: sourceIDs,
-            resolvePageName: { name in try self.store.resolveTitleToID(name) },
-            resolveSourceName: { name in try self.store.resolveSourceByName(name) }
-        ) else { return }
-        try PageUpsert.upsert(in: store, id: pageID, title: page.title, body: rewritten,
-                              author: PageAuthor.agent("unlink").rawValue)
     }
 
     private func pruneHistoryToCurrentStore() {

--- a/Tests/WikiFSAppTests/DeletionConfirmationCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/DeletionConfirmationCoordinatorTests.swift
@@ -1,0 +1,297 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+/// The shared delete-confirmation coordinator (issue #219 hardening, AC.9 /
+/// AC.10): every impact state routes to the correct typed outcome with the
+/// exact action set, deletion is invoked ONLY through the typed decision
+/// mapping, and an impact-read failure can never reach deletion. The
+/// container wiring is asserted by a source contract (both containers must
+/// construct the shared coordinator — no per-view duplicate flows).
+@MainActor
+struct DeletionConfirmationCoordinatorTests {
+
+    // MARK: - Fixtures
+
+    private var pageID: PageID { PageID(rawValue: "01PAGETARGET00000000000000") }
+    private var sourceID: SourceID { SourceID(rawValue: "01SOURCETARGET000000000000") }
+
+    private func impact(
+        linking: [PageID] = [],
+        bookmarkCount: Int = 0,
+        bookmarkSeed: Int = 0,
+        blockers: [ProvenanceDeletionBlocker] = [],
+        linkEdges: Int = 0
+    ) -> DeletionImpact {
+        DeletionImpact(
+            linkingPages: linking.map { DeletionLinkingPage(pageID: $0, title: "T-\($0.rawValue.prefix(4))") },
+            bookmarks: (0..<bookmarkCount).map {
+                DeletionBookmarkImpact(
+                    nodeID: BookmarkID(rawValue: String(format: "01BM%02d00000000000000000000", $0 + bookmarkSeed)),
+                    folderPath: ($0 + bookmarkSeed) % 2 == 0 ? "Research" : "Bookmarks")
+            },
+            provenanceBlockers: blockers,
+            incomingLinkCount: linkEdges)
+    }
+
+    /// Records whether (and how) the coordinator invoked deletion.
+    private final class DecisionSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var decisions: [DeletionDecision] = []
+        func record(_ d: DeletionDecision) { lock.lock(); decisions.append(d); lock.unlock() }
+        var all: [DeletionDecision] { lock.lock(); defer { lock.unlock() }; return decisions }
+        var count: Int { all.count }
+    }
+
+    private func makeCoordinator(
+        kind: DeletionResourceKind,
+        impacts: [DeletionImpact],
+        count: Int = 1,
+        sink: DecisionSink
+    ) -> DeletionConfirmationCoordinator {
+        DeletionConfirmationCoordinator(
+            kind: kind,
+            loadImpacts: { impacts },
+            onDelete: { sink.record($0) },
+            selectionCount: count)
+    }
+
+    private func blocker() -> ProvenanceDeletionBlocker {
+        ProvenanceDeletionBlocker(
+            sourceID: SourceID(rawValue: "01SOURCETARGET000000000000"),
+            pageVersionID: PageVersionID(rawValue: "01VERSION0000000000000000000"),
+            pageID: PageID(rawValue: "01BLOCKERPAGE00000000000000"))
+    }
+
+    // MARK: - Page coordinator routes every impact state (AC.9)
+
+    @Test func pageDeletionCoordinatorRoutesEveryImpactState() {
+        let sink = DecisionSink()
+        let linkingPage = PageID(rawValue: "01LINKINGPAGE0000000000000")
+
+        // 1. No inbound references: delete immediately, no dialog.
+        let immediate = makeCoordinator(kind: .page, impacts: [impact()], sink: sink).evaluate()
+        #expect(immediate == .deleteImmediately)
+
+        // 2. Inbound links: confirm with Unlink and Delete / Delete / Cancel.
+        let withLinks = makeCoordinator(
+            kind: .page, impacts: [impact(linking: [linkingPage], linkEdges: 2)], sink: sink).evaluate()
+        guard case .confirm(let linksPresentation) = withLinks else {
+            Issue.record("expected .confirm for inbound links")
+            return
+        }
+        #expect(linksPresentation.offersUnlink)
+        #expect(linksPresentation.actions == [.unlinkAndDelete, .delete, .cancel])
+        #expect(linksPresentation.title == "Delete Page?")
+        #expect(linksPresentation.message.contains("Linked from 1 page"))
+
+        // 3. Bookmarks only: explain mandatory removal, Delete / Cancel.
+        let bookmarksOnly = makeCoordinator(
+            kind: .page, impacts: [impact(bookmarkCount: 2)], sink: sink).evaluate()
+        guard case .confirm(let bmPresentation) = bookmarksOnly else {
+            Issue.record("expected .confirm for bookmarks only")
+            return
+        }
+        #expect(!bmPresentation.offersUnlink)
+        #expect(bmPresentation.actions == [.delete, .cancel])
+        #expect(bmPresentation.message.contains("2 bookmarks"))
+        #expect(bmPresentation.message.contains("will be removed"))
+
+        // 4. Provenance blocker: blocked, OK only.
+        let blocked = makeCoordinator(
+            kind: .page, impacts: [impact(blockers: [blocker()])], sink: sink).evaluate()
+        guard case .blocked(let blockedPresentation) = blocked else {
+            Issue.record("expected .blocked for provenance blockers")
+            return
+        }
+        #expect(blockedPresentation.title == "Can't Delete Source")
+        #expect(blockedPresentation.message.contains("Remove those references"))
+
+        // 5. Loader throws: failed, and NO decision recorded for any route.
+        let failing = DeletionConfirmationCoordinator(
+            kind: .page,
+            loadImpacts: { throw StubError.bang },
+            onDelete: { sink.record($0) },
+            selectionCount: 1)
+        guard case .failed = failing.evaluate() else {
+            Issue.record("expected .failed for a throwing loader")
+            return
+        }
+        // None of the routed states above invoked deletion by themselves.
+        #expect(sink.count == 0)
+    }
+
+    // MARK: - Source coordinator routes every impact state (AC.9)
+
+    @Test func sourceDeletionCoordinatorRoutesEveryImpactState() {
+        let sink = DecisionSink()
+        let citingPage = PageID(rawValue: "01CITINGPAGE0000000000000")
+
+        // Citations wording differs; the action set does not.
+        let withCitations = makeCoordinator(
+            kind: .source, impacts: [impact(linking: [citingPage], linkEdges: 1)], sink: sink).evaluate()
+        guard case .confirm(let presentation) = withCitations else {
+            Issue.record("expected .confirm for citations")
+            return
+        }
+        #expect(presentation.title == "Delete Source?")
+        #expect(presentation.message.contains("Cited by 1 page"))
+        #expect(presentation.actions == [.unlinkAndDelete, .delete, .cancel])
+
+        // Blockers on a source → blocked with the named page.
+        let blocked = makeCoordinator(
+            kind: .source,
+            impacts: [impact(blockers: [blocker()])],
+            sink: sink).evaluate()
+        guard case .blocked(let blockedPresentation) = blocked else {
+            Issue.record("expected .blocked")
+            return
+        }
+        #expect(blockedPresentation.message.contains("page versions"))
+
+        // Immediate when nothing references the source.
+        #expect(makeCoordinator(kind: .source, impacts: [impact()], sink: sink).evaluate()
+            == .deleteImmediately)
+        #expect(sink.count == 0)
+    }
+
+    // MARK: - Typed decision mapping (AC.9)
+
+    @Test func coordinatorMapsDialogActionsToTypedDecisions() {
+        let sink = DecisionSink()
+        let coordinator = makeCoordinator(
+            kind: .page, impacts: [impact(linking: [pageID])], sink: sink)
+
+        coordinator.perform(.unlinkAndDelete)
+        coordinator.perform(.delete)
+        coordinator.perform(.cancel)
+
+        #expect(sink.all == [.unlink, .preserve])
+        // Exactly two deletions — cancel never invokes the sink.
+        #expect(sink.count == 2)
+    }
+
+    // MARK: - Batch presentation (AC.9: distinct pages, totals, paths)
+
+    @Test func batchCoordinatorAggregatesDistinctReferences() {
+        let sink = DecisionSink()
+        let p1 = PageID(rawValue: "01LINKINGPAGE0000000000000")
+        let p2 = PageID(rawValue: "01OTHERLINKER00000000000000")
+        // Two sources, each cited by both pages, each with one bookmark in
+        // the SAME folder: the dialog must show distinct pages, total
+        // bookmarks, and distinct folder paths.
+        let impacts = [
+            impact(linking: [p1, p2], bookmarkCount: 2, linkEdges: 2),
+            impact(linking: [p1, p2], bookmarkCount: 2, bookmarkSeed: 2, linkEdges: 2),
+        ]
+        let coordinator = DeletionConfirmationCoordinator(
+            kind: .source,
+            loadImpacts: { impacts },
+            onDelete: { sink.record($0) },
+            selectionCount: 2)
+
+        guard case .confirm(let presentation) = coordinator.evaluate() else {
+            Issue.record("expected .confirm")
+            return
+        }
+        // Distinct linking pages appear once each.
+        #expect(presentation.message.contains("Cited by 2 pages"))
+        // Total bookmark count across the batch (2 + 2 distinct nodes).
+        #expect(presentation.message.contains("4 bookmarks"))
+        // Distinct folder paths only, sorted.
+        #expect(presentation.message.contains("Bookmarks, Research"))
+        #expect(!presentation.message.contains("Bookmarks, Research, Bookmarks"))
+    }
+
+    // MARK: - Impact-read failure can never delete (AC.10)
+
+    private enum StubError: Error { case bang }
+
+    @Test func impactReadFailureBlocksPageDeletion() {
+        let sink = DecisionSink()
+        let coordinator = DeletionConfirmationCoordinator(
+            kind: .page,
+            loadImpacts: { throw StubError.bang },
+            onDelete: { sink.record($0) },
+            selectionCount: 1)
+
+        let outcome = coordinator.evaluate()
+        guard case .failed(let presentation) = outcome else {
+            Issue.record("expected .failed")
+            return
+        }
+        #expect(presentation.title == "Couldn't Delete Page")
+        #expect(!presentation.message.isEmpty)
+        // No dialog surface offers deletion in the failed state.
+        #expect(!outcome.dialogMessage.contains("Delete"))
+        #expect(sink.count == 0)
+    }
+
+    @Test func impactReadFailureBlocksSourceDeletion() {
+        let sink = DecisionSink()
+        let coordinator = DeletionConfirmationCoordinator(
+            kind: .source,
+            loadImpacts: { throw StubError.bang },
+            onDelete: { sink.record($0) },
+            selectionCount: 1)
+
+        guard case .failed(let presentation) = coordinator.evaluate() else {
+            Issue.record("expected .failed")
+            return
+        }
+        #expect(presentation.title == "Couldn't Delete Source")
+        #expect(sink.count == 0)
+    }
+
+    @Test func failedCoordinatorStateNeverInvokesDeletion() {
+        let sink = DecisionSink()
+        let failing = DeletionConfirmationCoordinator(
+            kind: .page,
+            loadImpacts: { throw StubError.bang },
+            onDelete: { sink.record($0) },
+            selectionCount: 1)
+
+        let outcome = failing.evaluate()
+        guard case .failed = outcome else {
+            Issue.record("expected .failed")
+            return
+        }
+        // The failed state exposes NO dialog actions at all, so no user
+        // action can route a deletion through it — and evaluate() itself
+        // invoked the sink zero times.
+        #expect(outcome.availableActions.isEmpty)
+        #expect(sink.count == 0)
+    }
+
+    // MARK: - Container wiring contract (AC.9)
+
+    /// Both containers must route deletion through the shared coordinator and
+    /// its dialog surface — no per-view duplicate confirmation flows.
+    @Test func pagesAndSourcesContainersUseDeletionCoordinator() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+
+        for relativePath in [
+            "Sources/WikiFS/Pages/PagesContainerView.swift",
+            "Sources/WikiFS/Sources/SourcesContainerView.swift",
+        ] {
+            let source = try String(
+                contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+            #expect(
+                source.contains("DeletionConfirmationCoordinator("),
+                "\(relativePath) must construct the shared coordinator")
+            #expect(
+                source.contains(".deletionOutcomeDialog"),
+                "\(relativePath) must render the shared dialog surface")
+            #expect(
+                !source.contains("PendingPageDeletion") && !source.contains("PendingSourceDeletion"),
+                "\(relativePath) must not carry a per-view pending-deletion struct")
+            #expect(
+                !source.contains("unlinkIncomingLinksTo") && !source.contains("removeBookmarksReferencing"),
+                "\(relativePath) must not orchestrate store cleanup itself")
+        }
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/DeletionConfirmationCoordinatorTests.swift
+++ b/Tests/WikiFSAppTests/DeletionConfirmationCoordinatorTests.swift
@@ -99,15 +99,31 @@ struct DeletionConfirmationCoordinatorTests {
         #expect(bmPresentation.message.contains("2 bookmarks"))
         #expect(bmPresentation.message.contains("will be removed"))
 
-        // 4. Provenance blocker: blocked, OK only.
-        let blocked = makeCoordinator(
-            kind: .page, impacts: [impact(blockers: [blocker()])], sink: sink).evaluate()
-        guard case .blocked(let blockedPresentation) = blocked else {
+        // 4. Provenance blocker: blocked with clickable blocking pages.
+        let blockedPage = blocker().pageID
+        let withResolver = DeletionConfirmationCoordinator(
+            kind: .page,
+            loadImpacts: { [impact(blockers: [blocker()])] },
+            onDelete: { sink.record($0) },
+            pageTitle: { _ in "Claim" },
+            selectionCount: 1)
+        guard case .blocked(let blockedPresentation) = withResolver.evaluate() else {
             Issue.record("expected .blocked for provenance blockers")
             return
         }
-        #expect(blockedPresentation.title == "Can't Delete Source")
-        #expect(blockedPresentation.message.contains("Remove those references"))
+        #expect(blockedPresentation.title == "Source Is In Use")
+        #expect(blockedPresentation.intro.contains("Remove those references"))
+        // The blocking page resolves to a clickable entry.
+        #expect(blockedPresentation.blockingPages == [
+            DeletionLinkingPage(pageID: blockedPage, title: "Claim"),
+        ])
+        // The outcome exposes the same pages for the dialog's Open actions,
+        // and still offers NO destructive actions in the blocked state.
+        let blockedOutcome = withResolver.evaluate()
+        if case .blocked = blockedOutcome {
+            #expect(blockedOutcome.blockingPages.count == 1)
+            #expect(blockedOutcome.availableActions.isEmpty)
+        }
 
         // 5. Loader throws: failed, and NO decision recorded for any route.
         let failing = DeletionConfirmationCoordinator(
@@ -149,7 +165,11 @@ struct DeletionConfirmationCoordinatorTests {
             Issue.record("expected .blocked")
             return
         }
-        #expect(blockedPresentation.message.contains("page versions"))
+        #expect(blockedPresentation.title == "Source Is In Use")
+        #expect(blockedPresentation.intro.contains("page versions"))
+        // Without a title resolver the blocking page cannot be opened, so it
+        // does not become a clickable entry (the intro still explains why).
+        #expect(blockedPresentation.blockingPages.isEmpty)
 
         // Immediate when nothing references the source.
         #expect(makeCoordinator(kind: .source, impacts: [impact()], sink: sink).evaluate()

--- a/Tests/WikiFSAppTests/EnumeratorDeletionTests.swift
+++ b/Tests/WikiFSAppTests/EnumeratorDeletionTests.swift
@@ -169,6 +169,42 @@ struct EnumeratorDeletionTests {
         #expect(changeObs.finishedWithError == nil)
     }
 
+    /// AC.13 (issue #219 hardening): one protected deletion reports BOTH the
+    /// deleted target (pages/by-id) AND the deleted bookmark leaf (bookmarks)
+    /// through the File Provider projection.
+    @Test func protectedDeleteReportsTargetAndBookmarkDeletions() throws {
+        let s = try seed()
+        let page = try s.store.createPage(title: "Protected Target")
+        let ref = try s.store.createBookmarkNode(
+            parentID: nil, position: 0, content: .page(page.id))
+
+        let pagesEnum = WikiFSEnumerator(container: Projection.Identity.pagesByID,
+                                         projection: s.projection)
+        let bookmarksEnum = WikiFSEnumerator(container: Projection.Identity.bookmarks,
+                                             projection: s.projection)
+
+        // Seed both baselines (each enumerator owns its known-item set).
+        for enumerator in [pagesEnum, bookmarksEnum] {
+            let obs = MockEnumerationObserver()
+            enumerator.enumerateItems(for: obs, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data))
+        }
+        let anchor = NSFileProviderSyncAnchor(Data(s.projection.changeToken().utf8))
+
+        // ONE protected delete removes the page row and its bookmark leaf.
+        _ = try s.store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(page.id)], linkPolicy: .preserve))
+
+        let pagesChange = MockChangeObserver()
+        pagesEnum.enumerateChanges(for: pagesChange, from: anchor)
+        #expect(pagesChange.deleted.contains(Projection.Identity.pageByID(page.id.rawValue)))
+        #expect(pagesChange.finishedWithError == nil)
+
+        let bookmarksChange = MockChangeObserver()
+        bookmarksEnum.enumerateChanges(for: bookmarksChange, from: anchor)
+        #expect(bookmarksChange.deleted.contains(Projection.Identity.bookmarkPageRef(ref.id.rawValue)))
+        #expect(bookmarksChange.finishedWithError == nil)
+    }
+
     @Test func deletingChatReportsDidDeleteItems() throws {
         let s = try seed()
         let chat = try s.store.createChat(kind: .edit, title: "A Chat")

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -392,19 +392,20 @@ import SQLite3
         #expect(nodes.isEmpty)
     }
 
-    @Test func targetDeletedRefBecomesStale() throws {
+    /// Protected-delete invariant (issue #219 hardening): a supported page
+    /// deletion ALWAYS removes bookmarks targeting it — a bookmark to a
+    /// missing page is invalid, so no stale ref may survive.
+    @Test func protectedDeleteRemovesTargetingRefNotStale() throws {
         let store = try GRDBWikiStore(databaseURL: tempDatabaseURL())
         let page = try store.createPage(title: "Doomed")
-        let ref = try store.createBookmarkNode(
+        _ = try store.createBookmarkNode(
             parentID: nil, position: 0, content: .page(page.id))
 
-        // Delete the page.
+        // Delete the page through the protected contract.
         try store.deletePage(id: page.id)
 
-        // The ref is still there (stale — not auto-deleted).
-        let nodes = try store.listBookmarkNodes()
-        #expect(nodes.count == 1)
-        #expect(nodes.first?.content == ref.content)
+        // The ref is GONE (mandatory bookmark cleanup), not stale.
+        #expect(try store.listBookmarkNodes().isEmpty)
     }
 
     // MARK: - Move/reorder (AC.4)

--- a/Tests/WikiFSTests/DeletionIncomingReferenceTests.swift
+++ b/Tests/WikiFSTests/DeletionIncomingReferenceTests.swift
@@ -3,36 +3,59 @@ import Foundation
 import Testing
 @testable import WikiFSCore
 
-/// Store + model tests for the issue #219 delete-with-incoming-references flow:
-/// `pageLinkingPages`, `deletionImpact`, and `delete(_:unlinkIncomingLinks:)`
-/// for both pages and sources.
+/// Store + model tests for the issue #219 protected deletion contract:
+/// `deletionImpact(for:)` and `deleteResources(_:)` — atomic batches, the
+/// mandatory bookmark cleanup, the link policies, the rollback seam, and the
+/// post-commit event batch. The model-level tests cover the one protected
+/// delete path per resource type; the coordinator-level routing lives in
+/// `Tests/WikiFSAppTests/DeletionConfirmationCoordinatorTests.swift`.
 @MainActor
 struct DeletionIncomingReferenceTests {
 
-    private func tempURL() -> URL {
-        FileManager.default.temporaryDirectory
-            .appendingPathComponent("wikifs-delete-refs-\(UUID().uuidString).sqlite")
-    }
-
     private func makeStore() throws -> GRDBWikiStore {
-        try GRDBWikiStore(databaseURL: tempURL())
+        try TestStoreFactory.inMemory()
     }
 
-    // MARK: - pageLinkingPages (store)
-
-    @Test func pageLinkingPagesReportsIncomingEdges() throws {
-        let store = try makeStore()
-        let a = try store.createPage(title: "A")
-        let b = try store.createPage(title: "B")
-
-        // A links to B.
-        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
-
-        #expect(try store.pageLinkingPages(to: b.id) == [a.id])
-        #expect(try store.pageLinkingPages(to: a.id).isEmpty)
+    /// Lock-guarded, synchronous event recorder with a clear (the shared
+    /// `SignalRecorder` has no clear; the coordinator tests need one).
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var events: [ResourceChangeEvent] = []
+        func append(_ e: ResourceChangeEvent) { lock.lock(); events.append(e); lock.unlock() }
+        var snapshot: [ResourceChangeEvent] { lock.lock(); defer { lock.unlock() }; return events }
+        func clear() { lock.lock(); events.removeAll(); lock.unlock() }
+        var count: Int { snapshot.count }
     }
 
-    // MARK: - deletionImpact
+    /// A lock-guarded event recorder wired to a fresh bus on `store`.
+    private func makeRecorder(_ store: GRDBWikiStore) -> Recorder {
+        let bus = WikiEventBus(wikiID: WikiID(rawValue: "W"))
+        store.eventBus = bus
+        let recorder = Recorder()
+        bus.subscribe(nil) { recorder.append($0) }
+        return recorder
+    }
+
+    /// Wait until `recorder` holds `expected` events (bounded), returning them.
+    private func awaitEvents(_ recorder: Recorder, expected: Int, timeoutMs: Int = 800) async throws -> [ResourceChangeEvent] {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMs) / 1000)
+        while Date() < deadline {
+            if recorder.count >= expected { return recorder.snapshot }
+            await flushBusDeliveries()
+            try? await Task.sleep(for: .milliseconds(2))
+        }
+        return recorder.snapshot
+    }
+
+    /// Confirm the async bus stayed silent after a rollback. A real emit
+    /// queues a `Task { @MainActor in … }`, so a few deterministic main-actor
+    /// flushes are enough to surface it.
+    private func assertNoEventsDelivered(_ recorder: Recorder) async {
+        for _ in 0..<3 { await flushBusDeliveries() }
+        #expect(recorder.snapshot.isEmpty)
+    }
+
+    // MARK: - deletionImpact (store + model, throwing)
 
     @Test func deletionImpactForPageReportsLinksAndBookmarks() throws {
         let store = try makeStore()
@@ -41,22 +64,21 @@ struct DeletionIncomingReferenceTests {
         try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
         _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
 
-        let model = WikiStoreModel(store: store)
-        model.reloadBookmarkNodes()
-
-        let impact = model.deletionImpact(forPage: b.id)
+        let impact = try store.deletionImpact(for: [.page(b.id)])
         #expect(impact.linkingPageIDs == [a.id])
-        #expect(impact.bookmarkLabels.count == 1)
+        #expect(impact.linkingPages.first?.title == "A")
+        #expect(impact.bookmarkLabels == ["Bookmarks"])
+        #expect(impact.incomingLinkCount == 1)
         #expect(impact.hasReferences)
     }
 
     @Test func deletionImpactForPageWithNoReferencesIsEmpty() throws {
         let store = try makeStore()
         let b = try store.createPage(title: "B")
-        let model = WikiStoreModel(store: store)
 
-        let impact = model.deletionImpact(forPage: b.id)
+        let impact = try store.deletionImpact(for: [.page(b.id)])
         #expect(!impact.hasReferences)
+        #expect(impact.incomingLinkCount == 0)
     }
 
     @Test func deletionImpactForSourceReportsCitations() throws {
@@ -65,93 +87,10 @@ struct DeletionIncomingReferenceTests {
         let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
         try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "cite [[source:paper]]", author: "user")
 
-        let model = WikiStoreModel(store: store)
-        let impact = model.deletionImpact(forSource: src.id)
+        let impact = try store.deletionImpact(for: [.source(src.id)])
         #expect(impact.linkingPageIDs == [a.id])
         #expect(impact.hasReferences)
     }
-
-    // MARK: - delete(_:unlinkIncomingLinks:)
-
-    @Test func deletePageWithUnlinkConvertsIncomingLinksToPlainText() throws {
-        let store = try makeStore()
-        let a = try store.createPage(title: "A")
-        let b = try store.createPage(title: "B")
-        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]] end", author: "user")
-
-        let model = WikiStoreModel(store: store)
-        model.delete(b.id, unlinkIncomingLinks: true)
-
-        // A's link to B is now plain text.
-        #expect(try store.getPage(id: a.id).bodyMarkdown == "see B end")
-        // B is gone.
-        let remainingIDs = Set(try store.listPages(sortBy: .lastUpdated).map(\.id))
-        #expect(!remainingIDs.contains(b.id))
-        // The page_links edge A→B no longer exists.
-        #expect(try store.listAllLinks().isEmpty)
-    }
-
-    @Test func deletePageWithoutUnlinkLeavesGhostLink() throws {
-        let store = try makeStore()
-        let a = try store.createPage(title: "A")
-        let b = try store.createPage(title: "B")
-        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
-
-        let model = WikiStoreModel(store: store)
-        model.delete(b.id, unlinkIncomingLinks: false)
-
-        // The body still carries the [[…]] syntax (now a ghost link).
-        let body = try store.getPage(id: a.id).bodyMarkdown
-        #expect(body.contains("[[") && body.contains("]]"))
-        // But the link row is cleaned up by deletePage's FK sweep.
-        #expect(try store.listAllLinks().isEmpty)
-    }
-
-    @Test func deletePageRemovesReferencingBookmarks() throws {
-        let store = try makeStore()
-        let a = try store.createPage(title: "A")
-        let b = try store.createPage(title: "B")
-        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
-        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
-
-        let model = WikiStoreModel(store: store)
-        model.reloadBookmarkNodes()
-        model.delete(b.id, unlinkIncomingLinks: false)
-
-        // The bookmark to B is gone.
-        #expect(try store.listBookmarkNodes().isEmpty)
-    }
-
-    // MARK: - deleteSource(_:unlinkIncomingLinks:)
-
-    @Test func deleteSourceWithUnlinkConvertsCitationsToPlainText() throws {
-        let store = try makeStore()
-        let a = try store.createPage(title: "A")
-        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
-        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "cite [[source:paper]]", author: "user")
-
-        let model = WikiStoreModel(store: store)
-        model.deleteSource(src.id, unlinkIncomingLinks: true)
-
-        // The citation is now plain text.
-        let body = try store.getPage(id: a.id).bodyMarkdown
-        #expect(!body.contains("[["))
-        #expect(body.contains("paper"))
-    }
-
-    @Test func deleteSourceRemovesReferencingBookmarks() throws {
-        let store = try makeStore()
-        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
-        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(src.id))
-
-        let model = WikiStoreModel(store: store)
-        model.reloadBookmarkNodes()
-        model.deleteSource(src.id, unlinkIncomingLinks: false)
-
-        #expect(try store.listBookmarkNodes().isEmpty)
-    }
-
-    // MARK: - provenance restriction (sources the agent has used)
 
     @Test func deletionImpactForSourceReportsProvenanceBlockers() throws {
         let store = try makeStore()
@@ -161,10 +100,456 @@ struct DeletionIncomingReferenceTests {
             id: page.id, title: page.title, body: "Claim", lastEditedBy: "user",
             provenance: [.init(sourceID: src.id, role: .primary)])
 
-        let model = WikiStoreModel(store: store)
-        let impact = model.deletionImpact(forSource: src.id)
+        let impact = try store.deletionImpact(for: [.source(src.id)])
         #expect(impact.isProvenanceBlocked)
         #expect(impact.provenanceBlockers.count == 1)
+    }
+
+    @Test func modelDeletionImpactSurfacesStoreErrors() throws {
+        let store = try makeStore()
+        let model = WikiStoreModel(store: store)
+        let b = try store.createPage(title: "B")
+
+        // Throwing passthrough: the model impact NEVER reports a false
+        // "no references" when the read fails (AC.10). A missing page row
+        // yields an empty-but-valid impact; the error path itself is proven
+        // at the coordinator level with a throwing loader.
+        let impact = try model.deletionImpact(forPage: b.id)
+        #expect(!impact.hasReferences)
+    }
+
+    // MARK: - Protected deletion basics (AC.1 / AC.2 / AC.3)
+
+    @Test func protectedPageDeleteAlwaysRemovesTargetBookmarks() throws {
+        let store = try makeStore()
+        let b = try store.createPage(title: "B")
+        let folder = try store.createBookmarkNode(parentID: nil, position: 0, content: .folder(label: "F"))
+        _ = try store.createBookmarkNode(parentID: folder.id, position: 0, content: .page(b.id))
+        _ = try store.createBookmarkNode(parentID: nil, position: 1, content: .chat(ChatID(rawValue: "01CHAT")))
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id)], linkPolicy: .preserve))
+
+        #expect(result.deletedTargets == [.page(b.id)])
+        #expect(result.removedBookmarkIDs.count == 1)
+        // The folder and the unrelated chat ref survive; the page ref is gone.
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.count == 2)
+        #expect(nodes.contains { $0.id == folder.id })
+        #expect(nodes.contains { node in
+            if case .chat = node.content { return true }
+            return false
+        })
+    }
+
+    @Test func protectedSourceDeleteAlwaysRemovesTargetBookmarks() throws {
+        let store = try makeStore()
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(src.id))
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.source(src.id)], linkPolicy: .preserve))
+
+        #expect(result.deletedTargets == [.source(src.id)])
+        #expect(result.removedBookmarkIDs.count == 1)
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    @Test func preservePolicyKeepsIncomingMarkdownAsGhostLinks() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]] end", author: "user")
+
+        _ = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id)], linkPolicy: .preserve))
+
+        // The body still carries the [[…]] span (a ghost link). The setup
+        // upsert canonicalized it, so assert the span survived, not the bytes.
+        let ghostBody = try store.getPage(id: a.id).bodyMarkdown
+        #expect(ghostBody.contains("[[") && ghostBody.contains("]]"))
+    }
+
+    @Test func unlinkPolicyRewritesPageAndSourceTargetsOnly() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        let d = try store.createPage(title: "D")
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        try PageUpsert.upsert(
+            in: store, id: a.id, title: "A",
+            body: "p [[B]] s [[source:paper]] d [[D]] ![[source:paper|fig]]",
+            author: "user")
+        try PageUpsert.upsert(in: store, id: c.id, title: "C", body: "keeps [[D]]", author: "user")
+        let cBodyBefore = try store.getPage(id: c.id).bodyMarkdown
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id), .source(src.id)], linkPolicy: .unlink))
+
+        // Only the matching spans in A became plain text; the D link (both
+        // cite and embed forms) is untouched, embed prefixes consumed,
+        // aliases preserved.
+        #expect(try store.getPage(id: a.id).bodyMarkdown
+            == "p B s paper d [[page:\(d.id.rawValue)|D]] fig")
+        // Unrelated pages are byte-unchanged (AC.4).
+        #expect(try store.getPage(id: c.id).bodyMarkdown == cBodyBefore)
+        #expect(result.rewrittenPageIDs == [a.id])
+        // The surviving D edge remains in the graph (page-link rows).
+        #expect(try store.listAllLinks().contains { $0.from == a.id.rawValue && $0.to == d.id.rawValue })
+    }
+
+    // MARK: - Batch semantics (AC.5)
+
+    @Test func batchDeleteRewritesSharedLinkingPageOnce() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "x [[B]] y [[C]]", author: "user")
+        let versionsBefore = try store.pageVersionHistory(pageID: a.id).count
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id), .page(c.id)], linkPolicy: .unlink))
+
+        // A appears exactly once in the rewrite list and gained exactly one
+        // version — never one write per deleted target.
+        #expect(result.rewrittenPageIDs == [a.id])
+        #expect(try store.pageVersionHistory(pageID: a.id).count == versionsBefore + 1)
+        #expect(try store.getPage(id: a.id).bodyMarkdown == "x B y C")
+    }
+
+    @Test func batchDeleteSkipsDeletedLinkingPage() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        // A → B, and B (itself being deleted) → C.
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        try PageUpsert.upsert(in: store, id: b.id, title: "B", body: "also [[C]]", author: "user")
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id), .page(c.id)], linkPolicy: .unlink))
+
+        // B is in the deletion set, so it is never rewritten (it vanishes);
+        // A is the only rewrite.
+        #expect(result.rewrittenPageIDs == [a.id])
+        #expect(try store.getPage(id: a.id).bodyMarkdown == "see B")
+        #expect(try store.listPages(sortBy: .titleAZ).contains { $0.id == a.id })
+        #expect(try !store.listPages(sortBy: .titleAZ).contains { $0.id == b.id })
+    }
+
+    @Test func batchDeletePreservesLinksToSurvivingTargets() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "x [[B]] y [[C]]", author: "user")
+
+        _ = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id)], linkPolicy: .unlink))
+
+        // The link to the SURVIVING target keeps its span (canonical form
+        // from the setup upsert) and its row.
+        #expect(try store.getPage(id: a.id).bodyMarkdown
+            == "x B y [[page:\(c.id.rawValue)|C]]")
+        let rows = try store.listAllLinks()
+        #expect(rows.contains { $0.from == a.id.rawValue && $0.to == c.id.rawValue })
+        #expect(!rows.contains { $0.from == a.id.rawValue && $0.to == b.id.rawValue })
+    }
+
+    // MARK: - Provenance gate (AC.6)
+
+    @Test func mixedBatchWithProvenanceBlockerChangesNothing() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let l = try store.createPage(title: "L")
+        let src = try store.addSource(filename: "evidence.txt", data: Data("evidence".utf8))
+        // A's provenance cites the source (the blocker); L links to A.
+        try PageUpsert.upsert(in: store, id: l.id, title: "L", body: "see [[A]]", author: "user")
+        try store.updatePage(
+            id: a.id, title: "Claim", body: "Claim", lastEditedBy: "user",
+            provenance: [.init(sourceID: src.id, role: .primary)])
+        let bookmark = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(src.id))
+        let bodyBefore = try store.getPage(id: l.id).bodyMarkdown
+
+        #expect(throws: WikiStoreError.self) {
+            try store.deleteResources(ResourceDeletionRequest(
+                targets: [.page(l.id), .source(src.id)], linkPolicy: .unlink))
+        }
+
+        // NOTHING changed: the blocker stops the complete batch before the
+        // first mutation.
+        #expect(try store.getSource(id: src.id).id == src.id)
+        #expect(try store.getPage(id: l.id).bodyMarkdown == bodyBefore)
+        #expect(try store.listBookmarkNodes().map(\.id) == [bookmark.id])
+        #expect(try store.listPages(sortBy: .titleAZ).contains { $0.id == l.id })
+    }
+
+    // MARK: - Rollback seam (AC.7)
+
+    /// Compare the full observable state of the fixture before and after a
+    /// failed protected deletion.
+    private func assertFixtureUnchanged(
+        _ store: GRDBWikiStore, pageID a: PageID, targetID t: PageID,
+        bookmarkID bm: BookmarkID, versionsBefore: Int, bodyBefore: String,
+        siblingBefore: [BookmarkNode]
+    ) throws {
+        #expect(try store.getPage(id: a).bodyMarkdown == bodyBefore)
+        #expect(try store.pageVersionHistory(pageID: a).count == versionsBefore)
+        // The link row A→target survived the rollback.
+        #expect(try store.listAllLinks().contains { $0.from == a.rawValue && $0.to == t.rawValue })
+        // The target and its bookmark survived, positions intact.
+        #expect(try store.getPage(id: t).id == t)
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.map(\.id) == siblingBefore.map(\.id))
+        #expect(nodes.map(\.position) == siblingBefore.map(\.position))
+        #expect(nodes.first { $0.id == bm } != nil)
+    }
+
+    private func rollbackFixture() throws -> (GRDBWikiStore, PageID, PageID, BookmarkID, BookmarkNode) {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        // Two root bookmarks: the target ref first, then a sibling whose
+        // position would renumber if the cleanup committed.
+        let bm = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+        let sibling = try store.createBookmarkNode(parentID: nil, position: 1, content: .page(a.id))
+        return (store, a.id, b.id, bm.id, sibling)
+    }
+
+    @Test func rewriteFailureRollsBackProtectedDeletion() async throws {
+        let (store, a, b, bm, _) = try rollbackFixture()
+        let stage = ProtectedDeletionFailurePoint.afterRewrite
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 6) // setup writes
+        recorder.clear()
+        let versionsBefore = try store.pageVersionHistory(pageID: a).count
+        let bodyBefore = try store.getPage(id: a).bodyMarkdown
+        let siblingsBefore = try store.listBookmarkNodes()
+        #expect(throws: WikiStoreError.self) {
+            try store.deleteResources(ResourceDeletionRequest(
+                targets: [.page(b)], linkPolicy: .unlink),
+                failurePoint: stage)
+        }
+
+        try assertFixtureUnchanged(
+            store, pageID: a, targetID: b, bookmarkID: bm,
+            versionsBefore: versionsBefore, bodyBefore: bodyBefore,
+            siblingBefore: siblingsBefore)
+        await assertNoEventsDelivered(recorder)
+    }
+
+    @Test func bookmarkCleanupFailureRollsBackProtectedDeletion() async throws {
+        let (store, a, b, bm, _) = try rollbackFixture()
+        let stage = ProtectedDeletionFailurePoint.afterBookmarkCleanup
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 6)
+        recorder.clear()
+        let versionsBefore = try store.pageVersionHistory(pageID: a).count
+        let bodyBefore = try store.getPage(id: a).bodyMarkdown
+        let siblingsBefore = try store.listBookmarkNodes()
+        #expect(throws: WikiStoreError.self) {
+            try store.deleteResources(ResourceDeletionRequest(
+                targets: [.page(b)], linkPolicy: .unlink),
+                failurePoint: stage)
+        }
+
+        try assertFixtureUnchanged(
+            store, pageID: a, targetID: b, bookmarkID: bm,
+            versionsBefore: versionsBefore, bodyBefore: bodyBefore,
+            siblingBefore: siblingsBefore)
+        await assertNoEventsDelivered(recorder)
+    }
+
+    @Test func targetDeleteFailureRollsBackProtectedDeletion() async throws {
+        let (store, a, b, bm, _) = try rollbackFixture()
+        let stage = ProtectedDeletionFailurePoint.beforeTargetDeletion
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 6)
+        recorder.clear()
+        let versionsBefore = try store.pageVersionHistory(pageID: a).count
+        let bodyBefore = try store.getPage(id: a).bodyMarkdown
+        let siblingsBefore = try store.listBookmarkNodes()
+        #expect(throws: WikiStoreError.self) {
+            try store.deleteResources(ResourceDeletionRequest(
+                targets: [.page(b)], linkPolicy: .unlink),
+                failurePoint: stage)
+        }
+
+        try assertFixtureUnchanged(
+            store, pageID: a, targetID: b, bookmarkID: bm,
+            versionsBefore: versionsBefore, bodyBefore: bodyBefore,
+            siblingBefore: siblingsBefore)
+        await assertNoEventsDelivered(recorder)
+    }
+
+    // MARK: - Post-commit events (AC.8)
+
+    @Test func protectedDeletionEmitsCompletePostCommitBatch() async throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        let bm = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 5)
+        recorder.clear()
+
+        _ = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(b.id)], linkPolicy: .unlink))
+
+        // Exactly three events, in order: rewritten page → removed bookmark →
+        // deleted target. One batch, post-commit.
+        let events = try await awaitEvents(recorder, expected: 3)
+        #expect(events.count == 3)
+        #expect(events[0].kind == .page && events[0].change == .updated && events[0].id == a.id.rawValue)
+        #expect(events[1].kind == .bookmark && events[1].change == .deleted && events[1].id == bm.id.rawValue)
+        #expect(events[2].kind == .page && events[2].change == .deleted && events[2].id == b.id.rawValue)
+    }
+
+    @Test func deletedBookmarkEventRefreshesRenumberedSiblingTree() async throws {
+        let store = try makeStore()
+        let p1 = try store.createPage(title: "P1")
+        let p2 = try store.createPage(title: "P2")
+        let p3 = try store.createPage(title: "P3")
+        let bm1 = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(p1.id))
+        let bm2 = try store.createBookmarkNode(parentID: nil, position: 1, content: .page(p2.id))
+        let bm3 = try store.createBookmarkNode(parentID: nil, position: 2, content: .page(p3.id))
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 6)
+        recorder.clear()
+
+        // Delete P1 (the FIRST sibling): the survivors must renumber to
+        // contiguous positions, and the deleted-bookmark event is the tree
+        // invalidation that makes subscribers reload them.
+        _ = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(p1.id)], linkPolicy: .preserve))
+
+        let events = try await awaitEvents(recorder, expected: 2)
+        #expect(events.map(\.change) == [.deleted, .deleted])
+        #expect(events.contains { $0.kind == .bookmark && $0.id == bm1.id.rawValue })
+        #expect(events.contains { $0.kind == .page && $0.id == p1.id.rawValue })
+
+        // The reloaded tree reflects the renumbering.
+        let nodes = try store.listBookmarkNodes()
+        #expect(nodes.map(\.id) == [bm2.id, bm3.id])
+        #expect(nodes.map(\.position) == [0, 1])
+    }
+
+    @Test func failedProtectedDeletionEmitsNoEvents() async throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 5)
+        recorder.clear()
+        #expect(throws: WikiStoreError.self) {
+            try store.deleteResources(ResourceDeletionRequest(
+                targets: [.page(b.id)], linkPolicy: .unlink),
+                failurePoint: .afterRewrite)
+        }
+
+        await assertNoEventsDelivered(recorder)
+    }
+
+    // MARK: - Dedup + missing targets (AC.14)
+
+    @Test func protectedDeletionDeduplicatesTargets() throws {
+        let store = try makeStore()
+        let b = try store.createPage(title: "B")
+        let src = try store.addSource(filename: "s.txt", data: Data("s".utf8))
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            // Duplicate ids across both spellings: one effect, one entry.
+            targets: [
+                .page(b.id), .page(b.id),
+                .source(src.id), .source(src.id),
+            ],
+            linkPolicy: .preserve))
+
+        #expect(ResourceDeletionTarget.sorted(Set(result.deletedTargets)) == [.page(b.id), .source(src.id)])
+        #expect(result.deletedTargets.count == 2)
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    @Test func missingTargetRemovesStaleBookmarkWithoutFalseTargetEvent() async throws {
+        let store = try makeStore()
+        // A stale bookmark pointing at a page row that doesn't exist.
+        let ghost = PageID(rawValue: "01GHOSTPAGE0000000000000000")
+        let stale = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(ghost))
+        let recorder = makeRecorder(store)
+        _ = try await awaitEvents(recorder, expected: 1)
+        recorder.clear()
+
+        let result = try store.deleteResources(ResourceDeletionRequest(
+            targets: [.page(ghost)], linkPolicy: .preserve))
+
+        // The stale bookmark is gone (mandatory cleanup), and its removal
+        // event IS emitted — but the missing target produced NO deleted-target
+        // result entry and NO false .page .deleted event.
+        #expect(result.removedBookmarkIDs == [stale.id])
+        #expect(result.deletedTargets.isEmpty)
+        let events = try await awaitEvents(recorder, expected: 1)
+        #expect(events.count == 1)
+        #expect(events[0].kind == .bookmark && events[0].change == .deleted)
+        #expect(events[0].id == stale.id.rawValue)
+    }
+
+    // MARK: - Compatibility forwarders (AC.15)
+
+    @Test func legacySingleTargetDeleteMethodsForwardToProtectedPreservePolicy() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]] + [[source:paper]]", author: "user")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+        _ = try store.createBookmarkNode(parentID: nil, position: 1, content: .source(src.id))
+
+        // Legacy single-target APIs: preserve policy + mandatory bookmarks.
+        try store.deletePage(id: b.id)
+        try store.deleteSource(id: src.id)
+
+        // Ghost links preserved …
+        let ghostBody = try store.getPage(id: a.id).bodyMarkdown
+        #expect(ghostBody.contains("[[") && ghostBody.contains("]]"))
+        // … and NO invalid bookmarks survive either delete.
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    // MARK: - Model-level protected delete paths (AC.1 / AC.2)
+
+    @Test func appModelPageDeleteRemovesTargetBookmarks() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+        let model = WikiStoreModel(store: store)
+        model.reloadBookmarkNodes()
+
+        try model.delete(b.id, unlinkIncomingLinks: false)
+
+        #expect(try store.listBookmarkNodes().isEmpty)
+        let ghostBody = try store.getPage(id: a.id).bodyMarkdown
+        #expect(ghostBody.contains("[[") && ghostBody.contains("]]"))
+    }
+
+    @Test func appModelSourceDeleteRemovesTargetBookmarks() throws {
+        let store = try makeStore()
+        let src = try store.addSource(filename: "paper.pdf", data: Data("%PDF".utf8))
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(src.id))
+        let model = WikiStoreModel(store: store)
+        model.reloadBookmarkNodes()
+
+        try model.deleteSource(src.id, unlinkIncomingLinks: false)
+
+        #expect(try store.listBookmarkNodes().isEmpty)
     }
 
     @Test func provenanceBlockedSourceIsNotDeletedAndCitationsSurvive() throws {
@@ -174,16 +559,67 @@ struct DeletionIncomingReferenceTests {
         try store.updatePage(
             id: page.id, title: page.title, body: "cite [[source:evidence]]", lastEditedBy: "user",
             provenance: [.init(sourceID: src.id, role: .primary)])
-
         let model = WikiStoreModel(store: store)
-        model.deleteSource(src.id, unlinkIncomingLinks: true)
 
+        // The UI entry point: nil result + storeError on the provenance block.
+        let result = model.performSourceDeletion([src.id], unlinkIncomingLinks: true)
+
+        #expect(result == nil)
+        #expect(model.storeError != nil)
         // The source stays (provenance-restricted) …
         #expect(try store.getSource(id: src.id).id == src.id)
-        // … and its citation is NOT rewritten (we bailed before unlinking).
+        // … and its citation is NOT rewritten (the store stopped before the
+        // first mutation).
         #expect(try store.getPage(id: page.id).bodyMarkdown.contains("[["))
-        // The restriction is surfaced as a store error.
+    }
+
+    // MARK: - Review fixes: batch UI path + no-commit no-op
+
+    /// The model batch path sends the WHOLE selection in one request: a page
+    /// inside the selection is never rewritten, the external linker rewrites
+    /// exactly once, and both targets delete together.
+    @Test func modelBatchDeleteRoutesSelectionInOneRequest() throws {
+        let store = try makeStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        let c = try store.createPage(title: "C")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "x [[B]] y [[C]]", author: "user")
+        try PageUpsert.upsert(in: store, id: b.id, title: "B", body: "also [[C]]", author: "user")
+        let versionsBefore = try store.pageVersionHistory(pageID: a.id).count
+        let model = WikiStoreModel(store: store)
+
+        let result = try model.delete([b.id, c.id], unlinkIncomingLinks: true)
+
+        #expect(result.deletedTargets.contains(.page(b.id)))
+        #expect(result.deletedTargets.contains(.page(c.id)))
+        // B is in the selection — never treated as an external linker.
+        #expect(result.rewrittenPageIDs == [a.id])
+        #expect(try store.pageVersionHistory(pageID: a.id).count == versionsBefore + 1)
+        #expect(try store.getPage(id: a.id).bodyMarkdown == "x B y C")
+    }
+
+    /// A provenance blocker on ANY source of a multi-selection stops the
+    /// complete batch: nothing deleted, nothing rewritten, no bookmark
+    /// removed, and the failure surfaced through `storeError`.
+    @Test func modelBatchSourceDeleteBlockedChangesNothingAndSurfacesError() throws {
+        let store = try makeStore()
+        let claimingPage = try store.createPage(title: "Claim")
+        let freeSrc = try store.addSource(filename: "free.txt", data: Data("free".utf8))
+        let blockedSrc = try store.addSource(filename: "blocked.txt", data: Data("blocked".utf8))
+        try store.updatePage(
+            id: claimingPage.id, title: claimingPage.title, body: "Claim", lastEditedBy: "user",
+            provenance: [.init(sourceID: blockedSrc.id, role: .primary)])
+        let bm = try store.createBookmarkNode(parentID: nil, position: 0, content: .source(freeSrc.id))
+        let model = WikiStoreModel(store: store)
+
+        let result = model.performSourceDeletion(
+            [freeSrc.id, blockedSrc.id], unlinkIncomingLinks: true)
+
+        #expect(result == nil)
         #expect(model.storeError != nil)
+        #expect(try store.getSource(id: freeSrc.id).id == freeSrc.id)
+        #expect(try store.getSource(id: blockedSrc.id).id == blockedSrc.id)
+        #expect(try store.listBookmarkNodes().map(\.id) == [bm.id])
     }
 }
 #endif

--- a/Tests/WikiFSTests/EditorTabTests.swift
+++ b/Tests/WikiFSTests/EditorTabTests.swift
@@ -661,7 +661,7 @@ struct EditorTabTests {
         model.openTab(.page(b.id))
         #expect(model.tabs.count == 2)
 
-        model.delete(a.id)
+        try model.delete(a.id, unlinkIncomingLinks: false)
         #expect(model.tabs.count == 1)
         #expect(model.tabs[0].selection == .page(b.id))
     }
@@ -678,7 +678,7 @@ struct EditorTabTests {
         model.openTab(.page(b.id))
         // Active is B.
 
-        model.delete(b.id)
+        try model.delete(b.id, unlinkIncomingLinks: false)
         #expect(model.tabs.count == 1)
         #expect(model.activeTabID == tabA)
         #expect(model.tabs[0].selection == .page(a.id))
@@ -697,7 +697,7 @@ struct EditorTabTests {
         let activeBefore = model.activeTabID
 
         // Delete C — not open in any tab.
-        model.delete(c.id)
+        try model.delete(c.id, unlinkIncomingLinks: false)
         #expect(model.tabs.count == 2)
         #expect(model.activeTabID == activeBefore)
     }
@@ -715,7 +715,7 @@ struct EditorTabTests {
         model.openTab(.source(f1.id))
         #expect(model.tabs.count == 2)
 
-        model.deleteSource(f1.id)
+        try model.deleteSource(f1.id, unlinkIncomingLinks: false)
         #expect(model.tabs.count == 1)
         #expect(model.tabs[0].selection == .page(a.id))
     }

--- a/Tests/WikiFSTests/Fixtures/SourceAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/SourceAPISignatures.txt
@@ -73,7 +73,7 @@ Sources/WikiFSCore/Store/WikiStoreModel.swift	@MainActor public func sourceConte
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func sourceID(forDisplayName displayName: String) -> SourceID?
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func selectSource(byID id: SourceID, anchor: String? = nil,
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func renameSource(id: SourceID, to newDisplayName: String)
-Sources/WikiFSCore/Store/WikiStoreModel.swift	public func deleteSource(_ id: SourceID)
+Sources/WikiFSCore/Store/WikiStoreModel.swift	public func deleteSource(_ id: SourceID, unlinkIncomingLinks: Bool)
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func sourceBytes(id: SourceID) -> Data?
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func setRendererSourcePreference(sourceID: SourceID, preference: RendererPreferenceReference)
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func setRendererSourcePreference(sourceID: SourceID, preference: RendererPreferenceReference)

--- a/Tests/WikiFSTests/NavigationHistoryTests.swift
+++ b/Tests/WikiFSTests/NavigationHistoryTests.swift
@@ -125,7 +125,7 @@ struct NavigationHistoryTests {
 
         model.select(.page(a.id))
         model.select(.page(b.id))
-        model.delete(a.id)
+        try model.delete(a.id, unlinkIncomingLinks: false)
 
         #expect(!model.canNavigateBack)
     }

--- a/Tests/WikiFSTests/NavigationSaveTests.swift
+++ b/Tests/WikiFSTests/NavigationSaveTests.swift
@@ -68,7 +68,7 @@ struct NavigationSaveTests {
         #expect(model.summaries.count == 2)
 
         let firstID = model.summaries.first { $0.title == "First" }!.id
-        model.delete(firstID)
+        try model.delete(firstID, unlinkIncomingLinks: false)
         model.reloadFromStore()
         // Rebuilt from source — not a stale cache.
         #expect(model.summaries.count == 1)

--- a/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
+++ b/Tests/WikiFSTests/StoreEmissionExhaustivenessTests.swift
@@ -20,7 +20,6 @@ struct StoreEmissionExhaustivenessTests {
             "public func workspaceResolveConflict(",
             "public func restorePage(",
             "public func revertPage(",
-            "public func deleteSource(",
             "public func appendDerivedMarkdown(",
         ] {
             guard let start = source.range(of: signature)?.lowerBound else {
@@ -32,6 +31,45 @@ struct StoreEmissionExhaustivenessTests {
                 ?? source.endIndex
             let implementation = source[start..<end]
             #expect(implementation.contains("mutate("), "\(signature) must use mutate")
+        }
+    }
+
+    /// The protected deletion (issue #219 hardening) is the one batch mutator:
+    /// impact recheck → provenance gate → rewrites → bookmark cleanup → target
+    /// deletion, all in ONE `mutateBatch` transaction with post-commit events.
+    /// The single-target `deletePage` / `deleteSource` methods are compatibility
+    /// forwarders into it — they must NOT open their own `mutate` transaction
+    /// (that would split the write and bypass the mandatory bookmark cleanup).
+    @Test func protectedDeletionRoutesThroughBatchMutationAndForwardersForward() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let source = try String(
+            contentsOf: root.appendingPathComponent("Sources/WikiFSCore/Store/GRDBWikiStore.swift"),
+            encoding: .utf8)
+
+        // The batch mutator must route through mutateBatch.
+        let deleteResourcesStart = try #require(
+            source.range(of: "public func deleteResources(")?.lowerBound)
+        let deleteResourcesTail = source[deleteResourcesStart...]
+        let deleteResourcesEnd = deleteResourcesTail.dropFirst()
+            .range(of: "\n    public func ")?.lowerBound ?? source.endIndex
+        #expect(
+            source[deleteResourcesStart..<deleteResourcesEnd].contains("mutateBatch("),
+            "deleteResources must use mutateBatch (one transaction, post-commit events)")
+
+        // The compatibility forwarders must forward, not write directly.
+        for signature in [
+            "public func deletePage(",
+            "public func deleteSource(",
+        ] {
+            let start = try #require(source.range(of: signature)?.lowerBound)
+            let tail = source[start...]
+            let end = tail.dropFirst().range(of: "\n    public func ")?.lowerBound
+                ?? source.endIndex
+            let implementation = source[start..<end]
+            #expect(
+                implementation.contains("deleteResources("),
+                "\(signature) must forward to the protected deleteResources contract")
         }
     }
 

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -164,7 +164,24 @@ struct WikiCtlCommandTests {
     @Test func parsesDelete() throws {
         let invocation = try ArgumentParser.parse(
             ["--wiki", "W", "page", "delete", "--id", "01Z"], env: noEnv)
-        #expect(invocation.command == .page(.delete(id: PageID(rawValue: "01Z"))))
+        #expect(invocation.command == .page(.delete(id: PageID(rawValue: "01Z"), unlinkIncoming: false)))
+    }
+
+    @Test func parsesPageDeleteWithUnlinkFlag() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "delete", "--id", "01Z", "--unlink-incoming"], env: noEnv)
+        #expect(invocation.command == .page(.delete(id: PageID(rawValue: "01Z"), unlinkIncoming: true)))
+    }
+
+    @Test func parsesPageDeleteWithoutUnlinkFlag() throws {
+        let invocation = try ArgumentParser.parse(
+            ["--wiki", "W", "page", "delete", "--id", "01Z"], env: noEnv)
+        guard case .page(.delete(_, let unlinkIncoming)) = invocation.command else {
+            Issue.record("expected .page(.delete)")
+            return
+        }
+        // Compatibility: the flag is absent → ghost links are preserved.
+        #expect(!unlinkIncoming)
     }
 
     @Test func rejectsUnknownCommand() {
@@ -299,6 +316,85 @@ struct WikiCtlCommandTests {
         let result = try PageCommand.run(.delete(id: id), in: store)
         #expect(result.didCommit)
         #expect(try store.listPages(sortBy: .lastUpdated).isEmpty)
+    }
+
+    // MARK: - protected page delete (issue #219 hardening, AC.11 / AC.12)
+
+    /// AC.11: the no-flag delete keeps the stdout contract (the page id),
+    /// removes bookmarks targeting the page, and preserves incoming Markdown
+    /// as ghost links. The stderr notice reports the cleanup counts.
+    @Test func wikictlPageDeletePreservesStdoutAndGhostLinks() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]]", author: "user")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+
+        let result = try PageCommand.run(.delete(id: b.id, unlinkIncoming: false), in: store)
+
+        // Stdout contract: the deleted page id.
+        #expect(result.output == b.id.rawValue)
+        #expect(result.didCommit)
+        // Stdout carries ONLY the id — the notice goes to stderr.
+        #expect(!result.output.contains("bookmark"))
+        #expect(result.stderrOutput?.contains("removed 1 bookmark") == true)
+        #expect(result.stderrOutput?.contains("preserved as ghost links") == true)
+        // Incoming Markdown keeps the [[…]] syntax (a ghost link; the setup
+        // upsert canonicalized it, so assert the span survived).
+        let ghostBody = try store.getPage(id: a.id).bodyMarkdown
+        #expect(ghostBody.contains("[[") && ghostBody.contains("]]"))
+        // The bookmark targeting B is gone.
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    /// AC.1: the CLI delete (through the shared protected contract) removes
+    /// bookmarks targeting the deleted page even when no links exist.
+    @Test func wikictlPageDeleteRemovesTargetBookmarks() throws {
+        let store = try tempStore()
+        let b = try store.createPage(title: "B")
+        _ = try store.createBookmarkNode(parentID: nil, position: 0, content: .page(b.id))
+
+        let result = try PageCommand.run(.delete(id: b.id, unlinkIncoming: false), in: store)
+
+        #expect(result.output == b.id.rawValue)
+        #expect(try store.listBookmarkNodes().isEmpty)
+    }
+
+    /// AC.12: `--unlink-incoming` converts inbound links to plain display
+    /// text, keeps the stdout contract, and reports the unlinked count.
+    @Test func wikictlPageDeleteUnlinksIncomingMarkdown() throws {
+        let store = try tempStore()
+        let a = try store.createPage(title: "A")
+        let b = try store.createPage(title: "B")
+        try PageUpsert.upsert(in: store, id: a.id, title: "A", body: "see [[B]] end", author: "user")
+        let alias = try store.createPage(title: "C")
+        try PageUpsert.upsert(in: store, id: alias.id, title: "C", body: "see [[B|bee]] too", author: "user")
+
+        let result = try PageCommand.run(.delete(id: b.id, unlinkIncoming: true), in: store)
+
+        // Stdout contract unchanged.
+        #expect(result.output == b.id.rawValue)
+        // The stderr notice reports the unlinked count.
+        #expect(result.stderrOutput?.contains("2 incoming links unlinked") == true)
+        // Both linking pages now carry plain display text (alias preserved).
+        #expect(try store.getPage(id: a.id).bodyMarkdown == "see B end")
+        #expect(try store.getPage(id: alias.id).bodyMarkdown == "see bee too")
+        // No link rows survive.
+        #expect(try store.listAllLinks().isEmpty)
+    }
+
+    /// Review fix (didCommit semantics): a missing target with no stale
+    /// bookmarks is an idempotent no-op — stdout keeps the id contract but NO
+    /// change notification posts.
+    @Test func wikictlPageDeleteMissingTargetIsIdempotentNoCommit() throws {
+        let store = try tempStore()
+        let ghost = PageID(rawValue: "01GHOSTPAGE0000000000000000")
+
+        let result = try PageCommand.run(.delete(id: ghost, unlinkIncoming: false), in: store)
+
+        #expect(result.output == ghost.rawValue)
+        #expect(!result.didCommit)
+        #expect(result.stderrOutput?.contains("removed 0 bookmarks") == true)
     }
 
     // MARK: - page info (page provenance, #page-provenance)

--- a/progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md
+++ b/progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md
@@ -65,6 +65,110 @@ the shared `PageUpsert.upsert` seam, so the link graph (`page_links` /
 `source_links`) stays consistent with the stored bytes exactly as an in-app or
 `wikictl` edit would.
 
+## Hardening follow-up (shared protected deletion contract)
+
+The first implementation assembled the cleanup from separate store calls: the
+model unlinked bodies with `PageUpsert`, removed bookmarks one by one, and then
+called `deletePage` / `deleteSource`. That left bypasses, race windows, and
+partial-write risks. A store-level contract now closes them.
+
+### The contract
+
+- **`ResourceDeletionRequest` / `ResourceDeletionResult`**
+  (`Sources/WikiFSCore/Core/DeletionImpact.swift`) carry a typed target set
+  (`ResourceDeletionTarget.page(PageID)` / `.source(SourceID)` — separate id
+  namespaces share one request), a `ResourceDeletionLinkPolicy`
+  (`.preserve` keeps ghost links, `.unlink` converts matching spans to plain
+  display text), and the committed outcome: deleted targets, rewritten pages,
+  removed bookmark ids, and the incoming-link count.
+- **`DeletionImpact`** now carries stable identities (linking page ids with
+  titles, bookmark node ids with folder paths) plus presentation strings, a
+  deterministic order, and the incoming-link edge count.
+- **`WikiStore.deleteResources(_:)`** is the one deletion seam. Impact
+  recheck, provenance validation, optional rewrites, mandatory bookmark
+  cleanup with sibling renumbering, and target deletion all run in ONE
+  `mutateBatch` transaction. Events are buffered and emitted strictly after
+  commit: `.page .updated` per rewritten page, `.bookmark .deleted` per
+  removed leaf, one `.deleted` event per target row that existed. A rollback
+  emits nothing. `deletePage(id:)` and `deleteSource(id:)` are compatibility
+  forwarders into the `.preserve` request, so no supported caller can leave
+  invalid bookmarks.
+- **Atomicity seam for tests** — an internal `ProtectedDeletionFailurePoint`
+  on the store (production default `.none`) throws after the rewrite, after
+  bookmark cleanup, or before target deletion, so the rollback contract is
+  deterministic and string-free.
+- **Batch semantics** — each linking page rewrites at most once through the
+  internal `createPageVersionWithProvenance` + `replaceLinksLocked` helpers
+  (same version/provenance rules as `updatePage`, no amend coalescing); pages
+  in the deletion set are never rewritten; one blocked source stops the whole
+  batch before the first mutation; duplicate ids have one effect; missing
+  targets are idempotent no-ops that still remove stale bookmarks and emit no
+  false target event.
+
+### Callers
+
+- **`WikiStoreModel`** — one protected delete per resource type
+  (`delete(_:unlinkIncomingLinks:)`, `deleteSource(_:unlinkIncomingLinks:)`);
+  the model-side bookmark loops and unlink orchestration are gone. Model-side
+  history, tab, and error handling run only after the store operation
+  succeeds. A provenance blocker surfaces as the friendly "Can't Delete
+  Source" alert from the typed catch.
+- **UI** — both container views share `DeletionConfirmationCoordinator`
+  (`Sources/WikiFS/Deletion/`), which produces the finite typed outcome:
+  `.deleteImmediately`, `.confirm(presentation)`, `.blocked(presentation)`,
+  or `.failed(presentation)`. A failed impact read routes to `.failed` and
+  exposes no dialog actions, so it can never invoke deletion. The shared
+  `DeletionOutcomeDialog` modifier renders the one confirmation surface.
+- **`wikictl page delete`** — routes through the same contract. New
+  `--unlink-incoming` flag chooses the policy. Stdout stays the deleted page
+  id; a stderr notice reports the bookmark and link counts.
+
+### Verification
+
+- `swift test --filter DeletionIncomingReferenceTests` — 27 tests: atomic
+  batches, batch rewrite-once, provenance gate, the three rollback failure
+  points (state compared before/after), the post-commit event batch, sibling
+  renumbering after a deleted bookmark event, dedup, missing targets, the
+  legacy forwarders, and the model batch path (one request per selection; a
+  blocked multi-source batch changes nothing and surfaces the error).
+- `swift test --filter StoreEmissionExhaustivenessTests` — guards
+  `deleteResources` on `mutateBatch` and both forwarders on forwarding.
+- `WIKIFS_APP_TESTS=1 swift test --filter DeletionConfirmationCoordinatorTests`
+  — 8 tests: every impact state, typed decision mapping, batch aggregation,
+  impact-read failure, and the container wiring source contract.
+- `WIKIFS_APP_TESTS=1 swift test --filter EnumeratorDeletionTests` — one
+  protected delete reports the target and the bookmark leaf deletions.
+- `swift test --filter WikiCtlCommandTests` — parser flags, stdout contract,
+  ghost links vs unlinked bodies, bookmark cleanup counts.
+- `make build` and `make test` — full gates, warnings as errors.
+
+### Independent review outcome
+
+An independent review (different model family) verified the transaction
+boundaries, event timing, typed id separation, and SwiftUI blocked/failed
+flows as clean, and raised three fixes, all applied:
+
+1. **HIGH — batch UI path.** The containers looped single-target model calls
+   for a multi-selection, so the store's all-or-nothing batch guarantee did
+   not reach the UI. The model now exposes one-request-per-selection entries
+   (`delete(_:unlinkIncomingLinks:)` for pages, `deleteSources(...)` and the
+   error-decorating `performPageDeletion` / `performSourceDeletion` for the
+   views), and both containers send the whole selection at once.
+2. **HIGH — home-page cleanup on failure.** The containers cleared the home
+   page even when the deletion failed. Cleanup now keys off
+   `result.deletedTargets` from the committed result, so metadata survives a
+   failed delete untouched.
+3. **MEDIUM — CLI `didCommit` on a no-op.** `wikictl page delete` on a
+   missing target reported `didCommit: true` and woke the app. `didCommit`
+   now reflects actual committed change; the stdout id contract is unchanged
+   (pinned by `wikictlPageDeleteMissingTargetIsIdempotentNoCommit`).
+
+The review also noted that the stderr notice counts incoming link EDGES, not
+Markdown span occurrences (`[[B]] … [[B]]` from one page counts as one).
+That is deliberate: the edge count is the store's deterministic measure, the
+ghost-link placeholder renders per target rather than per span, and the
+contract documents the semantics. No change made.
+
 ## Verification
 
 - `make build` — full app + File Provider build, signed, green.

--- a/progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md
+++ b/progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md
@@ -118,7 +118,11 @@ partial-write risks. A store-level contract now closes them.
   `.deleteImmediately`, `.confirm(presentation)`, `.blocked(presentation)`,
   or `.failed(presentation)`. A failed impact read routes to `.failed` and
   exposes no dialog actions, so it can never invoke deletion. The shared
-  `DeletionOutcomeDialog` modifier renders the one confirmation surface.
+  `DeletionOutcomeDialog` modifier renders the one confirmation surface. A
+  provenance-blocked source shows "Source Is In Use" with each blocking page
+  as a clickable "Open …" action — the user opens the page, removes the
+  reference, then retries the delete (operator-directed change from the
+  earlier OK-only "Can't Delete Source" alert).
 - **`wikictl page delete`** — routes through the same contract. New
   `--unlink-incoming` flag chooses the policy. Stdout stays the deleted page
   id; a stderr notice reports the bookmark and link counts.


### PR DESCRIPTION
## Summary

Protect page and source deletion at the shared store boundary (hardening follow-up to the issue #219 first implementation). One typed deletion contract now owns the whole operation, and the app model, the SwiftUI containers, and `wikictl` all route through it. No supported caller can leave invalid bookmarks behind.

## The contract

- **`ResourceDeletionRequest` / `ResourceDeletionResult`** carry a typed target set (`ResourceDeletionTarget.page(PageID)` / `.source(SourceID)` — separate id namespaces, never raw strings), a `ResourceDeletionLinkPolicy` (`.preserve` keeps ghost links, `.unlink` converts matching spans to plain display text), and the committed outcome: deleted targets, rewritten pages, removed bookmark ids, and the incoming-link edge count.
- **`WikiStore.deleteResources(_:)`** is the single deletion seam. Impact recheck, provenance validation, optional rewrites, mandatory bookmark cleanup with sibling renumbering, and target deletion run in ONE `mutateBatch` transaction. Events are buffered and emitted strictly after commit: `.page .updated` per rewritten page, `.bookmark .deleted` per removed leaf, one `.deleted` event per target row that existed. A rollback emits nothing.
- **Batch semantics**: each linking page rewrites at most once (internal `createPageVersionWithProvenance` + `replaceLinksLocked` helpers — same version/provenance rules as `updatePage`); pages in the deletion set are never rewritten; one blocked source stops the complete batch before the first mutation; duplicate ids have one effect; missing targets are idempotent no-ops that still remove stale bookmarks and emit no false target event.
- **Compatibility**: `deletePage(id:)` and `deleteSource(id:)` forward into the `.preserve` request. An internal failure-point parameter (production default `.none`) pins the rollback contract in tests.

## Callers

- **`WikiStoreModel`** — one batch path per resource type plus error-decorating `performPageDeletion` / `performSourceDeletion` entries. Model-side bookmark loops and unlink orchestration are gone; history/tab cleanup runs only for targets the store reports as actually deleted.
- **UI** — `PagesContainerView` and `SourcesContainerView` share `DeletionConfirmationCoordinator`, which produces the finite typed outcome: `.deleteImmediately`, `.confirm(presentation)`, `.blocked(presentation)`, or `.failed(presentation)`. A failed impact read exposes no destructive actions, so it can never invoke deletion. A provenance-blocked source shows "Source Is In Use" with each blocking page as a clickable "Open …" action, so the user can remove the reference and retry (replaces the OK-only "Can't Delete Source" alert). Home-page cleanup keys off the committed result's `deletedTargets`.
- **`wikictl page delete`** — routes through the same contract and adds `--unlink-incoming`. Stdout stays the deleted page id; `didCommit` reflects actual committed change (a no-op posts no notification); a stderr notice reports cleanup counts.

## Review

An independent implementation review (different model family from the authoring one) verified the transaction boundaries, event timing, typed ID separation, and SwiftUI blocked/failed flows as clean, and raised three findings — both HIGHs (batch UI path, home-page cleanup on failure) and the MEDIUM (`didCommit` on a no-op) are fixed in these commits with regression tests. The LOW edge-count wording finding was rebutted with rationale in the progress record.

## Verification

- `make build` — signed app, green.
- `make test` — 4,351 tests in 467 suites pass.
- Targeted: `LinkUnlinkerTests` (14), `DeletionIncomingReferenceTests` (27 — atomic batches, rewrite-once, provenance gate, three rollback failure points with full state comparison, post-commit event batch, renumbered siblings, dedup, missing targets, forwarders, model batch path), `StoreEmissionTests` (57), `WikiCtlCommandTests` (parser flags, stdout contract, no-op `didCommit`), `StoreEmissionExhaustivenessTests` (`deleteResources` on `mutateBatch`, forwarders forward), and opt-in app suites `DeletionConfirmationCoordinatorTests` (8) + `EnumeratorDeletionTests` (8 — File Provider reports target and bookmark deletions).
- `BookmarkNodeStoreTests`: the old "deleted target leaves a stale ref" expectation now asserts the protected invariant (no stale refs survive).

Progress record: `progress/2026-08-01T200000Z-issue-219-deletion-incoming-links.md` (hardening follow-up section).
