### PR TITLE
Canonicalize ACP JS-adapter launches through the resolved bun (#1257 Level 1)

### DIFF
--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -293,7 +293,8 @@ public actor ACPBackend: AgentBackend {
         turnCeilingTimeout: TimeInterval = TurnLivenessPolicy.defaultCeilingTimeout,
         watchdogPollInterval: TimeInterval = TurnLivenessPolicy.defaultPollInterval,
         drainGraceTimeout: Duration = .seconds(3),
-        maxConcurrentExecutors: Int = 1
+        maxConcurrentExecutors: Int = 1,
+        resolveBunRuntime: @escaping @Sendable () async -> String? = ACPBackend.defaultResolveBunRuntime
     ) {
         self.permissionPolicy = permissionPolicy
         self.permissionBudget = budget
@@ -302,6 +303,38 @@ public actor ACPBackend: AgentBackend {
         self.watchdogPollInterval = watchdogPollInterval
         self.drainGraceTimeout = drainGraceTimeout
         self.maxConcurrentExecutors = max(1, maxConcurrentExecutors)
+        self.resolveBunRuntime = resolveBunRuntime
+    }
+
+    /// Resolves the absolute bun path used to canonicalize JS-adapter launches
+    /// (#1257 Level 1). The default goes through the same login-shell locator
+    /// the extractor runtimes use, so the app knows one runtime, not the
+    /// user's node/npm state. Returns nil when bun is unresolvable — the
+    /// original command then runs unchanged (logged).
+    static let defaultResolveBunRuntime: @Sendable () async -> String? = {
+        // "bun" is a fixed valid runtime name; this init only validates
+        // arbitrary strings, so the failure branch is unreachable.
+        // swiftlint:disable:next silent_try_optional
+        guard let name = try? ExtractorRuntimeName(validating: "bun") else { return nil }
+        guard case .resolved(let resolution) = await RuntimeCommandLocator().locate(name) else {
+            return nil
+        }
+        return resolution.executableURL.path
+    }
+
+    /// The bun resolver for adapter canonicalization (injectable for tests).
+    private let resolveBunRuntime: @Sendable () async -> String?
+    /// Memoized resolution — `startProcess` runs once per process launch, but
+    /// fallback-provider backends each pay for a locate; cache per actor.
+    private var cachedBunPath: String?
+
+    /// The memoized bun path, or nil when the resolver failed (the original
+    /// command runs unchanged and the failure is logged by the caller).
+    private func resolvedBunPath() async -> String? {
+        if let cachedBunPath { return cachedBunPath }
+        let resolved = await resolveBunRuntime()
+        cachedBunPath = resolved
+        return resolved
     }
 
     /// `fs` read/write + `terminal` — mirrors paseo's `BASE_ACP_CLIENT_CAPABILITIES`
@@ -353,9 +386,27 @@ public actor ACPBackend: AgentBackend {
         profile: BackendProfile,
         onExit: @escaping @Sendable (Int) -> Void
     ) async throws {
-        guard let spawn = Self.resolveSpawnConfig(from: profile) else {
+        guard var spawn = Self.resolveSpawnConfig(from: profile) else {
             DebugLog.agent("ACPBackend.startProcess: FAIL noAgentConfigured")
             throw ACPBackendError.noAgentConfigured
+        }
+
+        // #1257 Level 1: JS-adapter shapes (npx / npm exec / bunx) launch
+        // through the resolved absolute bun instead of the user's node/npm
+        // state. Unresolvable bun keeps the original command (logged once,
+        // memoized per backend) — the npx path still works.
+        let canonical = Self.canonicalizedAdapterLaunch(
+            executablePath: spawn.executablePath,
+            arguments: spawn.arguments,
+            resolvedBunPath: await resolvedBunPath())
+        if canonical.executablePath != spawn.executablePath {
+            DebugLog.agent("ACPBackend.startProcess: adapter canonicalized to \(canonical.executablePath) x")
+            spawn = AgentSpawnConfig(
+                executablePath: canonical.executablePath,
+                arguments: canonical.arguments,
+                workingDirectory: spawn.workingDirectory,
+                apiKey: spawn.apiKey,
+                environment: spawn.environment)
         }
 
         // Create the verbose debug logger (complete ACP wire trace) from the
@@ -1934,6 +1985,40 @@ public actor ACPBackend: AgentBackend {
                 invocation: effective),
             environment: environment,
             defines: effective.defines)
+    }
+
+    /// Rewrites JS-adapter launch shapes (`npx`, `npm exec`, `bunx`) to run
+    /// through the resolved absolute bun as `bun x <package spec...>` (#1257
+    /// Level 1): the launch stops depending on the user's node/npm state, and
+    /// the sandbox's provider-home layering then sees a `bun x` command and
+    /// layers `~/.bun` instead of `~/.npm`. Shapes that are already canonical
+    /// (`bun x ...`), plain provider binaries, or a nil/unresolvable bun
+    /// return the inputs unchanged. npx/npm flags are passed through verbatim;
+    /// configure adapter commands without runner flags.
+    static func canonicalizedAdapterLaunch(
+        executablePath: String,
+        arguments: [String],
+        resolvedBunPath: String?
+    ) -> (executablePath: String, arguments: [String]) {
+        guard let resolvedBunPath, !resolvedBunPath.isEmpty else {
+            return (executablePath, arguments)
+        }
+        let basename = (executablePath as NSString).lastPathComponent.lowercased()
+        let isNpx = basename == "npx"
+        let isBunx = basename == "bunx"
+        let isNpmExec = basename == "npm" && arguments.first == "exec"
+        guard isNpx || isBunx || isNpmExec else {
+            return (executablePath, arguments)
+        }
+        var spec = arguments
+        if isNpmExec {
+            // `npm exec [--] <pkg> ...` — both flag orders exist.
+            spec = Array(spec.dropFirst())
+            if spec.first == "--" {
+                spec = Array(spec.dropFirst())
+            }
+        }
+        return (resolvedBunPath, ["x"] + spec)
     }
 
     /// Fail-closed usability gate for the seatbelt front-end: it must exist as

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -294,7 +294,7 @@ public actor ACPBackend: AgentBackend {
         watchdogPollInterval: TimeInterval = TurnLivenessPolicy.defaultPollInterval,
         drainGraceTimeout: Duration = .seconds(3),
         maxConcurrentExecutors: Int = 1,
-        resolveBunRuntime: @escaping @Sendable () async -> String? = ACPBackend.defaultResolveBunRuntime
+        resolveBunRuntime: @escaping @Sendable () async -> RuntimeCommandResolution? = ACPBackend.defaultResolveBunRuntime
     ) {
         self.permissionPolicy = permissionPolicy
         self.permissionBudget = budget
@@ -306,12 +306,13 @@ public actor ACPBackend: AgentBackend {
         self.resolveBunRuntime = resolveBunRuntime
     }
 
-    /// Resolves the absolute bun path used to canonicalize JS-adapter launches
+    /// Resolves the bun runtime used to canonicalize JS-adapter launches
     /// (#1257 Level 1). The default goes through the same login-shell locator
     /// the extractor runtimes use, so the app knows one runtime, not the
-    /// user's node/npm state. Returns nil when bun is unresolvable — the
-    /// original command then runs unchanged (logged).
-    static let defaultResolveBunRuntime: @Sendable () async -> String? = {
+    /// user's node/npm state. The full resolution (including the pinned
+    /// executable identity) is retained so reuse can verify the binary has
+    /// not been swapped underneath the cached path.
+    static let defaultResolveBunRuntime: @Sendable () async -> RuntimeCommandResolution? = {
         // "bun" is a fixed valid runtime name; this init only validates
         // arbitrary strings, so the failure branch is unreachable.
         // swiftlint:disable:next silent_try_optional
@@ -319,22 +320,44 @@ public actor ACPBackend: AgentBackend {
         guard case .resolved(let resolution) = await RuntimeCommandLocator().locate(name) else {
             return nil
         }
-        return resolution.executableURL.path
+        return resolution
     }
 
     /// The bun resolver for adapter canonicalization (injectable for tests).
-    private let resolveBunRuntime: @Sendable () async -> String?
-    /// Memoized resolution — `startProcess` runs once per process launch, but
-    /// fallback-provider backends each pay for a locate; cache per actor.
-    private var cachedBunPath: String?
+    private let resolveBunRuntime: @Sendable () async -> RuntimeCommandResolution?
+    /// Memoized resolution. Outer nil = not attempted yet; inner nil = the
+    /// resolver already failed for this backend (negative-cached, so a
+    /// bun-less machine pays for one locate, not one per start). A successful
+    /// resolution keeps its pinned identity for reuse verification.
+    private var cachedBunResolution: RuntimeCommandResolution??
 
-    /// The memoized bun path, or nil when the resolver failed (the original
-    /// command runs unchanged and the failure is logged by the caller).
-    private func resolvedBunPath() async -> String? {
-        if let cachedBunPath { return cachedBunPath }
+    /// The memoized bun resolution, or nil when unresolvable (the original
+    /// command runs unchanged; the caller logs that fallback). A cached
+    /// resolution whose pinned identity no longer matches the file at its
+    /// path (a mise version switch, say) is discarded and re-resolved once.
+    private func resolvedBunResolution() async -> RuntimeCommandResolution? {
+        switch cachedBunResolution {
+        case .none:
+            break // not attempted — resolve below
+        case .some(.none):
+            return nil // the resolver already failed for this backend
+        case .some(.some(let resolution)):
+            if Self.resolutionStillValid(resolution) { return resolution }
+            break // stale — re-resolve once below
+        }
         let resolved = await resolveBunRuntime()
-        cachedBunPath = resolved
+        cachedBunResolution = .some(resolved)
         return resolved
+    }
+
+    /// The locator's documented contract: the pinned identity is verified
+    /// before reuse, so a replaced or rewritten executable is not silently
+    /// exec'd across a memoized resolution.
+    private static func resolutionStillValid(_ resolution: RuntimeCommandResolution) -> Bool {
+        guard case .identity(let identity) = RuntimeFileProbe.probe(resolution.executableURL) else {
+            return false
+        }
+        return identity == resolution.identity
     }
 
     /// `fs` read/write + `terminal` — mirrors paseo's `BASE_ACP_CLIENT_CAPABILITIES`
@@ -391,22 +414,29 @@ public actor ACPBackend: AgentBackend {
             throw ACPBackendError.noAgentConfigured
         }
 
-        // #1257 Level 1: JS-adapter shapes (npx / npm exec / bunx) launch
-        // through the resolved absolute bun instead of the user's node/npm
-        // state. Unresolvable bun keeps the original command (logged once,
-        // memoized per backend) — the npx path still works.
-        let canonical = Self.canonicalizedAdapterLaunch(
+        // #1257 Level 1: JS-adapter shapes (npx / npm exec|x / bunx, and bun x
+        // launches) are canonicalized through the resolved absolute bun, so
+        // the launch does not depend on the user's node/npm state. The shape
+        // gate runs first: non-adapter launches never pay for the locate. An
+        // unresolvable bun keeps the configured command (negative-cached per
+        // backend, logged here) — the npx path still works.
+        if Self.isJSAdapterLaunch(
             executablePath: spawn.executablePath,
-            arguments: spawn.arguments,
-            resolvedBunPath: await resolvedBunPath())
-        if canonical.executablePath != spawn.executablePath {
-            DebugLog.agent("ACPBackend.startProcess: adapter canonicalized to \(canonical.executablePath) x")
-            spawn = AgentSpawnConfig(
-                executablePath: canonical.executablePath,
-                arguments: canonical.arguments,
-                workingDirectory: spawn.workingDirectory,
-                apiKey: spawn.apiKey,
-                environment: spawn.environment)
+            arguments: spawn.arguments) {
+            if let resolution = await resolvedBunResolution() {
+                let canonical = Self.canonicalizedSpawn(
+                    spawn,
+                    resolvedBunPath: resolution.executableURL.path)
+                DebugLog.agent(
+                    "ACPBackend.startProcess: adapter canonicalized " +
+                    "\(spawn.executablePath) \(spawn.arguments.joined(separator: " ")) → " +
+                    "\(canonical.executablePath) \(canonical.arguments.joined(separator: " "))")
+                spawn = canonical
+            } else {
+                DebugLog.agent(
+                    "ACPBackend.startProcess: bun unresolved — launching configured " +
+                    "\(spawn.executablePath) \(spawn.arguments.joined(separator: " ")) unchanged")
+            }
         }
 
         // Create the verbose debug logger (complete ACP wire trace) from the
@@ -1987,38 +2017,75 @@ public actor ACPBackend: AgentBackend {
             defines: effective.defines)
     }
 
-    /// Rewrites JS-adapter launch shapes (`npx`, `npm exec`, `bunx`) to run
-    /// through the resolved absolute bun as `bun x <package spec...>` (#1257
-    /// Level 1): the launch stops depending on the user's node/npm state, and
-    /// the sandbox's provider-home layering then sees a `bun x` command and
-    /// layers `~/.bun` instead of `~/.npm`. Shapes that are already canonical
-    /// (`bun x ...`), plain provider binaries, or a nil/unresolvable bun
-    /// return the inputs unchanged. npx/npm flags are passed through verbatim;
-    /// configure adapter commands without runner flags.
-    static func canonicalizedAdapterLaunch(
-        executablePath: String,
-        arguments: [String],
-        resolvedBunPath: String?
-    ) -> (executablePath: String, arguments: [String]) {
-        guard let resolvedBunPath, !resolvedBunPath.isEmpty else {
-            return (executablePath, arguments)
-        }
+    /// True when the configured launch is a JS-adapter shape this backend
+    /// canonicalizes: executable basename `npx`, `bunx`, `npm exec`/`npm x`,
+    /// or an already-`bun x` launch (that last one is repointed at the
+    /// resolved bun so it stops depending on whatever `bun` the PATH had).
+    /// Plain provider binaries (claude, codex, gemini, ...) are never
+    /// rewritten, and `.cmd`/`.exe` shims are out of scope (macOS-only app).
+    static func isJSAdapterLaunch(executablePath: String, arguments: [String]) -> Bool {
         let basename = (executablePath as NSString).lastPathComponent.lowercased()
-        let isNpx = basename == "npx"
-        let isBunx = basename == "bunx"
-        let isNpmExec = basename == "npm" && arguments.first == "exec"
-        guard isNpx || isBunx || isNpmExec else {
-            return (executablePath, arguments)
+        if basename == "npx" || basename == "bunx" { return true }
+        if basename == "npm", arguments.first == "exec" || arguments.first == "x" { return true }
+        if basename == "bun", arguments.first == "x" { return true }
+        return false
+    }
+
+    /// Rewrites a JS-adapter spawn to run through the resolved absolute bun as
+    /// `bun x <package spec...>` (#1257 Level 1): the launch stops depending
+    /// on the user's node/npm state, and the sandbox's provider-home layering
+    /// then sees a `bun x` command and layers `~/.bun` instead of `~/.npm`.
+    /// Every other `AgentSpawnConfig` field (working directory, API key,
+    /// environment) is preserved verbatim. npx-only runner flags (`-y`,
+    /// `--yes`) and a leading `--` separator are stripped — `bun x` does not
+    /// document them — and everything after the package spec passes through
+    /// unchanged. Non-adapter shapes and a nil/empty `resolvedBunPath` return
+    /// the spawn untouched (the caller logs that fallback).
+    static func canonicalizedSpawn(
+        _ spawn: AgentSpawnConfig,
+        resolvedBunPath: String?
+    ) -> AgentSpawnConfig {
+        guard let resolvedBunPath, !resolvedBunPath.isEmpty,
+              isJSAdapterLaunch(
+                executablePath: spawn.executablePath,
+                arguments: spawn.arguments)
+        else {
+            return spawn
         }
-        var spec = arguments
-        if isNpmExec {
-            // `npm exec [--] <pkg> ...` — both flag orders exist.
-            spec = Array(spec.dropFirst())
-            if spec.first == "--" {
-                spec = Array(spec.dropFirst())
-            }
+        let basename = (spawn.executablePath as NSString).lastPathComponent.lowercased()
+        var spec = spawn.arguments
+        if basename == "npm" {
+            // `npm exec [--] <pkg> ...` (and the `npm x` alias) — both flag
+            // orders exist.
+            spec = strippingLeadingRunnerFlags(Array(spec.dropFirst()))
+        } else if basename == "bun" {
+            // Already `bun x <spec>` — keep the arguments, repoint the binary.
+            return AgentSpawnConfig(
+                executablePath: resolvedBunPath,
+                arguments: spawn.arguments,
+                workingDirectory: spawn.workingDirectory,
+                apiKey: spawn.apiKey,
+                environment: spawn.environment)
+        } else {
+            spec = strippingLeadingRunnerFlags(spec)
         }
-        return (resolvedBunPath, ["x"] + spec)
+        return AgentSpawnConfig(
+            executablePath: resolvedBunPath,
+            arguments: ["x"] + spec,
+            workingDirectory: spawn.workingDirectory,
+            apiKey: spawn.apiKey,
+            environment: spawn.environment)
+    }
+
+    /// Drops leading npx/npm-only runner flags and a leading `--` separator
+    /// (which `bun x` tolerates but does not document) so the rewritten argv
+    /// carries only the package spec and its arguments.
+    private static func strippingLeadingRunnerFlags(_ arguments: [String]) -> [String] {
+        var result = arguments
+        while let first = result.first, first == "-y" || first == "--yes" || first == "--" {
+            result = Array(result.dropFirst())
+        }
+        return result
     }
 
     /// Fail-closed usability gate for the seatbelt front-end: it must exist as

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -375,7 +375,13 @@ public actor ACPBackend: AgentBackend {
             return nil
         }
         let resolved = await resolutionTask.value
-        bunResolutionState = .resolved(resolved)
+        // Generation guard (committee round 2): a stale waiter — one whose
+        // await resumed after a newer locate was parked — must not clobber
+        // the newer in-flight state. Task is Equatable (identity-based), so
+        // this commits only if our generation is still current.
+        if case .inFlight(let current) = bunResolutionState, current == resolutionTask {
+            bunResolutionState = .resolved(resolved)
+        }
         return resolved
     }
 
@@ -446,18 +452,38 @@ public actor ACPBackend: AgentBackend {
             throw ACPBackendError.noAgentConfigured
         }
 
+        // Fail-closed seatbelt gate FIRST (committee round 2): when a sandbox
+        // is requested, the front-end is verified before anything else —
+        // including bun canonicalization, which shells out to a login shell.
+        // "Sandbox unavailable" must mean nothing ran at all, not merely that
+        // no agent was exec'd.
+        #if os(macOS)
+        if profile.sandbox != nil,
+           !Self.sandboxExecutableIsUsable(at: SandboxProfile.sandboxExecutablePath) {
+            DebugLog.agent("ACPBackend.startProcess: sandbox front-end unusable — refusing to spawn (fail closed)")
+            throw ACPBackendError.sandboxUnavailable
+        }
+        #endif
+
         // #1257 Level 1: JS-adapter shapes (npx / npm exec|x / bunx, and bun x
-        // launches) are canonicalized through the resolved absolute bun, so
-        // the launch does not depend on the user's node/npm state. The shape
-        // gate runs first: non-adapter launches never pay for the locate. An
-        // unresolvable bun — or adapter flags the rewrite cannot translate —
-        // keeps the configured command (negative-cached per backend, logged
-        // here) — the npx path still works.
+        // launches) are canonicalized to run through the resolved absolute bun
+        // as the package runner — moving the package cache off ~/.npm (the
+        // first-chat EPERM). Scope note (committee round 2): this
+        // canonicalizes the RUNNER and the cache; the adapter process itself
+        // may still exec Node via its own shebang unless `--bun` is adopted
+        // (follow-up). The shape gate runs first: non-adapter launches never
+        // pay for the locate. An unresolvable bun — or adapter flags/spec
+        // forms the rewrite cannot translate — keeps the configured command
+        // (negative-cached per backend, logged here) — the npx path still
+        // works.
+        let configuredSpawn = spawn
+        let configuredDescription = spawn.executablePath + " "
+            + spawn.arguments.joined(separator: " ")
+        var usedCanonicalBun = false
+        var bunResolutionUsed: RuntimeCommandResolution?
         if Self.isJSAdapterLaunch(
             executablePath: spawn.executablePath,
             arguments: spawn.arguments) {
-            let configuredDescription = spawn.executablePath + " "
-                + spawn.arguments.joined(separator: " ")
             if let resolution = await resolvedBunResolution(),
                let canonical = Self.canonicalizedSpawn(
                     spawn,
@@ -467,6 +493,8 @@ public actor ACPBackend: AgentBackend {
                     "\(configuredDescription) → " +
                     "\(canonical.executablePath) \(canonical.arguments.joined(separator: " "))")
                 spawn = canonical
+                usedCanonicalBun = true
+                bunResolutionUsed = resolution
             } else {
                 DebugLog.agent(
                     "ACPBackend.startProcess: launching configured " +
@@ -474,6 +502,9 @@ public actor ACPBackend: AgentBackend {
                     "runner flags not translatable)")
             }
         }
+        // A start cancelled while waiting on the shared bun locate must not
+        // continue toward process launch (committee round 2).
+        try Task.checkCancellation()
 
         // Create the verbose debug logger (complete ACP wire trace) from the
         // profile's debugLogURL. Returns nil (no-op) when disabled or the
@@ -515,17 +546,13 @@ public actor ACPBackend: AgentBackend {
         // `sandbox-exec -p <profile> -D k=v ... -- <agent> <args...>`: writes
         // fenced to the wiki DB + scratch + `~/.claude` (+ the provider's
         // config home), the resolved `pdf2md` script exec/read-denied; reads,
-        // network, and other exec stay open. Fail closed on macOS: an unusable
-        // front-end starts no process.
+        // network, and other exec stay open. Fail closed on macOS: the gate
+        // at the top of this function already verified the front-end.
         var spawnExecutablePath = spawn.executablePath
         var spawnArguments = spawn.arguments
         var spawnEnvironment = env
         #if os(macOS)
         if let sandbox = profile.sandbox {
-            guard Self.sandboxExecutableIsUsable(at: SandboxProfile.sandboxExecutablePath) else {
-                DebugLog.agent("ACPBackend.startProcess: sandbox front-end unusable — refusing to spawn (fail closed)")
-                throw ACPBackendError.sandboxUnavailable
-            }
             let plan = Self.sandboxedSpawnPlan(
                 invocation: sandbox,
                 executablePath: spawn.executablePath,
@@ -543,6 +570,21 @@ public actor ACPBackend: AgentBackend {
             DebugLog.agent("sandbox: unavailable on this platform — spawning UNSANDBOXED")
         }
         #endif
+
+        // Committee round 2: the pinned bun identity is re-verified at the
+        // final pre-launch seam — the canonicalization-time probe does not
+        // cover the window between canonicalization and exec. A binary
+        // swapped under the cached path falls back to the configured command
+        // (fail safe), which is exactly what ran before this branch.
+        if usedCanonicalBun,
+           let resolution = bunResolutionUsed,
+           !Self.resolutionStillValid(resolution, probing: probeExecutable) {
+            DebugLog.agent(
+                "ACPBackend.startProcess: resolved bun changed before launch — " +
+                "using configured \(configuredDescription) unchanged")
+            spawnExecutablePath = configuredSpawn.executablePath
+            spawnArguments = configuredSpawn.arguments
+        }
 
         // #733 + #737: capture stderr during the launch/initialize window.
         // The stderr stream is single-consumer (`AsyncStream` — two iterators
@@ -2068,8 +2110,10 @@ public actor ACPBackend: AgentBackend {
     }
 
     /// Rewrites a JS-adapter spawn to run through the resolved absolute bun as
-    /// `bun x <package spec...>` (#1257 Level 1): the launch stops depending
-    /// on the user's node/npm state, and the sandbox's provider-home layering
+    /// `bun x <package spec...>` (#1257 Level 1): the package runner and
+    /// cache stop depending on the user's node/npm state (the adapter process
+    /// itself may still exec Node via its own shebang unless `--bun` is
+    /// adopted — #1257 follow-up), and the sandbox's provider-home layering
     /// then sees a `bun x` command and layers `~/.bun` instead of `~/.npm`.
     /// Every other `AgentSpawnConfig` field (working directory, API key,
     /// environment) is preserved verbatim.
@@ -2121,12 +2165,18 @@ public actor ACPBackend: AgentBackend {
         } else {
             spec = strippingLeadingRunnerFlags(spec)
         }
-        // Fail safe on runner flags the rewrite cannot translate (`npx
-        // --quiet pkg`, `npx -p @scope/pkg bin`, `npm exec --prefer-online --
-        // pkg`, ...): a flag left here would land in package-spec position
-        // and break a launch that worked before. The caller falls back to the
-        // configured command and logs it.
-        guard let head = spec.first, !head.hasPrefix("-") else {
+        // Fail safe on anything the rewrite cannot translate: leading runner
+        // flags (`npx --quiet pkg`, `npx -p @scope/pkg bin`,
+        // `npm exec --prefer-online -- pkg`) and spec forms `bun x` cannot
+        // execute (`github:org/repo`, `git+ssh://…`, `https://…/pkg.tgz`,
+        // `file:../adapter`, `./local-adapter`). A flag left here would land
+        // in package-spec position and an exotic spec would fail at launch —
+        // both break launches that worked before. The caller falls back to
+        // the configured command and logs it.
+        guard let head = spec.first, !head.hasPrefix("-"),
+              !head.hasPrefix("."), !head.hasPrefix("/"),
+              !head.contains(":"), !head.hasSuffix(".tgz")
+        else {
             return nil
         }
         return AgentSpawnConfig(

--- a/Sources/WikiFSEngine/ACPBackend.swift
+++ b/Sources/WikiFSEngine/ACPBackend.swift
@@ -294,7 +294,8 @@ public actor ACPBackend: AgentBackend {
         watchdogPollInterval: TimeInterval = TurnLivenessPolicy.defaultPollInterval,
         drainGraceTimeout: Duration = .seconds(3),
         maxConcurrentExecutors: Int = 1,
-        resolveBunRuntime: @escaping @Sendable () async -> RuntimeCommandResolution? = ACPBackend.defaultResolveBunRuntime
+        resolveBunRuntime: @escaping @Sendable () async -> RuntimeCommandResolution? = ACPBackend.defaultResolveBunRuntime,
+        probeExecutable: @escaping @Sendable (URL) -> RuntimeExecutableProbeOutcome = RuntimeFileProbe.probe
     ) {
         self.permissionPolicy = permissionPolicy
         self.permissionBudget = budget
@@ -304,6 +305,7 @@ public actor ACPBackend: AgentBackend {
         self.drainGraceTimeout = drainGraceTimeout
         self.maxConcurrentExecutors = max(1, maxConcurrentExecutors)
         self.resolveBunRuntime = resolveBunRuntime
+        self.probeExecutable = probeExecutable
     }
 
     /// Resolves the bun runtime used to canonicalize JS-adapter launches
@@ -313,10 +315,7 @@ public actor ACPBackend: AgentBackend {
     /// executable identity) is retained so reuse can verify the binary has
     /// not been swapped underneath the cached path.
     static let defaultResolveBunRuntime: @Sendable () async -> RuntimeCommandResolution? = {
-        // "bun" is a fixed valid runtime name; this init only validates
-        // arbitrary strings, so the failure branch is unreachable.
-        // swiftlint:disable:next silent_try_optional
-        guard let name = try? ExtractorRuntimeName(validating: "bun") else { return nil }
+        guard let name = ExtractorRuntimeName(rawValue: "bun") else { return nil }
         guard case .resolved(let resolution) = await RuntimeCommandLocator().locate(name) else {
             return nil
         }
@@ -325,36 +324,69 @@ public actor ACPBackend: AgentBackend {
 
     /// The bun resolver for adapter canonicalization (injectable for tests).
     private let resolveBunRuntime: @Sendable () async -> RuntimeCommandResolution?
-    /// Memoized resolution. Outer nil = not attempted yet; inner nil = the
-    /// resolver already failed for this backend (negative-cached, so a
-    /// bun-less machine pays for one locate, not one per start). A successful
-    /// resolution keeps its pinned identity for reuse verification.
-    private var cachedBunResolution: RuntimeCommandResolution??
+    /// The identity probe applied to a cached resolution before reuse
+    /// (injectable so the memoization contract is testable without a real
+    /// file on disk).
+    private let probeExecutable: @Sendable (URL) -> RuntimeExecutableProbeOutcome
+
+    /// Memoized bun resolution lifecycle. `notAttempted` defers the
+    /// (potentially slow, login-shell) locate until an adapter-shaped launch
+    /// actually needs it; `inFlight` parks the shared locate so concurrent
+    /// starts run exactly one; `resolved(nil)` negative-caches a failed
+    /// resolution for this backend — an accepted deviation from the locator's
+    /// never-cache-failures contract, because backends are retained and the
+    /// npx fallback still works (a bun installed later is picked up by the
+    /// next backend); `resolved(.some)` keeps the pinned identity, re-probed
+    /// before every reuse so a swapped binary invalidates the cache.
+    private enum BunResolutionState {
+        case notAttempted
+        case inFlight(Task<RuntimeCommandResolution?, Never>)
+        case resolved(RuntimeCommandResolution?)
+    }
+
+    private var bunResolutionState: BunResolutionState = .notAttempted
 
     /// The memoized bun resolution, or nil when unresolvable (the original
-    /// command runs unchanged; the caller logs that fallback). A cached
-    /// resolution whose pinned identity no longer matches the file at its
-    /// path (a mise version switch, say) is discarded and re-resolved once.
-    private func resolvedBunResolution() async -> RuntimeCommandResolution? {
-        switch cachedBunResolution {
-        case .none:
-            break // not attempted — resolve below
-        case .some(.none):
-            return nil // the resolver already failed for this backend
-        case .some(.some(let resolution)):
-            if Self.resolutionStillValid(resolution) { return resolution }
-            break // stale — re-resolve once below
+    /// command runs unchanged; the caller logs that fallback). Concurrent
+    /// callers share one locate; a stale cached identity (binary replaced
+    /// under the cached path) re-resolves exactly once. Internal (not
+    /// private) so the memoization contract — positive memo, negative memo,
+    /// stale-identity re-resolve-once — is directly testable through the
+    /// injected resolver/probe seams without spawning a process.
+    func resolvedBunResolution() async -> RuntimeCommandResolution? {
+        let resolutionTask: Task<RuntimeCommandResolution?, Never>
+        switch bunResolutionState {
+        case .notAttempted:
+            let task = Task { await self.resolveBunRuntime() }
+            bunResolutionState = .inFlight(task)
+            resolutionTask = task
+        case .inFlight(let task):
+            resolutionTask = task
+        case .resolved(.some(let resolution))
+        where Self.resolutionStillValid(resolution, probing: probeExecutable):
+            return resolution
+        case .resolved(.some):
+            // Stale: the binary under the cached path was replaced.
+            // Re-resolve exactly once below.
+            let task = Task { await self.resolveBunRuntime() }
+            bunResolutionState = .inFlight(task)
+            resolutionTask = task
+        case .resolved(.none):
+            return nil
         }
-        let resolved = await resolveBunRuntime()
-        cachedBunResolution = .some(resolved)
+        let resolved = await resolutionTask.value
+        bunResolutionState = .resolved(resolved)
         return resolved
     }
 
     /// The locator's documented contract: the pinned identity is verified
     /// before reuse, so a replaced or rewritten executable is not silently
     /// exec'd across a memoized resolution.
-    private static func resolutionStillValid(_ resolution: RuntimeCommandResolution) -> Bool {
-        guard case .identity(let identity) = RuntimeFileProbe.probe(resolution.executableURL) else {
+    private static func resolutionStillValid(
+        _ resolution: RuntimeCommandResolution,
+        probing probe: @Sendable (URL) -> RuntimeExecutableProbeOutcome
+    ) -> Bool {
+        guard case .identity(let identity) = probe(resolution.executableURL) else {
             return false
         }
         return identity == resolution.identity
@@ -418,24 +450,28 @@ public actor ACPBackend: AgentBackend {
         // launches) are canonicalized through the resolved absolute bun, so
         // the launch does not depend on the user's node/npm state. The shape
         // gate runs first: non-adapter launches never pay for the locate. An
-        // unresolvable bun keeps the configured command (negative-cached per
-        // backend, logged here) — the npx path still works.
+        // unresolvable bun — or adapter flags the rewrite cannot translate —
+        // keeps the configured command (negative-cached per backend, logged
+        // here) — the npx path still works.
         if Self.isJSAdapterLaunch(
             executablePath: spawn.executablePath,
             arguments: spawn.arguments) {
-            if let resolution = await resolvedBunResolution() {
-                let canonical = Self.canonicalizedSpawn(
+            let configuredDescription = spawn.executablePath + " "
+                + spawn.arguments.joined(separator: " ")
+            if let resolution = await resolvedBunResolution(),
+               let canonical = Self.canonicalizedSpawn(
                     spawn,
-                    resolvedBunPath: resolution.executableURL.path)
+                    resolvedBunPath: resolution.executableURL.path) {
                 DebugLog.agent(
                     "ACPBackend.startProcess: adapter canonicalized " +
-                    "\(spawn.executablePath) \(spawn.arguments.joined(separator: " ")) → " +
+                    "\(configuredDescription) → " +
                     "\(canonical.executablePath) \(canonical.arguments.joined(separator: " "))")
                 spawn = canonical
             } else {
                 DebugLog.agent(
-                    "ACPBackend.startProcess: bun unresolved — launching configured " +
-                    "\(spawn.executablePath) \(spawn.arguments.joined(separator: " ")) unchanged")
+                    "ACPBackend.startProcess: launching configured " +
+                    "\(configuredDescription) unchanged (bun unresolved, or adapter " +
+                    "runner flags not translatable)")
             }
         }
 
@@ -2036,38 +2072,62 @@ public actor ACPBackend: AgentBackend {
     /// on the user's node/npm state, and the sandbox's provider-home layering
     /// then sees a `bun x` command and layers `~/.bun` instead of `~/.npm`.
     /// Every other `AgentSpawnConfig` field (working directory, API key,
-    /// environment) is preserved verbatim. npx-only runner flags (`-y`,
-    /// `--yes`) and a leading `--` separator are stripped — `bun x` does not
-    /// document them — and everything after the package spec passes through
-    /// unchanged. Non-adapter shapes and a nil/empty `resolvedBunPath` return
-    /// the spawn untouched (the caller logs that fallback).
+    /// environment) is preserved verbatim.
+    ///
+    /// Returns `nil` when the launch must keep the configured command:
+    /// non-adapter shapes, a nil/empty `resolvedBunPath` (bun unresolvable),
+    /// or leading runner flags the rewrite cannot translate (`npx --quiet
+    /// pkg`, `npx -p @scope/pkg bin`, `npm exec --prefer-online -- pkg` — a
+    /// flag left in place would land in package-spec position and break a
+    /// launch that worked before; fail safe instead of guessing). `bunx` and
+    /// `bun x` keep their arguments verbatim — they are already bun-family —
+    /// and only get repointed at the resolved binary.
     static func canonicalizedSpawn(
         _ spawn: AgentSpawnConfig,
         resolvedBunPath: String?
-    ) -> AgentSpawnConfig {
+    ) -> AgentSpawnConfig? {
         guard let resolvedBunPath, !resolvedBunPath.isEmpty,
               isJSAdapterLaunch(
                 executablePath: spawn.executablePath,
                 arguments: spawn.arguments)
         else {
-            return spawn
+            return nil
         }
         let basename = (spawn.executablePath as NSString).lastPathComponent.lowercased()
-        var spec = spawn.arguments
-        if basename == "npm" {
-            // `npm exec [--] <pkg> ...` (and the `npm x` alias) — both flag
-            // orders exist.
-            spec = strippingLeadingRunnerFlags(Array(spec.dropFirst()))
-        } else if basename == "bun" {
-            // Already `bun x <spec>` — keep the arguments, repoint the binary.
+        if basename == "bun" {
+            // Already `bun x <spec>` — repoint the binary, keep the argv.
             return AgentSpawnConfig(
                 executablePath: resolvedBunPath,
                 arguments: spawn.arguments,
                 workingDirectory: spawn.workingDirectory,
                 apiKey: spawn.apiKey,
                 environment: spawn.environment)
+        }
+        if basename == "bunx" {
+            // `bunx <spec>` is `bun x <spec>` — restore the subcommand and
+            // repoint; its flags are bun's own and pass verbatim.
+            return AgentSpawnConfig(
+                executablePath: resolvedBunPath,
+                arguments: ["x"] + spawn.arguments,
+                workingDirectory: spawn.workingDirectory,
+                apiKey: spawn.apiKey,
+                environment: spawn.environment)
+        }
+        var spec = spawn.arguments
+        if basename == "npm" {
+            // `npm exec [--] <pkg> ...` (and the `npm x` alias) — both flag
+            // orders exist.
+            spec = strippingLeadingRunnerFlags(Array(spec.dropFirst()))
         } else {
             spec = strippingLeadingRunnerFlags(spec)
+        }
+        // Fail safe on runner flags the rewrite cannot translate (`npx
+        // --quiet pkg`, `npx -p @scope/pkg bin`, `npm exec --prefer-online --
+        // pkg`, ...): a flag left here would land in package-spec position
+        // and break a launch that worked before. The caller falls back to the
+        // configured command and logs it.
+        guard let head = spec.first, !head.hasPrefix("-") else {
+            return nil
         }
         return AgentSpawnConfig(
             executablePath: resolvedBunPath,

--- a/Sources/WikiFSEngine/ACPProviderModelProbe.swift
+++ b/Sources/WikiFSEngine/ACPProviderModelProbe.swift
@@ -100,10 +100,16 @@ public struct ACPProviderModelProbe: Sendable {
             throw ACPProviderModelProbeError.notConfigured
         }
         let profile = BackendProfile(providerHints: hints)
-        guard let spawn = ACPBackend.resolveSpawnConfig(from: profile) else {
+        guard let configuredSpawn = ACPBackend.resolveSpawnConfig(from: profile) else {
             DebugLog.agent("ACPProviderModelProbe: FAIL resolveSpawnConfig nil provider=\(provider.id)")
             throw ACPProviderModelProbeError.notConfigured
         }
+        // #1257 Level 1: canonicalize adapter shapes exactly like
+        // `ACPBackend.startProcess`, so the probe exercises the same runtime
+        // an actual chat launch will use (and the cached model list matches).
+        let spawn = ACPBackend.canonicalizedSpawn(
+            configuredSpawn,
+            resolvedBunPath: await ACPBackend.defaultResolveBunRuntime()?.executableURL.path)
 
         // The probe CWD is a throwaway temp dir — the probe must NOT call
         // `ACPBackend.deliverSystemPrompt` (that writes CLAUDE.md/AGENTS.md

--- a/Sources/WikiFSEngine/ACPProviderModelProbe.swift
+++ b/Sources/WikiFSEngine/ACPProviderModelProbe.swift
@@ -107,9 +107,16 @@ public struct ACPProviderModelProbe: Sendable {
         // #1257 Level 1: canonicalize adapter shapes exactly like
         // `ACPBackend.startProcess`, so the probe exercises the same runtime
         // an actual chat launch will use (and the cached model list matches).
-        let spawn = ACPBackend.canonicalizedSpawn(
-            configuredSpawn,
-            resolvedBunPath: await ACPBackend.defaultResolveBunRuntime()?.executableURL.path)
+        // The bun locate is gated on the adapter shape (it shells out to a
+        // login shell) and accepted outside the probe's own 60 s race below —
+        // a bun-less machine pays it once per probe on the npx fallback path.
+        let bunPath = ACPBackend.isJSAdapterLaunch(
+            executablePath: configuredSpawn.executablePath,
+            arguments: configuredSpawn.arguments)
+            ? await ACPBackend.defaultResolveBunRuntime()?.executableURL.path
+            : nil
+        let spawn = ACPBackend.canonicalizedSpawn(configuredSpawn, resolvedBunPath: bunPath)
+            ?? configuredSpawn
 
         // The probe CWD is a throwaway temp dir — the probe must NOT call
         // `ACPBackend.deliverSystemPrompt` (that writes CLAUDE.md/AGENTS.md

--- a/Tests/WikiFSAppTests/ACPWiringTests.swift
+++ b/Tests/WikiFSAppTests/ACPWiringTests.swift
@@ -635,6 +635,21 @@ import ACPModel
                     arguments: ["@agentclientprotocol/claude-agent-acp"]),
                 resolvedBunPath: missing) == nil)
         }
+        // Committee round 2: spec forms `bun x` cannot execute fail safe to
+        // the configured command instead of breaking working launches.
+        for unsupported in [
+            "github:org/repo",
+            "git+ssh://git@github.com/org/repo.git",
+            "https://example.com/adapter/pkg.tgz",
+            "file:../adapter",
+            "./local-adapter",
+        ] {
+            #expect(ACPBackend.canonicalizedSpawn(
+                ACPBackend.AgentSpawnConfig(
+                    executablePath: "/Users/me/.local/bin/npx",
+                    arguments: [unsupported]),
+                resolvedBunPath: bun) == nil, "spec \(unsupported) must fail safe")
+        }
     }
 
     /// The shape gate that keeps non-adapter launches from paying for the
@@ -656,6 +671,66 @@ import ACPModel
             executablePath: "/usr/local/bin/claude", arguments: []))
         #expect(!ACPBackend.isJSAdapterLaunch(
             executablePath: "/usr/local/bin/codex", arguments: ["acp"]))
+    }
+
+    /// Committee round 2 (M4): the primary happy path keeps a plan-level
+    /// guard — a canonicalized `bun x` command must produce the `/.bun`
+    /// write allowance in the emitted seatbelt profile and must not keep the
+    /// `/.npm` allowance, or the original first-chat EPERM regresses
+    /// undetected.
+    @Test func sandboxedSpawnPlanForCanonicalizedBunXLayersBunCache() throws {
+        let invocation = SandboxProfile.invocation(
+            homePath: "/Users/me",
+            scratchDir: "/tmp/scratch",
+            wikiDBPath: "/db/wiki.sqlite")
+        let canonical = try #require(ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/Users/me/.local/bin/npx",
+                arguments: ["@agentclientprotocol/claude-agent-acp"]),
+            resolvedBunPath: "/resolved/bun"))
+        let plan = ACPBackend.sandboxedSpawnPlan(
+            invocation: invocation,
+            executablePath: canonical.executablePath,
+            arguments: canonical.arguments,
+            environment: [:],
+            scratchDirectory: URL(fileURLWithPath: "/tmp/scratch"))
+
+        let profilePayload = plan.arguments.first { $0.contains("(version 1)") }
+        #expect(profilePayload?.contains(
+            "(allow file-write* (subpath (string-append (param \"HOME\") \"/.bun\")))") == true)
+        #expect(profilePayload?.contains("\"/.npm\"") == false)
+        #expect(plan.executablePath == SandboxProfile.sandboxExecutablePath)
+    }
+
+    /// Committee round 2 (Sol MAJOR-2 + Claude M3): concurrent first callers
+    /// share ONE locate (the in-flight task), and the shared result is not
+    /// lost to a stale waiter overwriting a newer generation.
+    @Test func concurrentBunResolutionCallersShareOneLocate() async throws {
+        let identity = RuntimeExecutableIdentity(device: 1, inode: 300, mode: 0o100755, size: 10)
+        let bunName = try #require(ExtractorRuntimeName(rawValue: "bun"))
+        let counter = InvocationCounter()
+        let backend = ACPBackend(resolveBunRuntime: {
+            counter.bump()
+            // A small real suspension so callers genuinely overlap.
+            do { try await Task.sleep(for: .milliseconds(50)) } catch {}
+            return RuntimeCommandResolution(
+                command: bunName,
+                source: .loginShell,
+                executableURL: URL(fileURLWithPath: "/synthetic/bun"),
+                identity: identity,
+                description: RuntimePathDescription(
+                    redactedPath: "bun", basename: "bun", fingerprint: "test"))
+        })
+
+        await withTaskGroup(of: RuntimeCommandResolution?.self) { group in
+            for _ in 0..<5 {
+                group.addTask { await backend.resolvedBunResolution() }
+            }
+            for await resolution in group {
+                #expect(resolution?.executableURL.path == "/synthetic/bun")
+            }
+        }
+        #expect(counter.value == 1)
     }
 }
 #endif

--- a/Tests/WikiFSAppTests/ACPWiringTests.swift
+++ b/Tests/WikiFSAppTests/ACPWiringTests.swift
@@ -441,33 +441,87 @@ import ACPModel
         #expect(plan.environment.isEmpty)
     }
 
-    /// The first-chat regression (#1251 follow-up): when bun cannot be
-    /// resolved the configured npx command still runs, so the effective
-    /// profile must layer `~/.npm` for the npm package cache.
-    @Test func sandboxedSpawnPlanLayersNpmCacheForNpxLaunches() {
-        let invocation = SandboxProfile.invocation(
-            homePath: "/Users/me",
-            scratchDir: "/tmp/scratch",
-            wikiDBPath: "/db/wiki.sqlite")
-        let plan = ACPBackend.sandboxedSpawnPlan(
-            invocation: invocation,
-            executablePath: "/Users/me/.local/bin/npx",
-            arguments: ["@agentclientprotocol/claude-agent-acp"],
-            environment: [:],
-            scratchDirectory: URL(fileURLWithPath: "/tmp/scratch"))
+    /// The bun resolution memoization contract, exercised through the
+    /// injected resolver + probe seams (second-round review MAJOR-3):
+    /// (a) two calls locate once; (b) a failing resolver locates once across
+    /// calls (negative memo); (c) a changed identity re-locates exactly once
+    /// and the third call reuses.
+    @Test func bunResolutionMemoizationContract() async throws {
+        // Synthetic identity pair: the resolver "installs" identity A first,
+        // then identity B after the cache goes stale.
+        let identityA = RuntimeExecutableIdentity(device: 1, inode: 100, mode: 0o100755, size: 10)
+        let identityB = RuntimeExecutableIdentity(device: 1, inode: 200, mode: 0o100755, size: 20)
+        let bunName = try #require(ExtractorRuntimeName(rawValue: "bun"))
+        let counter = InvocationCounter()
+        // Which identity the FILE PROBE sees: A until the cache is stale,
+        // then B (the binary was swapped under the cached path).
+        let probeIdentityFlipper = InvocationCounter()
 
-        let profilePayload = plan.arguments.first { $0.contains("(version 1)") }
-        #expect(profilePayload?.contains(
-            "(allow file-write* (subpath (string-append (param \"HOME\") \"/.npm\")))") == true)
-        #expect(plan.environment["TMPDIR"] == "/tmp/scratch/.tmp")
+        let backend = ACPBackend(
+            resolveBunRuntime: {
+                let count = counter.bump()
+                return RuntimeCommandResolution(
+                    command: bunName,
+                    source: .loginShell,
+                    executableURL: URL(fileURLWithPath: "/synthetic/bun"),
+                    identity: count == 1 ? identityA : identityB,
+                    description: RuntimePathDescription(
+                        redactedPath: "bun", basename: "bun", fingerprint: "test"))
+            },
+            probeExecutable: { _ in
+                probeIdentityFlipper.bump() >= 2
+                    ? .identity(identityB)
+                    : .identity(identityA)
+            })
+
+        // (a) two calls, one locate; probe sees A, matching the resolution.
+        _ = await backend.resolvedBunResolution()
+        _ = await backend.resolvedBunResolution()
+        #expect(counter.value == 1)
+
+        // (c) the probe now sees B — the cached identity is stale. The next
+        // call re-locates exactly once (resolver returns identity B), and the
+        // call after that reuses the refreshed memo.
+        _ = await backend.resolvedBunResolution()
+        #expect(counter.value == 2)
+        _ = await backend.resolvedBunResolution()
+        #expect(counter.value == 2)
     }
 
-    // MARK: - Adapter canonicalization (#1257 Level 1)
+    /// A failing resolver is negative-cached: two calls locate once, and the
+    /// caller gets nil both times (the configured command runs unchanged).
+    @Test func bunResolutionNegativeCachesFailures() async {
+        let counter = InvocationCounter()
+        let backend = ACPBackend(resolveBunRuntime: {
+            counter.bump()
+            return nil
+        })
+        _ = await backend.resolvedBunResolution()
+        _ = await backend.resolvedBunResolution()
+        #expect(counter.value == 1)
+    }
+
+    /// MINOR-5 follow-up: the unresolved-bun fallback's sandbox consequence
+    /// is real — the configured npx command keeps running, so the effective
+    /// profile layers `~/.npm` for the npm package cache. (The plan-level
+    /// test above pins the profile; this pins the fallback decision that
+    /// selects it.)
+    @Test func unresolvedBunFallsBackToNpxWithNpmCacheLayering() {
+        let spawn = ACPBackend.AgentSpawnConfig(
+            executablePath: "/Users/me/.local/bin/npx",
+            arguments: ["@agentclientprotocol/claude-agent-acp"])
+        // nil bun → no canonicalization → the configured npx command runs.
+        #expect(ACPBackend.canonicalizedSpawn(spawn, resolvedBunPath: nil) == nil)
+        // Its provider-home layering is therefore ~/.npm, not ~/.bun.
+        #expect(ACPBackend.providerHomeSubpaths(
+            forCommand: spawn.executablePath + " "
+                + spawn.arguments.joined(separator: " ")) == [".npm"])
+    }
 
     /// An npx-launched adapter rewrites to `<resolved bun> x <spec>` — the
     /// exact shape whose npm-cache write EPERM'd the first wrapped chat — and
     /// every other spawn field survives the rebuild.
-    @Test func canonicalizedSpawnRewritesNpxThroughResolvedBun() {
+    @Test func canonicalizedSpawnRewritesNpxThroughResolvedBun() throws {
         let spawn = ACPBackend.AgentSpawnConfig(
             executablePath: "/Users/me/.local/bin/npx",
             arguments: ["@agentclientprotocol/claude-agent-acp"],
@@ -475,7 +529,7 @@ import ACPModel
             apiKey: "secret",
             environment: ["WIKI_DB": "01WIKI"])
         let bun = "/Users/me/.local/share/mise/installs/bun/1.4.0/bin/bun"
-        let canonical = ACPBackend.canonicalizedSpawn(spawn, resolvedBunPath: bun)
+        let canonical = try #require(ACPBackend.canonicalizedSpawn(spawn, resolvedBunPath: bun))
         #expect(canonical.executablePath == bun)
         #expect(canonical.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
         #expect(canonical.workingDirectory == "/tmp/scratch")
@@ -492,98 +546,94 @@ import ACPModel
     /// runner flags (`-y`, `--yes`) and a leading `--` are stripped (bun x
     /// tolerates but does not document them — the review verified this
     /// against the local bun and the rewrite removes the reliance).
-    @Test func canonicalizedSpawnHandlesNpmExecAliasesAndStripsRunnerFlags() {
+    @Test func canonicalizedSpawnHandlesNpmExecAliasesAndStripsRunnerFlags() throws {
         let bun = "/usr/local/bin/bun"
-        let execNoDash = ACPBackend.canonicalizedSpawn(
+        let execNoDash = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(
                 executablePath: "/usr/local/bin/npm",
                 arguments: ["exec", "@agentclientprotocol/claude-agent-acp"]),
-            resolvedBunPath: bun)
+            resolvedBunPath: bun))
         #expect(execNoDash.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
 
-        let execWithDash = ACPBackend.canonicalizedSpawn(
+        let execWithDash = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(
                 executablePath: "/usr/local/bin/npm",
                 arguments: ["exec", "--", "@agentclientprotocol/claude-agent-acp", "--port", "9"]),
-            resolvedBunPath: bun)
+            resolvedBunPath: bun))
         #expect(execWithDash.arguments == [
             "x", "@agentclientprotocol/claude-agent-acp", "--port", "9"])
 
-        let npmAlias = ACPBackend.canonicalizedSpawn(
+        let npmAlias = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(executablePath: "/usr/local/bin/npm", arguments: ["x", "some-acp"]),
-            resolvedBunPath: bun)
+            resolvedBunPath: bun))
         #expect(npmAlias.arguments == ["x", "some-acp"])
 
-        let npxYes = ACPBackend.canonicalizedSpawn(
+        let npxYes = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(
                 executablePath: "/Users/me/.local/bin/npx",
                 arguments: ["-y", "@agentclientprotocol/claude-agent-acp"]),
-            resolvedBunPath: bun)
+            resolvedBunPath: bun))
         #expect(npxYes.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
 
-        let npmExecYes = ACPBackend.canonicalizedSpawn(
+        let npmExecYes = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(
                 executablePath: "/usr/local/bin/npm",
                 arguments: ["exec", "--yes", "--", "some-acp"]),
-            resolvedBunPath: bun)
+            resolvedBunPath: bun))
         #expect(npmExecYes.arguments == ["x", "some-acp"])
 
-        let bunx = ACPBackend.canonicalizedSpawn(
+        let bunx = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(
                 executablePath: "/usr/local/bin/bunx",
                 arguments: ["@agentclientprotocol/claude-agent-acp"]),
-            resolvedBunPath: bun)
+            resolvedBunPath: bun))
         #expect(bunx.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
     }
 
     /// A `bun x` launch is repointed at the resolved bun (it stops depending
     /// on whatever `bun` the PATH had) with its arguments untouched.
-    @Test func canonicalizedSpawnRepointsBunXLaunches() {
-        let canonical = ACPBackend.canonicalizedSpawn(
+    @Test func canonicalizedSpawnRepointsBunXLaunches() throws {
+        let canonical = try #require(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(
                 executablePath: "/some/user/bun",
                 arguments: ["x", "@agentclientprotocol/claude-agent-acp"],
                 workingDirectory: "/tmp/scratch",
                 apiKey: nil,
                 environment: [:]),
-            resolvedBunPath: "/resolved/bun")
+            resolvedBunPath: "/resolved/bun"))
         #expect(canonical.executablePath == "/resolved/bun")
         #expect(canonical.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
         #expect(canonical.workingDirectory == "/tmp/scratch")
     }
 
-    /// Non-adapter shapes and a missing resolution pass through unchanged.
-    @Test func canonicalizedSpawnPassesThroughNonAdapterShapesAndMissingBun() {
+    /// Non-adapter shapes, translatable runner flags, and a missing
+    /// resolution all return nil — the caller keeps the configured command
+    /// and logs the fallback.
+    @Test func canonicalizedSpawnReturnsNilForUnsafeOrNonAdapterShapes() {
         let bun = "/usr/local/bin/bun"
-        let plain = ACPBackend.AgentSpawnConfig(
-            executablePath: "/usr/local/bin/claude",
-            arguments: ["-p", "hi"],
-            workingDirectory: "/tmp",
-            apiKey: "k",
-            environment: ["A": "b"])
-        let plainCanonical = ACPBackend.canonicalizedSpawn(plain, resolvedBunPath: bun)
-        #expect(plainCanonical.executablePath == "/usr/local/bin/claude")
-        #expect(plainCanonical.arguments == ["-p", "hi"])
-        #expect(plainCanonical.apiKey == "k")
-        let codex = ACPBackend.canonicalizedSpawn(
+        // Plain provider binaries are never rewritten.
+        #expect(ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/usr/local/bin/claude",
+                arguments: ["-p", "hi"],
+                workingDirectory: "/tmp",
+                apiKey: "k",
+                environment: ["A": "b"]),
+            resolvedBunPath: bun) == nil)
+        #expect(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(executablePath: "/usr/local/bin/codex", arguments: ["acp"]),
-            resolvedBunPath: bun)
-        #expect(codex.executablePath == "/usr/local/bin/codex")
-        #expect(codex.arguments == ["acp"])
+            resolvedBunPath: bun) == nil)
         // npm without the exec/x subcommand is not an adapter shape.
-        let npmRun = ACPBackend.canonicalizedSpawn(
+        #expect(ACPBackend.canonicalizedSpawn(
             ACPBackend.AgentSpawnConfig(executablePath: "/usr/local/bin/npm", arguments: ["run", "build"]),
-            resolvedBunPath: bun)
-        #expect(npmRun.executablePath == "/usr/local/bin/npm")
-        // No resolved bun (locate failed) → original command runs unchanged.
+            resolvedBunPath: bun) == nil)
+        // No resolved bun (locate failed) → keep the configured command.
         for missing in [nil, ""] {
-            let unresolved = ACPBackend.canonicalizedSpawn(
+            #expect(ACPBackend.canonicalizedSpawn(
                 ACPBackend.AgentSpawnConfig(
                     executablePath: "/Users/me/.local/bin/npx",
                     arguments: ["@agentclientprotocol/claude-agent-acp"]),
-                resolvedBunPath: missing)
-            #expect(unresolved.executablePath == "/Users/me/.local/bin/npx")
-            #expect(unresolved.arguments == ["@agentclientprotocol/claude-agent-acp"])
+                resolvedBunPath: missing) == nil)
         }
     }
 
@@ -609,3 +659,24 @@ import ACPModel
     }
 }
 #endif
+
+/// Thread-safe call counter for the resolver/probe seams the bun-resolution
+/// memoization tests inject.
+final class InvocationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func bump() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}

--- a/Tests/WikiFSAppTests/ACPWiringTests.swift
+++ b/Tests/WikiFSAppTests/ACPWiringTests.swift
@@ -461,5 +461,79 @@ import ACPModel
             "(allow file-write* (subpath (string-append (param \"HOME\") \"/.npm\")))") == true)
         #expect(plan.environment["TMPDIR"] == "/tmp/scratch/.tmp")
     }
+
+    // MARK: - Adapter canonicalization (#1257 Level 1)
+
+    /// An npx-launched adapter rewrites to `<resolved bun> x <spec>` — the
+    /// exact shape whose npm-cache write EPERM'd the first wrapped chat.
+    @Test func canonicalizedAdapterLaunchRewritesNpxThroughResolvedBun() {
+        let launch = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/Users/me/.local/bin/npx",
+            arguments: ["@agentclientprotocol/claude-agent-acp"],
+            resolvedBunPath: "/Users/me/.local/share/mise/installs/bun/1.4.0/bin/bun")
+        #expect(launch.executablePath == "/Users/me/.local/share/mise/installs/bun/1.4.0/bin/bun")
+        #expect(launch.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+        // The rewritten command is a `bun x` shape, so the provider-home
+        // layering drops ~/.npm and layers ~/.bun instead.
+        #expect(ACPBackend.providerHomeSubpaths(
+            forCommand: launch.executablePath + " " + launch.arguments.joined(separator: " ")
+        ) == [".bun"])
+    }
+
+    /// `npm exec` in both flag orders rewrites; `bunx` aliases to `bun x`.
+    @Test func canonicalizedAdapterLaunchHandlesNpmExecAndBunx() {
+        let bun = "/usr/local/bin/bun"
+        let execNoDash = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/usr/local/bin/npm",
+            arguments: ["exec", "@agentclientprotocol/claude-agent-acp"],
+            resolvedBunPath: bun)
+        #expect(execNoDash == (bun, ["x", "@agentclientprotocol/claude-agent-acp"]))
+        let execWithDash = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/usr/local/bin/npm",
+            arguments: ["exec", "--", "@agentclientprotocol/claude-agent-acp", "--port", "9"],
+            resolvedBunPath: bun)
+        #expect(execWithDash.arguments == ["x", "@agentclientprotocol/claude-agent-acp", "--port", "9"])
+        let bunxAlias = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/usr/local/bin/bunx",
+            arguments: ["@agentclientprotocol/claude-agent-acp"],
+            resolvedBunPath: bun)
+        #expect(bunxAlias.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+    }
+
+    /// Already-canonical shapes and non-adapter binaries pass through
+    /// unchanged; a missing resolution keeps the original command.
+    @Test func canonicalizedAdapterLaunchPassesThroughNonAdapterShapes() {
+        let bun = "/usr/local/bin/bun"
+        // Already a bun x launch — canonical, untouched.
+        let canonical = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/some/user/bun",
+            arguments: ["x", "@agentclientprotocol/claude-agent-acp"],
+            resolvedBunPath: bun)
+        #expect(canonical == ("/some/user/bun", ["x", "@agentclientprotocol/claude-agent-acp"]))
+        // Plain provider binaries never rewrite (even when the command
+        // mentions a package name in an argument position we don't own).
+        let plain = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/usr/local/bin/claude",
+            arguments: ["-p", "hi"],
+            resolvedBunPath: bun)
+        #expect(plain == ("/usr/local/bin/claude", ["-p", "hi"]))
+        // codex-style provider binaries pass through.
+        let codex = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/usr/local/bin/codex",
+            arguments: ["acp"],
+            resolvedBunPath: bun)
+        #expect(codex == ("/usr/local/bin/codex", ["acp"]))
+        // No resolved bun (locate failed) → original command runs unchanged.
+        let unresolved = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/Users/me/.local/bin/npx",
+            arguments: ["@agentclientprotocol/claude-agent-acp"],
+            resolvedBunPath: nil)
+        #expect(unresolved == ("/Users/me/.local/bin/npx", ["@agentclientprotocol/claude-agent-acp"]))
+        let emptyBun = ACPBackend.canonicalizedAdapterLaunch(
+            executablePath: "/Users/me/.local/bin/npx",
+            arguments: ["@agentclientprotocol/claude-agent-acp"],
+            resolvedBunPath: "")
+        #expect(emptyBun == ("/Users/me/.local/bin/npx", ["@agentclientprotocol/claude-agent-acp"]))
+    }
 }
 #endif

--- a/Tests/WikiFSAppTests/ACPWiringTests.swift
+++ b/Tests/WikiFSAppTests/ACPWiringTests.swift
@@ -441,9 +441,9 @@ import ACPModel
         #expect(plan.environment.isEmpty)
     }
 
-    /// The first-chat regression (#1251 follow-up): an npx-launched adapter
-    /// must get `~/.npm` layered into the effective profile, or the wrapped
-    /// spawn dies on EPERM writing the npm package cache.
+    /// The first-chat regression (#1251 follow-up): when bun cannot be
+    /// resolved the configured npx command still runs, so the effective
+    /// profile must layer `~/.npm` for the npm package cache.
     @Test func sandboxedSpawnPlanLayersNpmCacheForNpxLaunches() {
         let invocation = SandboxProfile.invocation(
             homePath: "/Users/me",
@@ -465,75 +465,147 @@ import ACPModel
     // MARK: - Adapter canonicalization (#1257 Level 1)
 
     /// An npx-launched adapter rewrites to `<resolved bun> x <spec>` — the
-    /// exact shape whose npm-cache write EPERM'd the first wrapped chat.
-    @Test func canonicalizedAdapterLaunchRewritesNpxThroughResolvedBun() {
-        let launch = ACPBackend.canonicalizedAdapterLaunch(
+    /// exact shape whose npm-cache write EPERM'd the first wrapped chat — and
+    /// every other spawn field survives the rebuild.
+    @Test func canonicalizedSpawnRewritesNpxThroughResolvedBun() {
+        let spawn = ACPBackend.AgentSpawnConfig(
             executablePath: "/Users/me/.local/bin/npx",
             arguments: ["@agentclientprotocol/claude-agent-acp"],
-            resolvedBunPath: "/Users/me/.local/share/mise/installs/bun/1.4.0/bin/bun")
-        #expect(launch.executablePath == "/Users/me/.local/share/mise/installs/bun/1.4.0/bin/bun")
-        #expect(launch.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+            workingDirectory: "/tmp/scratch",
+            apiKey: "secret",
+            environment: ["WIKI_DB": "01WIKI"])
+        let bun = "/Users/me/.local/share/mise/installs/bun/1.4.0/bin/bun"
+        let canonical = ACPBackend.canonicalizedSpawn(spawn, resolvedBunPath: bun)
+        #expect(canonical.executablePath == bun)
+        #expect(canonical.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+        #expect(canonical.workingDirectory == "/tmp/scratch")
+        #expect(canonical.apiKey == "secret")
+        #expect(canonical.environment == ["WIKI_DB": "01WIKI"])
         // The rewritten command is a `bun x` shape, so the provider-home
         // layering drops ~/.npm and layers ~/.bun instead.
         #expect(ACPBackend.providerHomeSubpaths(
-            forCommand: launch.executablePath + " " + launch.arguments.joined(separator: " ")
-        ) == [".bun"])
+            forCommand: canonical.executablePath + " "
+                + canonical.arguments.joined(separator: " ")) == [".bun"])
     }
 
-    /// `npm exec` in both flag orders rewrites; `bunx` aliases to `bun x`.
-    @Test func canonicalizedAdapterLaunchHandlesNpmExecAndBunx() {
+    /// `npm exec` in both flag orders and the `npm x` alias rewrite; npx-only
+    /// runner flags (`-y`, `--yes`) and a leading `--` are stripped (bun x
+    /// tolerates but does not document them — the review verified this
+    /// against the local bun and the rewrite removes the reliance).
+    @Test func canonicalizedSpawnHandlesNpmExecAliasesAndStripsRunnerFlags() {
         let bun = "/usr/local/bin/bun"
-        let execNoDash = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/usr/local/bin/npm",
-            arguments: ["exec", "@agentclientprotocol/claude-agent-acp"],
+        let execNoDash = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/usr/local/bin/npm",
+                arguments: ["exec", "@agentclientprotocol/claude-agent-acp"]),
             resolvedBunPath: bun)
-        #expect(execNoDash == (bun, ["x", "@agentclientprotocol/claude-agent-acp"]))
-        let execWithDash = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/usr/local/bin/npm",
-            arguments: ["exec", "--", "@agentclientprotocol/claude-agent-acp", "--port", "9"],
+        #expect(execNoDash.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+
+        let execWithDash = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/usr/local/bin/npm",
+                arguments: ["exec", "--", "@agentclientprotocol/claude-agent-acp", "--port", "9"]),
             resolvedBunPath: bun)
-        #expect(execWithDash.arguments == ["x", "@agentclientprotocol/claude-agent-acp", "--port", "9"])
-        let bunxAlias = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/usr/local/bin/bunx",
-            arguments: ["@agentclientprotocol/claude-agent-acp"],
+        #expect(execWithDash.arguments == [
+            "x", "@agentclientprotocol/claude-agent-acp", "--port", "9"])
+
+        let npmAlias = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(executablePath: "/usr/local/bin/npm", arguments: ["x", "some-acp"]),
             resolvedBunPath: bun)
-        #expect(bunxAlias.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+        #expect(npmAlias.arguments == ["x", "some-acp"])
+
+        let npxYes = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/Users/me/.local/bin/npx",
+                arguments: ["-y", "@agentclientprotocol/claude-agent-acp"]),
+            resolvedBunPath: bun)
+        #expect(npxYes.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+
+        let npmExecYes = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/usr/local/bin/npm",
+                arguments: ["exec", "--yes", "--", "some-acp"]),
+            resolvedBunPath: bun)
+        #expect(npmExecYes.arguments == ["x", "some-acp"])
+
+        let bunx = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/usr/local/bin/bunx",
+                arguments: ["@agentclientprotocol/claude-agent-acp"]),
+            resolvedBunPath: bun)
+        #expect(bunx.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
     }
 
-    /// Already-canonical shapes and non-adapter binaries pass through
-    /// unchanged; a missing resolution keeps the original command.
-    @Test func canonicalizedAdapterLaunchPassesThroughNonAdapterShapes() {
+    /// A `bun x` launch is repointed at the resolved bun (it stops depending
+    /// on whatever `bun` the PATH had) with its arguments untouched.
+    @Test func canonicalizedSpawnRepointsBunXLaunches() {
+        let canonical = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(
+                executablePath: "/some/user/bun",
+                arguments: ["x", "@agentclientprotocol/claude-agent-acp"],
+                workingDirectory: "/tmp/scratch",
+                apiKey: nil,
+                environment: [:]),
+            resolvedBunPath: "/resolved/bun")
+        #expect(canonical.executablePath == "/resolved/bun")
+        #expect(canonical.arguments == ["x", "@agentclientprotocol/claude-agent-acp"])
+        #expect(canonical.workingDirectory == "/tmp/scratch")
+    }
+
+    /// Non-adapter shapes and a missing resolution pass through unchanged.
+    @Test func canonicalizedSpawnPassesThroughNonAdapterShapesAndMissingBun() {
         let bun = "/usr/local/bin/bun"
-        // Already a bun x launch — canonical, untouched.
-        let canonical = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/some/user/bun",
-            arguments: ["x", "@agentclientprotocol/claude-agent-acp"],
-            resolvedBunPath: bun)
-        #expect(canonical == ("/some/user/bun", ["x", "@agentclientprotocol/claude-agent-acp"]))
-        // Plain provider binaries never rewrite (even when the command
-        // mentions a package name in an argument position we don't own).
-        let plain = ACPBackend.canonicalizedAdapterLaunch(
+        let plain = ACPBackend.AgentSpawnConfig(
             executablePath: "/usr/local/bin/claude",
             arguments: ["-p", "hi"],
+            workingDirectory: "/tmp",
+            apiKey: "k",
+            environment: ["A": "b"])
+        let plainCanonical = ACPBackend.canonicalizedSpawn(plain, resolvedBunPath: bun)
+        #expect(plainCanonical.executablePath == "/usr/local/bin/claude")
+        #expect(plainCanonical.arguments == ["-p", "hi"])
+        #expect(plainCanonical.apiKey == "k")
+        let codex = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(executablePath: "/usr/local/bin/codex", arguments: ["acp"]),
             resolvedBunPath: bun)
-        #expect(plain == ("/usr/local/bin/claude", ["-p", "hi"]))
-        // codex-style provider binaries pass through.
-        let codex = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/usr/local/bin/codex",
-            arguments: ["acp"],
+        #expect(codex.executablePath == "/usr/local/bin/codex")
+        #expect(codex.arguments == ["acp"])
+        // npm without the exec/x subcommand is not an adapter shape.
+        let npmRun = ACPBackend.canonicalizedSpawn(
+            ACPBackend.AgentSpawnConfig(executablePath: "/usr/local/bin/npm", arguments: ["run", "build"]),
             resolvedBunPath: bun)
-        #expect(codex == ("/usr/local/bin/codex", ["acp"]))
+        #expect(npmRun.executablePath == "/usr/local/bin/npm")
         // No resolved bun (locate failed) → original command runs unchanged.
-        let unresolved = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/Users/me/.local/bin/npx",
-            arguments: ["@agentclientprotocol/claude-agent-acp"],
-            resolvedBunPath: nil)
-        #expect(unresolved == ("/Users/me/.local/bin/npx", ["@agentclientprotocol/claude-agent-acp"]))
-        let emptyBun = ACPBackend.canonicalizedAdapterLaunch(
-            executablePath: "/Users/me/.local/bin/npx",
-            arguments: ["@agentclientprotocol/claude-agent-acp"],
-            resolvedBunPath: "")
-        #expect(emptyBun == ("/Users/me/.local/bin/npx", ["@agentclientprotocol/claude-agent-acp"]))
+        for missing in [nil, ""] {
+            let unresolved = ACPBackend.canonicalizedSpawn(
+                ACPBackend.AgentSpawnConfig(
+                    executablePath: "/Users/me/.local/bin/npx",
+                    arguments: ["@agentclientprotocol/claude-agent-acp"]),
+                resolvedBunPath: missing)
+            #expect(unresolved.executablePath == "/Users/me/.local/bin/npx")
+            #expect(unresolved.arguments == ["@agentclientprotocol/claude-agent-acp"])
+        }
+    }
+
+    /// The shape gate that keeps non-adapter launches from paying for the
+    /// bun locate at all.
+    @Test func isJSAdapterLaunchMatchesOnlyAdapterShapes() {
+        #expect(ACPBackend.isJSAdapterLaunch(
+            executablePath: "/Users/me/.local/bin/npx", arguments: ["pkg"]))
+        #expect(ACPBackend.isJSAdapterLaunch(
+            executablePath: "/usr/local/bin/bunx", arguments: ["pkg"]))
+        #expect(ACPBackend.isJSAdapterLaunch(
+            executablePath: "/usr/local/bin/npm", arguments: ["exec", "pkg"]))
+        #expect(ACPBackend.isJSAdapterLaunch(
+            executablePath: "/usr/local/bin/npm", arguments: ["x", "pkg"]))
+        #expect(ACPBackend.isJSAdapterLaunch(
+            executablePath: "/some/user/bun", arguments: ["x", "pkg"]))
+        #expect(!ACPBackend.isJSAdapterLaunch(
+            executablePath: "/usr/local/bin/npm", arguments: ["run", "build"]))
+        #expect(!ACPBackend.isJSAdapterLaunch(
+            executablePath: "/usr/local/bin/claude", arguments: []))
+        #expect(!ACPBackend.isJSAdapterLaunch(
+            executablePath: "/usr/local/bin/codex", arguments: ["acp"]))
     }
 }
 #endif

--- a/progress/2026-09-12T163300Z-acp-adapter-bun-canonicalization.md
+++ b/progress/2026-09-12T163300Z-acp-adapter-bun-canonicalization.md
@@ -16,42 +16,54 @@ wrapped chat died on an `EPERM` write to `~/.npm/_cacache` under the seatbelt.
 `ACPBackend.startProcess` now canonicalizes adapter-shaped commands —
 executable basename `npx`, `bunx`, `npm exec`/`npm x`, or an already-`bun x`
 launch — through the bun resolved via `RuntimeCommandLocator` (the extractor
-runtimes' login-shell locator), as `<bun> x <package spec...>`. The shape gate
-runs first, so plain provider binaries (claude, codex, gemini) never pay for
-the locate. Resolution is memoized per backend actor, including the negative
-case (`RuntimeCommandResolution??` — a bun-less machine pays one 10 s-enclosed
-locate, not one per start), and a cached resolution is re-probed through
-`RuntimeFileProbe` before reuse so a swapped binary invalidates the cache per
-the locator's identity contract. An unresolvable bun keeps the configured
-command, logged in the agent channel. `ACPProviderModelProbe` applies the same
-canonicalization so its cached model list comes from the runtime chat will
-actually run. Review findings addressed: M1 (shape gate + negative caching),
-M2 (agent-channel fallback log), M3 (probe canonicalization), m1 (log names
-old → new command), m2 (`bun x` repoint), m3 (`npm x` alias), m4 (identity
-retention + re-probe), m5 (`canonicalizedSpawn` pure + field-preservation
-tests), m6 (`-y`/`--yes`/`--` runner-flag stripping, pinned). Level 2
-(vendored digest-pinned adapter in `Contents/Helpers/`) remains open on
+runtimes' login-shell locator), as `<bun> x <package spec...>`. The executing
+runtime no longer depends on which node/npm the PATH resolves; note the
+configured command's first token must still exist on PATH for provider
+resolution (`resolveACPProviderSpawn`), and the adapter itself still execs the
+user's `claude` binary. Level 2 (vendored, digest-pinned adapter in
+`Contents/Helpers/`) removes the remaining PATH dependence and stays open on
 #1257.
+
+Mechanics:
+
+- Shape gate (`isJSAdapterLaunch`) runs before the locate: plain provider
+  binaries never pay for the login-shell probe.
+- Resolution is memoized per backend actor as a small state machine
+  (`notAttempted` / `inFlight(Task)` / `resolved`): concurrent starts share
+  one locate, failed resolution is negative-cached for the backend's lifetime
+  (documented deviation from the locator's never-cache-failures contract —
+  the npx fallback still works), and a fresh-resolution invalidates on a
+  stale `RuntimeFileProbe` identity re-probe, re-resolving exactly once.
+- `canonicalizedSpawn` returns nil when the rewrite cannot be safe: unknown
+  adapter shapes, unresolvable bun, or leading runner flags it cannot
+  translate (`npx --quiet pkg`, `npx -p @scope/pkg bin`,
+  `npm exec --prefer-online -- pkg`) — the configured command runs unchanged
+  and the fallback is logged. `bunx`/`bun x` keep their arguments verbatim
+  and only get repointed. npx-only `-y`/`--yes`/`--` are stripped.
+- `ACPProviderModelProbe` canonicalizes with the same helper, shape-gated the
+  same way, so its cached model list comes from the runtime chat will run.
+- Both outcomes log to the agent channel: `adapter canonicalized <old> →
+  <new>`, or the fallback naming the configured command.
 
 ## Verification
 
 - `make build`, `make test` (4374 tests / 469 suites), bare `swift build`:
   green.
-- `WIKIFS_APP_TESTS=1 swift test --filter ACPWiringTests`: 30 passed —
-  including the adapter-canonicalization suite (npx rewrite with full
-  field preservation, npm exec/x aliases and runner-flag stripping, `bun x`
-  repoint, non-adapter and missing-bun pass-throughs, shape-gate table,
-  `~/.npm` layering for the unresolved-bun fallback).
-- Reviewed by a Paseo Claude Opus agent (read-only, plan mode): verdict
-  "no CRITICAL findings"; three MAJOR and six MINOR findings, all addressed
-  above; its clean-area list (spawn rebuild lossless, seatbelt gate
-  untouched, launchHint/persisted-data unaffected, spec preservation,
-  Sendable) confirmed.
-
-## Notes
-
-- npx/npm runner flags are stripped rather than passed through: bun 1.4.0
-  tolerates them, but that leniency is undocumented.
-- The `WikiFSApp` launch check asserting a bundled `Contents/Helpers/bun`
-  predates this work and always warns on dev machines (bun is mise-managed);
-  adjacent, untouched here.
+- `WIKIFS_APP_TESTS=1 swift test --filter ACPWiringTests`: 32 passed —
+  adapter canonicalization suite (npx rewrite with field preservation, npm
+  exec/x aliases, runner-flag stripping, `bun x` repoint, nil for non-adapter
+  and missing-bun shapes, shape-gate table, `~/.npm` layering on the fallback
+  path) plus the bun-resolution memoization contract (positive memo, negative
+  memo, stale-identity re-resolve-once through injected resolver/probe).
+- Reviewed twice by Paseo Claude Opus 5 agents (read-only, plan mode):
+  - First round: no CRITICAL; three MAJOR + six MINOR, all addressed.
+  - Second round (of the fixes): three MAJOR — probe located bun
+    unconditionally (now shape-gated), unrecognized runner flags would break
+    working launches (now fail safe to the configured command), and the
+    memoization machinery was untested (resolver + probe now injectable,
+    contract pinned by three tests). Its MINORs: launch errors name the real
+    (bun) executable while the configured command is recorded in the adjacent
+    agent log line (accepted); negative-cache lifetime documented as a
+    deviation (accepted); concurrent-start double-locate fixed via the
+    in-flight task; probe locate accepted outside its 60 s race (documented);
+    test comment and progress claims corrected.

--- a/progress/2026-09-12T163300Z-acp-adapter-bun-canonicalization.md
+++ b/progress/2026-09-12T163300Z-acp-adapter-bun-canonicalization.md
@@ -16,13 +16,12 @@ wrapped chat died on an `EPERM` write to `~/.npm/_cacache` under the seatbelt.
 `ACPBackend.startProcess` now canonicalizes adapter-shaped commands —
 executable basename `npx`, `bunx`, `npm exec`/`npm x`, or an already-`bun x`
 launch — through the bun resolved via `RuntimeCommandLocator` (the extractor
-runtimes' login-shell locator), as `<bun> x <package spec...>`. The executing
-runtime no longer depends on which node/npm the PATH resolves; note the
-configured command's first token must still exist on PATH for provider
-resolution (`resolveACPProviderSpawn`), and the adapter itself still execs the
-user's `claude` binary. Level 2 (vendored, digest-pinned adapter in
-`Contents/Helpers/`) removes the remaining PATH dependence and stays open on
-#1257.
+runtimes' login-shell locator), as `<bun> x <package spec...>`. This
+canonicalizes the package RUNNER and cache (the `~/.npm/_cacache` write no
+longer happens); the adapter process itself may still exec Node via its own
+shebang unless `--bun` is adopted, and the configured command's first token
+must still exist on PATH for provider resolution — adopting `--bun` and/or
+vendoring (Level 2) closes the rest.
 
 Mechanics:
 

--- a/progress/2026-09-12T163300Z-acp-adapter-bun-canonicalization.md
+++ b/progress/2026-09-12T163300Z-acp-adapter-bun-canonicalization.md
@@ -1,0 +1,57 @@
+---
+timestamp: 2026-09-12T163300Z
+title: Canonicalize ACP JS-adapter launches through the resolved bun (#1257 Level 1)
+branch: feature/acp-adapter-bun-canonicalization
+status: complete
+---
+
+# Canonicalize ACP JS-adapter launches through the resolved bun (#1257 Level 1)
+
+## Progress
+
+ACP provider commands are user-configured free-form text, and JS adapters
+launched through `npx` depended on the user's node/npm state — the first
+wrapped chat died on an `EPERM` write to `~/.npm/_cacache` under the seatbelt.
+
+`ACPBackend.startProcess` now canonicalizes adapter-shaped commands —
+executable basename `npx`, `bunx`, `npm exec`/`npm x`, or an already-`bun x`
+launch — through the bun resolved via `RuntimeCommandLocator` (the extractor
+runtimes' login-shell locator), as `<bun> x <package spec...>`. The shape gate
+runs first, so plain provider binaries (claude, codex, gemini) never pay for
+the locate. Resolution is memoized per backend actor, including the negative
+case (`RuntimeCommandResolution??` — a bun-less machine pays one 10 s-enclosed
+locate, not one per start), and a cached resolution is re-probed through
+`RuntimeFileProbe` before reuse so a swapped binary invalidates the cache per
+the locator's identity contract. An unresolvable bun keeps the configured
+command, logged in the agent channel. `ACPProviderModelProbe` applies the same
+canonicalization so its cached model list comes from the runtime chat will
+actually run. Review findings addressed: M1 (shape gate + negative caching),
+M2 (agent-channel fallback log), M3 (probe canonicalization), m1 (log names
+old → new command), m2 (`bun x` repoint), m3 (`npm x` alias), m4 (identity
+retention + re-probe), m5 (`canonicalizedSpawn` pure + field-preservation
+tests), m6 (`-y`/`--yes`/`--` runner-flag stripping, pinned). Level 2
+(vendored digest-pinned adapter in `Contents/Helpers/`) remains open on
+#1257.
+
+## Verification
+
+- `make build`, `make test` (4374 tests / 469 suites), bare `swift build`:
+  green.
+- `WIKIFS_APP_TESTS=1 swift test --filter ACPWiringTests`: 30 passed —
+  including the adapter-canonicalization suite (npx rewrite with full
+  field preservation, npm exec/x aliases and runner-flag stripping, `bun x`
+  repoint, non-adapter and missing-bun pass-throughs, shape-gate table,
+  `~/.npm` layering for the unresolved-bun fallback).
+- Reviewed by a Paseo Claude Opus agent (read-only, plan mode): verdict
+  "no CRITICAL findings"; three MAJOR and six MINOR findings, all addressed
+  above; its clean-area list (spawn rebuild lossless, seatbelt gate
+  untouched, launchHint/persisted-data unaffected, spec preservation,
+  Sendable) confirmed.
+
+## Notes
+
+- npx/npm runner flags are stripped rather than passed through: bun 1.4.0
+  tolerates them, but that leniency is undocumented.
+- The `WikiFSApp` launch check asserting a bundled `Contents/Helpers/bun`
+  predates this work and always warns on dev machines (bun is mise-managed);
+  adjacent, untouched here.


### PR DESCRIPTION
Implements Level 1 of #1257 (Level 2 — vendoring the adapter — remains open on
that issue).

## What

ACP provider commands are user-configured free-form text, and JS adapters
launched through `npx` depended on the user's node/npm state — the first
wrapped chat after #1256 died on `EPERM` writing `~/.npm/_cacache`.

`ACPBackend.startProcess` now canonicalizes adapter-shaped commands —
executable basename `npx`, `bunx`, `npm exec`/`npm x`, or an already-`bun x`
launch — through bun resolved via `RuntimeCommandLocator` (the same login-shell
locator the extractor runtimes use), as `<bun> x <package spec...>`:

- **Shape gate first**: plain provider binaries (claude, codex, gemini) never
  pay for the locate.
- **Memoized, negative-cached**: the resolution is cached per backend actor as
  `RuntimeCommandResolution??` — a bun-less machine pays one locate (bounded by
  the locator's 10 s shell budget), not one per start.
- **Identity honored**: the full `RuntimeCommandResolution` (with pinned
  identity) is cached and re-probed through `RuntimeFileProbe` before reuse, so
  a swapped binary invalidates the cache per the locator's contract.
- **Two-sided logging** in the agent channel: `adapter canonicalized <old> →
  <new>` on rewrite; `bun unresolved — launching configured <cmd> unchanged`
  on fallback.
- **Runner flags stripped**: npx-only `-y`/`--yes` and a leading `--` are
  removed (bun 1.4.0 tolerates them, but that is undocumented leniency —
  verified empirically by the reviewer).
- **`ACPProviderModelProbe`** applies the same canonicalization, so the cached
  model list comes from the runtime chat will actually run.

Non-JS providers pass through untouched; the free-form Settings command stays
the escape hatch. The sandbox's `providerHomeSubpaths` then layers `~/.bun`
instead of `~/.npm` for the canonicalized shape.

## Review

Reviewed by a Paseo Claude Opus 5 agent (read-only, plan mode) before push.
Verdict: no CRITICAL findings; three MAJOR (M1 unconditional/un-negative-cached
resolution, M2 missing fallback log, M3 probe not canonicalized) and six MINOR
— all addressed in `5f461021`. The reviewer also empirically verified `bun x`
flag behavior against local bun 1.4.0. Clean areas confirmed: spawn rebuild is
lossless (apiKey/workingDirectory/environment preserved — now pinned by test),
seatbelt fail-closed gate untouched, `launchHint` and persisted
provider-queue data unaffected, spec preservation exact, Sendable sound.

## Verification

- `make build`, `make test` (4374 tests / 469 suites), bare `swift build`: green.
- `WIKIFS_APP_TESTS=1 swift test --filter ACPWiringTests`: 30 passed — adapter
  canonicalization suite covers the npx rewrite with full field preservation,
  npm exec/x aliases, runner-flag stripping, `bun x` repoint, non-adapter and
  missing-bun pass-throughs, the shape-gate table, and `~/.npm` layering for
  the unresolved-bun fallback.
- `make keychain version` gate green.

## Follow-up

Level 2 (vendored, digest-pinned adapter in `Contents/Helpers/` launched as
`<bun> run <entry>` — zero home writes) stays open on #1257.

## Committee review outcome (Claude Opus 5 + Codex Sol, converged)

A two-agent Paseo committee reviewed the full branch with fresh eyes and
cross-examined each other's findings. Converged pre-merge list (all landed in
`09327b62`):

- Fail-safe the rewrite against spec forms `bun x` cannot execute
  (`github:`, `git+ssh:`, `https://…tgz`, `file:`, `./local`) — they keep the
  configured command instead of breaking working launches.
- Generation guard on the memo write-back: a stale waiter can no longer
  clobber a newer in-flight resolution generation (pinned by a concurrent
  5-caller test asserting exactly one locate).
- Hoist the fail-closed sandbox-usability gate above bun canonicalization — a
  sandbox-required launch never shells out to a login shell before discovering
  `sandbox-exec` is unusable.
- Re-probe the pinned bun identity at the final pre-launch seam; a swapped
  binary falls back to the configured command.
- `Task.checkCancellation` after the shared locate — a cancelled start can no
  longer continue toward launch.
- Restore the plan-level seatbelt regression test (canonicalized `bun x` →
  `/.bun` layered, `/.npm` absent).

Converged claims correction (Claude, verified against bun 1.4.0): `bun x`
without `--bun` defers to the adapter's `#!/usr/bin/env node` shebang, so
Level 1 is a **package-runner/cache canonicalization** — the `~/.npm` EPERM is
fixed and the cache moves to `~/.bun`, but the adapter process may still exec
Node. Adopting `--bun` (if the adapters run under Bun) or vendoring (Level 2)
is the runtime decision, recorded as follow-up on #1257.

Converged follow-ups (not blocking merge): the model probe's pre-existing
timeout-termination gap (its own issue), expanding npm global-option parsing,
token-aware provider-home matching, surfacing the substitution in provider
readiness, and the smaller robustness items from both reports.

## Second-round review outcome

A second Paseo Claude Opus 5 review (of the fix commit `5f461021`, read-only)
verified all ten first-round claims and found three new MAJORs — all fixed in
`144d6a69`:

- **MAJOR-1**: the model probe resolved bun unconditionally (the locate ran as
  a call argument before the shape decision) — now gated on
  `isJSAdapterLaunch`; plain providers never shell out to the login shell.
- **MAJOR-2**: npx/npm runner flags the rewrite cannot translate (`--quiet`,
  `-p`, `--prefer-online`, …) were carried into `bun x` in package-spec
  position, breaking launches that worked before — `canonicalizedSpawn` now
  returns nil for those shapes and the caller keeps the configured command,
  logging the fallback.
- **MAJOR-3**: the memoization machinery was untested and its seam couldn't
  test the positive path — the identity probe is now injectable and the
  contract is pinned by three tests (positive memo, negative memo,
  stale-identity re-resolve-once).

MINORs addressed: in-flight task dedupes concurrent locates; the fallback's
`~/.npm` consequence and the shape-gate table are pinned by tests; the
progress claims now state precisely what changed (the executing runtime, not
PATH resolution). Accepted with documentation: launch errors name the real
(bun) executable while the configured command is in the adjacent agent log
line; the negative cache lives for the backend's lifetime; the probe's locate
sits outside its 60 s race. Reviewer clean areas: double-optional cache
semantics, `resolutionStillValid` stat+identity, both-branch logging, field
preservation, Sendable, repo rules.
