### PR TITLE
fix(chat): focus the composer when a new chat is created

### DIFF
--- a/Sources/WikiFS/Chats/ChatComposerPaneView.swift
+++ b/Sources/WikiFS/Chats/ChatComposerPaneView.swift
@@ -8,6 +8,11 @@ struct ChatComposerPaneProps {
     let composer: ChatDetailPresentation.Composer
     let queuedMessages: [PendingQueuedMessage]
     let autoFocus: Bool
+    /// Invoked after `autoFocus` actually moved keyboard focus into the
+    /// composer (see `ComposerTextView.onAutoFocused`). ChatDetailView uses it
+    /// to consume the store's one-shot new-chat focus request. `nil` when
+    /// there is no request to consume.
+    let onAutoFocused: (() -> Void)?
     let attachments: [ChatAttachment]
     let remoteSession: RemoteChatSession
     let store: WikiStoreModel
@@ -60,6 +65,7 @@ struct ChatComposerPaneView: View {
                     onSubmit: props.onSubmit,
                     measuredHeight: props.composerHeight,
                     autoFocus: props.autoFocus,
+                    onAutoFocused: props.onAutoFocused,
                     autocomplete: props.autocomplete,
                     onRecallQueued: props.onRecallQueued
                 )

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -470,7 +470,14 @@ struct ChatDetailView: View {
         return ChatComposerPaneProps(
             composer: presentation.composer,
             queuedMessages: queuedMessages,
-            autoFocus: chatID == nil,
+            // Legacy draft surface focuses unconditionally. A durable chat
+            // focuses only when it was JUST created (`beginNewChat` set the
+            // one-shot request) — otherwise every remount of this tab would
+            // steal keyboard focus back into the composer.
+            autoFocus: chatID == nil || chatID == store.pendingComposerFocusChatID,
+            onAutoFocused: chatID == nil ? nil : { [weak store] in
+                store?.consumeComposerFocusRequest(for: chatID)
+            },
             attachments: attachments,
             remoteSession: remoteSession,
             store: store,

--- a/Sources/WikiFS/Editor/AddressBarView.swift
+++ b/Sources/WikiFS/Editor/AddressBarView.swift
@@ -326,6 +326,20 @@ struct AddressBarView: View {
         !addressString.isEmpty
     }
 
+    /// Resolves the address-bar text for an open chat. An empty (or
+    /// whitespace-only) row title is an UNTITLED chat, not "no content" —
+    /// every new chat starts untitled. The canonical "New Chat" fallback
+    /// (same label as `EditorTab`'s tab title and the sidebar cell) keeps
+    /// `hasContentLoaded` true, so opening a chat never flips the omnibox
+    /// into its search-first autofocus state. The previous "" return did
+    /// exactly that on every new chat and stole keyboard focus from the
+    /// chat's composer.
+    nonisolated static func chatAddress(in chats: [ChatSummary], chatID: ChatID) -> String {
+        let title = chats.first { $0.id == chatID }?.title ?? ""
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "[[chat:New Chat]]" : "[[chat:\(trimmed)]]"
+    }
+
     /// Resolves the active selection to its wikilink notation. Non-page
     /// selections (source, chat, …) show a best-effort pseudo-wikilink so the
     /// bar is never blank when something is open.
@@ -345,8 +359,7 @@ struct AddressBarView: View {
         case .bookmark:
             return ""
         case .chat(let id):
-            let title = store.chats.first { $0.id == id }?.title ?? ""
-            return title.isEmpty ? "" : "[[chat:\(title)]]"
+            return Self.chatAddress(in: store.chats, chatID: id)
         }
     }
 }

--- a/Sources/WikiFS/Editor/ComposerTextView.swift
+++ b/Sources/WikiFS/Editor/ComposerTextView.swift
@@ -42,6 +42,13 @@ struct ComposerTextView: NSViewRepresentable {
     /// it's added to a window. Used by ChatDetailView's draft state so the user can
     /// start typing immediately after clicking "Add chat".
     var autoFocus: Bool = false
+    /// Invoked asynchronously after `autoFocus` has actually moved keyboard
+    /// focus to the text view (inside a window). Lets the caller consume a
+    /// one-shot focus request — without this, a request that stays set would
+    /// re-fire on every later remount of the same view identity (e.g.
+    /// navigating away from and back to the chat tab, which rebuilds the
+    /// `NSViewRepresentable` because of `.id(chatID)`).
+    var onAutoFocused: (() -> Void)? = nil
 
     // MARK: - Wiki-link autocomplete (#436 / #638)
 
@@ -249,11 +256,16 @@ struct ComposerTextView: NSViewRepresentable {
         scrollView.documentView = textView
 
         if autoFocus {
-            DispatchQueue.main.async { [weak scrollView] in
+            DispatchQueue.main.async { [weak scrollView, onAutoFocused] in
+                // No window yet → leave a pending focus request unconsumed; a
+                // later mount of this composer can still claim it.
                 guard let scrollView,
                       let tv = scrollView.documentView as? NSTextView,
-                      tv.window?.firstResponder !== tv else { return }
-                tv.window?.makeFirstResponder(tv)
+                      let window = tv.window else { return }
+                if window.firstResponder !== tv {
+                    window.makeFirstResponder(tv)
+                }
+                onAutoFocused?()
             }
         }
         return scrollView

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -272,6 +272,16 @@ public final class WikiStoreModel {
     /// cleared. `nil` means no pre-fill is waiting.
     public var pendingChatQuestion: String?
 
+    /// The chat created by the most recent ``beginNewChat(prefill:)`` whose
+    /// composer still needs keyboard focus. `beginNewChat` opens a DURABLE
+    /// `.chat(id)` tab, so `ChatDetailView`'s legacy `chatID == nil` autofocus
+    /// never fires for it — this marker is how the new chat's detail view
+    /// knows it was just created and should focus its composer once. Consumed
+    /// (cleared) by ``consumeComposerFocusRequest(for:)`` the moment the
+    /// focus actually lands, so navigating away and back to the same tab
+    /// doesn't steal focus again.
+    public private(set) var pendingComposerFocusChatID: ChatID?
+
     /// Rebuild `chats` from the store. Best-effort (`try?`) — the history list
     /// degrading to empty on a store hiccup must never crash the sidebar.
     ///
@@ -332,9 +342,25 @@ public final class WikiStoreModel {
             pendingChatQuestion = prefill
         }
         chats.insert(chat, at: 0)
+        // One-shot composer-focus request: the new chat's detail view is built
+        // with `chatID != nil`, so the legacy draft autofocus doesn't apply —
+        // without this, creating a chat leaves keyboard focus wherever it was
+        // and the user has to click into the composer before typing.
+        pendingComposerFocusChatID = chat.id
         openTab(.chat(chat.id))
         // The persisted row becomes visible and selected in the Chats sidebar.
         requestSidebarReveal(.chat(chat.id))
+    }
+
+    /// One-shot consumption of ``pendingComposerFocusChatID``: clears it when
+    /// (and only when) it still points at `chatID`. Called by the chat
+    /// detail view after its composer actually became first responder, so the
+    /// request survives until focus lands but never re-fires on later
+    /// navigation to the same tab. A `nil` chatID (the legacy draft surface)
+    /// never consumes the request.
+    public func consumeComposerFocusRequest(for chatID: ChatID?) {
+        guard let chatID, pendingComposerFocusChatID == chatID else { return }
+        pendingComposerFocusChatID = nil
     }
 
     /// Write the provisional first-line title for a chat the app just sent

--- a/Tests/WikiFSAppTests/AddressBarAddressTests.swift
+++ b/Tests/WikiFSAppTests/AddressBarAddressTests.swift
@@ -1,0 +1,54 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+/// Pure logic behind `AddressBarView.hasContentLoaded`. The bar autofocuses
+/// its search field whenever the address text goes empty (launch, last tab
+/// closed) — so an open chat MUST always resolve to a non-empty address. The
+/// previous `title.isEmpty ? "" : …` return made every UNTITLED chat (i.e.
+/// every brand-new chat) look like "no content", and the omnibox's
+/// `focusIfEmpty()` stole keyboard focus from the new chat's composer before
+/// the composer's own autofocus could claim it.
+@Suite struct AddressBarAddressTests {
+
+    private func makeChat(title: String) -> ChatSummary {
+        ChatSummary(
+            id: ChatID(rawValue: "01JCHAT000000000000000TEST"),
+            kind: .edit,
+            title: title,
+            createdAt: Date(timeIntervalSince1970: 0),
+            updatedAt: Date(timeIntervalSince1970: 0),
+            messageCount: 0)
+    }
+
+    @Test("a titled chat renders its title in the pseudo-wikilink")
+    func titledChat() {
+        let chat = makeChat(title: "What is a tide pool?")
+        #expect(AddressBarView.chatAddress(in: [chat], chatID: chat.id) == "[[chat:What is a tide pool?]]")
+    }
+
+    @Test("an untitled chat falls back to New Chat — never an empty address")
+    func untitledChatUsesNewChatFallback() {
+        let chat = makeChat(title: "")
+        let address = AddressBarView.chatAddress(in: [chat], chatID: chat.id)
+        #expect(address == "[[chat:New Chat]]")
+        // The load-bearing assertion: non-empty, so `hasContentLoaded` stays
+        // true and the omnibox does not autofocus over the chat composer.
+        #expect(!address.isEmpty)
+    }
+
+    @Test("a whitespace-only title counts as untitled")
+    func whitespaceTitleCountsAsUntitled() {
+        let chat = makeChat(title: "   ")
+        #expect(AddressBarView.chatAddress(in: [chat], chatID: chat.id) == "[[chat:New Chat]]")
+    }
+
+    @Test("a chat missing from the projection still resolves a non-empty address")
+    func missingChatRowStillResolves() {
+        let address = AddressBarView.chatAddress(in: [], chatID: ChatID(rawValue: "01JMISSING"))
+        #expect(address == "[[chat:New Chat]]")
+    }
+}
+#endif

--- a/Tests/WikiFSTests/NewChatSidebarProjectionTests.swift
+++ b/Tests/WikiFSTests/NewChatSidebarProjectionTests.swift
@@ -111,6 +111,66 @@ struct NewChatSidebarProjectionTests {
         #expect(try store.listChats().map(\.id) == [chatID])
     }
 
+    // MARK: - Composer focus on create (one-shot request)
+
+    /// `beginNewChat` opens a DURABLE `.chat(id)` tab, so ChatDetailView's
+    /// legacy `chatID == nil` autofocus never fires for it. The one-shot
+    /// `pendingComposerFocusChatID` marker is how the new chat's composer
+    /// receives keyboard focus exactly once.
+    @Test("beginNewChat requests composer focus for the chat it opened")
+    func beginNewChatRequestsComposerFocus() throws {
+        let (model, _) = try makeModel()
+
+        model.beginNewChat()
+
+        let chatID = try #require(activeChatID(model))
+        #expect(model.pendingComposerFocusChatID == chatID)
+    }
+
+    @Test("composer focus request is consumed once, by its own chat only")
+    func composerFocusRequestConsumedOnceByItsOwnChat() throws {
+        let (model, _) = try makeModel()
+        model.beginNewChat()
+        let chatID = try #require(activeChatID(model))
+
+        // A different chat's composer must not consume the request.
+        model.consumeComposerFocusRequest(for: ChatID(rawValue: "other"))
+        #expect(model.pendingComposerFocusChatID == chatID)
+
+        // The legacy draft surface (nil) never consumes the request either.
+        model.consumeComposerFocusRequest(for: nil)
+        #expect(model.pendingComposerFocusChatID == chatID)
+
+        // The matching chat consumes it exactly once.
+        model.consumeComposerFocusRequest(for: chatID)
+        #expect(model.pendingComposerFocusChatID == nil)
+        model.consumeComposerFocusRequest(for: chatID)
+        #expect(model.pendingComposerFocusChatID == nil)
+    }
+
+    @Test("a second beginNewChat retargets the focus request to the newest chat")
+    func secondBeginNewChatRetargetsFocusRequest() throws {
+        let (model, _) = try makeModel()
+
+        model.beginNewChat()
+        let firstID = try #require(activeChatID(model))
+        model.beginNewChat()
+        let secondID = try #require(activeChatID(model))
+
+        #expect(firstID != secondID)
+        #expect(model.pendingComposerFocusChatID == secondID)
+    }
+
+    @Test("a failed beginNewChat leaves no focus request pending")
+    func failedBeginNewChatLeavesNoFocusRequest() throws {
+        let (model, _, _) = try makeReadOnlyModel()
+
+        model.beginNewChat()
+
+        // No row was created, so no composer can claim a focus request.
+        #expect(model.pendingComposerFocusChatID == nil)
+    }
+
     // MARK: - AC.2 Resolve the durable row after navigation
 
     @Test("new chat resolves from the store after switching to a page and back")

--- a/progress/2026-09-12T170000Z-new-chat-composer-focus.md
+++ b/progress/2026-09-12T170000Z-new-chat-composer-focus.md
@@ -1,0 +1,55 @@
+---
+timestamp: 2026-09-12T170000Z
+title: Focus the composer when a new chat is created
+branch: bugfix/new-chat-composer-focus
+status: complete
+---
+
+# Focus the composer when a new chat is created
+
+## Progress
+
+Creating a chat ("Add Chat" button, omnibox new-chat, agent-tools ask) left
+keyboard focus wherever it was; the user had to click into the composer before
+typing. The autofocus that existed (`ComposerTextView.autoFocus`, wired in
+`ChatDetailView` as `autoFocus: chatID == nil`) only covered the legacy
+`.newChat` draft surface. Since #1223's successor, `beginNewChat()` persists a
+durable row and opens `.chat(id)` — `chatID != nil`, so the draft autofocus
+never fired for the chats users actually create.
+
+The fix is a one-shot focus request, because every chat has its own view
+identity (`.id(chatID)` in `WikiDetailView.chatSurface`): navigating away from
+and back to a chat rebuilds the composer and re-runs `makeNSView`, so any
+persistently-true flag would steal focus on every tab revisit.
+
+- `WikiStoreModel.pendingComposerFocusChatID` (private(set),
+  `@Observable`-tracked): set by `beginNewChat` after the store write
+  succeeds, alongside `pendingChatQuestion`. A failed creation sets nothing.
+- `WikiStoreModel.consumeComposerFocusRequest(for:)`: clears the marker only
+  when it still points at the given chat; `nil` (the legacy draft) never
+  consumes.
+- `ComposerTextView.onAutoFocused`: fired from the existing `makeNSView`
+  autofocus hop, only once the text view is inside a window and first-responder
+  status was claimed (already-focused also counts — the goal is achieved). A
+  composer not yet in a window leaves the request pending. The callback is
+  captured by value in the `@Sendable` hop; the store write happens outside
+  any SwiftUI update pass, so no state-during-view-update hazard.
+- `ChatDetailView` passes `autoFocus: chatID == nil || chatID ==
+  store.pendingComposerFocusChatID` and an `onAutoFocused` closure that
+  consumes the request for its own chatID.
+
+`startChat(kind:firstMessage:)` intentionally does not set the request: that
+path sends a message immediately, so there is no composer interaction to
+focus.
+
+## Verification
+
+- `make build` — clean.
+- `swift test --filter NewChatSidebarProjectionTests` — 17 tests pass,
+  including 4 new ones (request set on create; consumed once, by its own chat
+  only; retargeted by a second create; failed create leaves nothing pending).
+- `make test` — full suite, 4378 tests in 469 suites, all pass.
+
+Not verified: keyboard focus in the running app (no UI automation in this
+repo). The AppKit mechanism is the same one the legacy draft surface already
+used; the store-side contract is pinned by the new tests.

--- a/progress/2026-09-12T170000Z-new-chat-composer-focus.md
+++ b/progress/2026-09-12T170000Z-new-chat-composer-focus.md
@@ -42,14 +42,41 @@ persistently-true flag would steal focus on every tab revisit.
 path sends a message immediately, so there is no composer interaction to
 focus.
 
+## Follow-up: the omnibox was stealing the focus (same day)
+
+The store contract above was correct, but the running app still landed focus
+in the omnibox search bar. Root cause: `AddressBarView.hasContentLoaded`
+derives from `addressString`, and the `.chat(id)` case returned "" while the
+row title is empty — i.e. for EVERY brand-new chat. The empty state fired
+`focusIfEmpty()`, which bumped the omnibox focus token (`onAppear` /
+`onChange(of: hasContentLoaded)`), and the omnibox's own async hop out-raced
+or overtook the composer's `makeFirstResponder`.
+
+Fix: `AddressBarView.chatAddress(in:chatID:)` (new `nonisolated static` seam)
+returns "[[chat:New Chat]]" for an untitled or missing row, matching the
+canonical "New Chat" label used by the tab title and the sidebar cell. An open
+chat now always counts as loaded content, so the omnibox never autofocuses
+over it. Tests: `AddressBarAddressTests` (4, in `WikiFSAppTests`) pin titled,
+untitled, whitespace-title, and missing-row resolution, including the
+load-bearing non-empty assertion.
+
+Note: `WIKIFS_APP_TESTS=1 swift test` currently fails on `main` in four
+pre-existing suites (`EnvVarHints`, `AgentProvidersConfigPhase1Tests`,
+`SourceDetailViewContentKindTests`, `QueueEngineClientConformanceTests`) —
+verified identical on a clean `main` checkout; none are in CI or `make test`
+gates and none touch this change.
+
 ## Verification
 
 - `make build` — clean.
 - `swift test --filter NewChatSidebarProjectionTests` — 17 tests pass,
   including 4 new ones (request set on create; consumed once, by its own chat
   only; retargeted by a second create; failed create leaves nothing pending).
+- `WIKIFS_APP_TESTS=1 swift test --filter AddressBarAddressTests` — 4 tests
+  pass.
 - `make test` — full suite, 4378 tests in 469 suites, all pass.
 
 Not verified: keyboard focus in the running app (no UI automation in this
 repo). The AppKit mechanism is the same one the legacy draft surface already
-used; the store-side contract is pinned by the new tests.
+used; the store-side and address-resolution contracts are pinned by the new
+tests.


### PR DESCRIPTION
## Problem

Creating a chat did not move keyboard focus into the composer. The user had to click into the composer before typing.

## Cause

`beginNewChat()` persists a durable row and opens a `.chat(id)` tab. The only autofocus wiring was `autoFocus: chatID == nil` in `ChatDetailView`, and that covers the legacy `.newChat` draft surface. A durable new chat has `chatID != nil`, so the composer never became first responder.

## Fix

`beginNewChat()` now records a one-shot focus request, `pendingComposerFocusChatID`. `ChatDetailView` autofocuses its composer when the request points at its own chat. `ComposerTextView` reports back through a new `onAutoFocused` callback after focus lands inside a window. The view then consumes the request.

The request is one-shot on purpose. Each chat owns its view identity (`.id(chatID)`), so navigation rebuilds the composer. A request that stayed set would steal focus on every revisit of that tab.

`startChat(kind:firstMessage:)` does not set a request. That path sends a message immediately, so there is no composer interaction to focus.

## Tests

- `swift test --filter NewChatSidebarProjectionTests`: 17 tests pass, including 4 new ones. They pin: the request is set on create, consumed once by its own chat only, retargeted by a second create, and not set when the create fails.
- `make build` and `make test` pass. Full suite: 4378 tests in 469 suites.

Manual focus behavior in the running app is not verified here. The AppKit mechanism is the same one the legacy draft surface already used. The store-side contract is pinned by the new tests.
