### PR TITLE
Allow user-selected HTTP source URLs

### DIFF
--- a/Tests/WikiFSTests/AppTransportSecurityPackagingTests.swift
+++ b/Tests/WikiFSTests/AppTransportSecurityPackagingTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@Suite("App transport security packaging")
+struct AppTransportSecurityPackagingTests {
+    @Test("main app permits user-selected HTTP URLs without changing helper policies")
+    func mainAppPermitsUserSelectedHTTPURLs() throws {
+        let buildScript = try String(
+            contentsOf: Self.repositoryRoot.appending(path: "build.sh"),
+            encoding: .utf8)
+
+        let mainAppPlist = try #require(Self.heredocBody(
+            in: buildScript,
+            introducedBy: "cat > \"${CONTENTS}/Info.plist\" <<PLIST"))
+        let fileProviderPlist = try #require(Self.heredocBody(
+            in: buildScript,
+            introducedBy: "cat > \"${APPEX_CONTENTS}/Info.plist\" <<PLIST"))
+        let daemonPlist = try #require(Self.heredocBody(
+            in: buildScript,
+            introducedBy: "cat > \"${DAEMON_XPC_CONTENTS}/Info.plist\" <<PLIST"))
+
+        #expect(mainAppPlist.contains("<key>NSAppTransportSecurity</key>"))
+        #expect(mainAppPlist.contains("<key>NSAllowsArbitraryLoads</key><true/>"))
+        #expect(!fileProviderPlist.contains("NSAppTransportSecurity"))
+        #expect(!daemonPlist.contains("NSAppTransportSecurity"))
+    }
+
+    private static func heredocBody(in script: String, introducedBy marker: String) -> Substring? {
+        guard let markerRange = script.range(of: marker) else { return nil }
+        let bodyStart = markerRange.upperBound
+        guard let bodyEnd = script.range(of: "\nPLIST", range: bodyStart..<script.endIndex)?.lowerBound
+        else { return nil }
+        return script[bodyStart..<bodyEnd]
+    }
+
+    private static let repositoryRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}

--- a/build.sh
+++ b/build.sh
@@ -383,6 +383,13 @@ cat > "${CONTENTS}/Info.plist" <<PLIST
 	<key>NSHighResolutionCapable</key><true/>
 	<key>NSPrincipalClass</key><string>NSApplication</string>
 	<key>LSApplicationCategoryType</key><string>public.app-category.productivity</string>
+	<!-- Add from URL defaults scheme-less input to HTTPS, but honors an explicit
+	     HTTP URL selected by the user. Because those hosts are not known at build
+	     time, a fixed NSExceptionDomains allowlist cannot support this workflow. -->
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key><true/>
+	</dict>
 	<!-- Per-developer ids read at runtime by WikiIdentifiers (Bundle.main path).
 	     WIKIDaemonServiceID is the name the app passes to
 	     NSXPCConnection(serviceName:) — it MUST match wikid.xpc's


### PR DESCRIPTION
## Summary

- allow the main app to fetch explicit plain HTTP source URLs
- keep HTTPS as the default for URLs without a scheme
- keep the ATS exception out of the File Provider and `wikid` helper bundles
- add a packaging contract test for the ATS scope

## Security scope

User-provided source domains are not known at build time, so a fixed `NSExceptionDomains` list cannot support Add from URL. The main app therefore sets `NSAllowsArbitraryLoads`; bundled helpers retain the default ATS policy.

## Verification

- `bash -n build.sh`
- `swift test --filter AppTransportSecurityPackagingTests`
- `make build`
- inspected emitted plists: main app `NSAllowsArbitraryLoads = true`; File Provider and `wikid` ATS dictionaries absent
- `make test`: 4,352 tests passed
- pre-commit lint: 0 violations

Fixes #1247
