### PR TITLE
feat(chat): chat rows — summary-or-question title, created-date subtitle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,8 +420,12 @@ cat "$C/wikis.json"                      # registry: name → ULID
 sqlite3 "$C/<ulid>.sqlite" ".tables"     # pages, chats, chat_messages, …
 ```
 
-Schema lives in `Sources/WikiFSCore/SQLiteWikiStore.swift`
-(`createFreshSchemaV20` / `createChatTablesV23` / the `migrate(from:)` ladder).
+Schema lives in `Sources/WikiFSCore/Store/GRDBWikiStore.swift`
+(`createFreshSchema` / `createChatTablesV23` / the version ladder in
+`migrate(from:)`, currently at v53). Persistent chats are THREE tables:
+`chat_transcript_items` is the durable transcript the app reads;
+`chat_messages` is the flat compatibility projection (export, search index,
+summarizer source); `chats` holds the per-chat row (title, config, ordering).
 Persistent chats are two tables: `chats` (one row per conversation) and
 `chat_messages` (one row per persistable `AgentEvent`) — see
 `plans/chat-and-persistence.md`.

--- a/Sources/WikiFS/Chats/ChatDetailPresentation.swift
+++ b/Sources/WikiFS/Chats/ChatDetailPresentation.swift
@@ -19,10 +19,7 @@ struct ChatDetailPresentation {
         let runningKind: WikiOperation.Kind?
         let preflightError: String?
         let pendingPermissions: [PendingPermission]
-        let runStartedAt: Date?
         let projectionInput: TranscriptProjectionInput
-        let exitStatus: Int32?
-
     }
 
     struct Controls {
@@ -52,7 +49,6 @@ struct ChatDetailPresentation {
     let preflightBannerMessage: String?
     let showsThinkingIndicator: Bool
     let outlineEntries: [ChatOutlineEntry]
-    let chatInspectorAvailable: Bool
 
     static func make(
         chatID: ChatID?,
@@ -108,7 +104,6 @@ struct ChatDetailPresentation {
             isChatOperationConfigured: isChatOperationConfigured
         )
         let canSend = canSendPredicate(
-            hasMount: true,
             runState: remoteSession.runState,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured,
@@ -150,7 +145,6 @@ struct ChatDetailPresentation {
                 isEnabled: composerEnabled,
                 caption: composerCaptionText(
                     runState: remoteSession.runState,
-                    hasChatID: chatID != nil,
                     isLiveChat: isLiveChat,
                     isChatOperationConfigured: isChatOperationConfigured,
                     isDraftSubmitPending: isDraftSubmitPending
@@ -180,8 +174,7 @@ struct ChatDetailPresentation {
                 isLiveChat: isLiveChat
             ),
             showsThinkingIndicator: transcriptIsAnswering,
-            outlineEntries: outlineEntries,
-            chatInspectorAvailable: !outlineEntries.isEmpty
+            outlineEntries: outlineEntries
         )
     }
 
@@ -314,12 +307,10 @@ struct ChatDetailPresentation {
 
     static func composerCaptionText(
         runState: ChatRunState,
-        hasChatID: Bool,
         isLiveChat: Bool,
         isChatOperationConfigured: Bool,
         isDraftSubmitPending: Bool = false
     ) -> String? {
-        _ = hasChatID
         if isChatOperationConfigured == false {
             return "Configure an enabled provider and model in Settings → Providers before sending."
         }
@@ -338,13 +329,11 @@ struct ChatDetailPresentation {
     }
 
     static func canSendPredicate(
-        hasMount: Bool,
         runState: ChatRunState,
         hasDraftText: Bool,
         isChatOperationConfigured: Bool,
         isDraftSubmitPending: Bool = false
     ) -> Bool {
-        _ = hasMount
         return isChatOperationConfigured
             && !runState.isAnswering
             && runState != .queued

--- a/Sources/WikiFS/Chats/ChatDetailView.swift
+++ b/Sources/WikiFS/Chats/ChatDetailView.swift
@@ -64,9 +64,7 @@ struct ChatDetailView: View {
             runningKind: remoteSession.runningKind,
             preflightError: remoteSession.preflightError,
             pendingPermissions: remoteSession.pendingPermissions,
-            runStartedAt: remoteSession.runStartedAt,
-            projectionInput: remoteSession.displayProjectionInput,
-            exitStatus: remoteSession.exitStatus
+            projectionInput: remoteSession.displayProjectionInput
         )
     }
 
@@ -234,9 +232,14 @@ struct ChatDetailView: View {
             installOutgoingEnvironment()
             updateRightSidebarRegistration()
         }
-        .onChange(of: presentation.outlineEntries) { _, _ in
-            updateRightSidebarRegistration()
-        }
+        // The right sidebar renders the outline as a captured snapshot: it
+        // re-renders only when a NEW registration arrives (see
+        // SidebarRegistrationRefresh below for why BOTH triggers matter).
+        .modifier(SidebarRegistrationRefresh(
+            projectionInput: remoteSession.displayProjectionInput,
+            outlineEntries: presentation.outlineEntries,
+            onRefresh: updateRightSidebarRegistration
+        ))
         .onChange(of: remoteSession.runState) { _, _ in
             if let chatID, !isLiveChat {
                 loadPersistedTranscript(chatID: chatID)
@@ -727,7 +730,10 @@ struct ChatDetailView: View {
         // The durable row's provisional title appears the moment the user
         // sends — no cross-process round trip.
         if let chatID {
-            store.applyProvisionalChatTitle(chatID: chatID, userText: message)
+            // The wire message (attachment refs included) is what the daemon
+            // derives its title from — pass the same text so both writers
+            // converge byte-for-byte instead of by inverse-strip coincidence.
+            store.applyProvisionalChatTitle(chatID: chatID, userText: payload.wireMessage)
         }
         outgoing.send(chatID: chatID, payload: payload, makeRequest: makeSubmitRequest)
     }
@@ -785,7 +791,7 @@ struct ChatDetailView: View {
         guard isChatOperationConfigured, let pending = queuedMessages.first else { return }
         queuedMessages.removeFirst()
         if let chatID {
-            store.applyProvisionalChatTitle(chatID: chatID, userText: pending.draftText)
+            store.applyProvisionalChatTitle(chatID: chatID, userText: pending.wireMessage)
         }
         outgoing.send(
             chatID: chatID,
@@ -891,14 +897,12 @@ struct ChatDetailView: View {
 
     static func composerCaptionText(
         runState: ChatRunState,
-        hasChatID: Bool,
         isLiveChat: Bool,
         isChatOperationConfigured: Bool,
         isDraftSubmitPending: Bool = false
     ) -> String? {
         ChatDetailPresentation.composerCaptionText(
             runState: runState,
-            hasChatID: hasChatID,
             isLiveChat: isLiveChat,
             isChatOperationConfigured: isChatOperationConfigured,
             isDraftSubmitPending: isDraftSubmitPending
@@ -906,14 +910,12 @@ struct ChatDetailView: View {
     }
 
     nonisolated static func canSendPredicate(
-        hasMount: Bool,
         runState: ChatRunState,
         hasDraftText: Bool,
         isChatOperationConfigured: Bool,
         isDraftSubmitPending: Bool = false
     ) -> Bool {
         ChatDetailPresentation.canSendPredicate(
-            hasMount: hasMount,
             runState: runState,
             hasDraftText: hasDraftText,
             isChatOperationConfigured: isChatOperationConfigured,
@@ -937,6 +939,30 @@ struct ChatDetailView: View {
         }
         persistedTranscriptItems = items
         updateRightSidebarRegistration()
+    }
+}
+
+/// Sidebar invalidation for the chat surface. The right sidebar renders the
+/// outline as a captured snapshot and re-renders only when a new registration
+/// object arrives, so every input the outline depends on must be enumerated
+/// here and force a re-registration:
+///
+/// - `projectionInput`: session rehydration transiently empties it (daemon
+///   attaching, history not yet mirrored) and live turns grow it per delta.
+///   Without this trigger the sidebar freezes whichever frame was current —
+///   an outline rendered blank for a chat whose transcript was fully visible.
+/// - `outlineEntries`: covers projection changes that alter the entry list
+///   without changing the input shape.
+@MainActor
+private struct SidebarRegistrationRefresh: ViewModifier {
+    let projectionInput: TranscriptProjectionInput
+    let outlineEntries: [ChatOutlineEntry]
+    let onRefresh: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: projectionInput) { _, _ in onRefresh() }
+            .onChange(of: outlineEntries) { _, _ in onRefresh() }
     }
 }
 

--- a/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
+++ b/Sources/WikiFS/Chats/ChatInspectorOutlineView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WikiFSCore
 
 /// Inspector-body content for the chat surface's outline.
 struct ChatInspectorOutlineView: View {
@@ -9,46 +10,65 @@ struct ChatInspectorOutlineView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 2) {
                 ForEach(entries, id: \.id) { entry in
-                    Button {
-                        onSelect(entry.id)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 0) {
-                            if let ts = entry.questionTimestamp {
-                                Text(ts, format: .dateTime.hour().minute())
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.tertiary)
-                                    .padding(.bottom, 2)
-                            }
-                            HStack(alignment: .top, spacing: 4) {
-                                Text("•")
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.secondary)
-                                Text(entry.question.isEmpty ? "(empty)" : entry.question)
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.primary)
-                                    .multilineTextAlignment(.leading)
-                            }
-                            if let response = entry.response {
-                                HStack(alignment: .top, spacing: 4) {
-                                    Text("•")
-                                        .font(.system(size: 13))
-                                        .foregroundStyle(.secondary)
-                                    Text(response)
-                                        .font(.system(size: 13))
-                                        .foregroundStyle(.secondary)
-                                        .multilineTextAlignment(.leading)
-                                }
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
+                    outlineRow(entry)
                 }
             }
             .padding(.vertical, 6)
         }
+    }
+
+    /// One outline entry. The row action is a tap gesture rather than a
+    /// Button on purpose: a Button's press gesture swallows drag events, so
+    /// drag-to-select on the entry texts could never engage. With a tap
+    /// gesture, a click still jumps to the turn while a drag selects text.
+    private func outlineRow(_ entry: ChatOutlineEntry) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let ts = entry.questionTimestamp {
+                Text(ts, format: .dateTime.hour().minute())
+                    .font(.system(size: 13))
+                    .foregroundStyle(.tertiary)
+                    .padding(.bottom, 2)
+            }
+            HStack(alignment: .top, spacing: 4) {
+                Text("•")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                Text(entry.question.isEmpty ? "(empty)" : entry.question)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+                    .textSelection(.enabled)
+            }
+            if let response = entry.response {
+                HStack(alignment: .top, spacing: 4) {
+                    Text("•")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                    Text(response)
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.leading)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect(entry.id) }
+        .contextMenu {
+            Button("Copy Question") {
+                _ = MetadataActionRouter.systemClipboardCopy(entry.question)
+            }
+            if let response = entry.response {
+                Button("Copy Response") {
+                    _ = MetadataActionRouter.systemClipboardCopy(response)
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onSelect(entry.id) }
     }
 }

--- a/Sources/WikiFS/Chats/ChatsListView.swift
+++ b/Sources/WikiFS/Chats/ChatsListView.swift
@@ -186,7 +186,7 @@ final class ChatsListViewController: NSViewController {
 
     private func signature(_ rows: [ChatSummary]) -> String {
         rows.map {
-            "\($0.id.rawValue)|\($0.title)|\($0.updatedAt.timeIntervalSince1970)|\($0.summary ?? "")"
+            "\($0.id.rawValue)|\($0.title)"
         }.joined(separator: "\n")
     }
 
@@ -441,7 +441,11 @@ final class ChatsCellView: NSTableCellView {
     func configure(chat: ChatSummary, isLive: Bool) {
         iconView.image = NSImage(systemSymbolName: ResourceKind.chat.systemImageName,
                                   accessibilityDescription: nil)
-        let title = chat.title.isEmpty ? "New Chat" : chat.title
+        // Title: the summary-model's one-line summary when the summarizer
+        // produced one, otherwise the stored title — the user's question —
+        // with the known injected skills-budget warning stripped (rows created
+        // before the derivation fix carry it). Subtitle: the creation date.
+        let title = Self.rowTitle(for: chat)
         titleField.stringValue = title
         toolTip = title
 
@@ -453,12 +457,27 @@ final class ChatsCellView: NSTableCellView {
             liveDot.isHidden = true
             liveLabel.isHidden = true
             subtitleField.isHidden = false
-            if let summary = chat.summary {
-                subtitleField.stringValue = summary
-            } else {
-                subtitleField.stringValue = chat.updatedAt.formatted(.relative(presentation: .named))
-            }
+            subtitleField.stringValue = Self.rowSubtitle(for: chat)
         }
+    }
+
+    /// The row's title line: the chat's stored title — the user's question,
+    /// or the model-generated title when the summarizer stage is configured —
+    /// with the known skills-budget warning stripped. A title that cleans to
+    /// nothing (warning-only rows created before the derivation fix) falls
+    /// back to "New Chat". Mirrors the tab title and chat header so every
+    /// surface names the chat identically. The cached response summary
+    /// (`chats.summary`) deliberately does NOT appear: it summarizes the
+    /// answer, not the chat, and previously shadowed the title here. Pure
+    /// seam so the contract is testable without hosting AppKit views.
+    nonisolated static func rowTitle(for chat: ChatSummary) -> String {
+        AgentPresentationPreamble.visibleText(chat.title, policy: .completeOnly) ?? "New Chat"
+    }
+
+    /// The row's subtitle: the chat's creation date, per the row design
+    /// (the title line carries the content; the date anchors it in time).
+    nonisolated static func rowSubtitle(for chat: ChatSummary) -> String {
+        chat.createdAt.formatted(date: .abbreviated, time: .shortened)
     }
 }
 

--- a/Sources/WikiFSCore/Core/AgentPresentationPreamble.swift
+++ b/Sources/WikiFSCore/Core/AgentPresentationPreamble.swift
@@ -53,6 +53,16 @@ public enum AgentPresentationPreamble {
         }
 
         let firstContentLine = lines[firstContentIndex].trimmingCharacters(in: .whitespaces)
+
+        // Near-miss canary: a line that OPENS like the skills-budget banner
+        // but is not the exact known sentence means the vendor reworded it.
+        // Surface it in diagnostics instead of silently preserving new banner
+        // text in titles, summaries, and exports.
+        if firstContentLine.hasPrefix("Warning: Skill descriptions"),
+           !firstContentLine.hasPrefix(knownWarningSentence) {
+            DebugLog.chatLive("AgentPresentationPreamble: unrecognized 'Warning: Skill descriptions' variant — the banner may have been reworded; preserved verbatim: \(firstContentLine.prefix(140))")
+        }
+
         if firstContentLine.hasPrefix(knownWarningSentence) {
             return remainder(afterWarningLineAt: firstContentIndex, in: lines)
         }

--- a/Sources/WikiFSCore/Core/ChatModels.swift
+++ b/Sources/WikiFSCore/Core/ChatModels.swift
@@ -26,15 +26,6 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     public var updatedAt: Date
     /// Persisted message count, for the history list's subtitle.
     public var messageCount: Int
-    /// One-line summary of the model's first response, generated on chat
-    /// completion (issue #411). `nil` for chats that haven't been summarized
-    /// yet (existing chats after migration, or chats whose `finish()` never
-    /// fired). The sidebar shows this when present, falling back to the
-    /// relative timestamp.
-    public var summary: String?
-    /// When the summary was written, for staleness display. `nil` alongside
-    /// `summary`.
-    public var summaryAt: Date?
     /// The ACP session ID for resume (#830). Set after the chat's session is
     /// created; cleared on terminal teardown (resume permanently failed) or
     /// successful completion. `nil` for pre-#830 chats and chats whose resume
@@ -61,7 +52,6 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     public init(
         id: ChatID, kind: ChatKind, title: String,
         createdAt: Date, updatedAt: Date, messageCount: Int,
-        summary: String? = nil, summaryAt: Date? = nil,
         acpSessionId: AcpSessionID? = nil,
         modelProviderId: ProviderID? = nil, modelId: ModelID? = nil,
         configuredThinkingOptionID: ChatConfigurationValueID? = nil,
@@ -73,8 +63,6 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.messageCount = messageCount
-        self.summary = summary
-        self.summaryAt = summaryAt
         self.acpSessionId = acpSessionId
         self.modelProviderId = modelProviderId
         self.modelId = modelId
@@ -88,8 +76,14 @@ public struct ChatSummary: Identifiable, Hashable, Sendable {
     /// `[[chat:…]]` attachment reference lines (prepended by `sendMessage`
     /// when sidebar items are dragged into the chat, issue #385) so the title
     /// is the user's actual question, not the first attachment's wikilink.
+    /// Also strips the known agent skills-budget preamble (`AgentPresentationPreamble`)
+    /// — some backends prepend "Warning: Skill descriptions were shortened…"
+    /// to the message text, and without this the warning became the chat's
+    /// title while the transcript kept the real question. A message that is
+    /// only the warning derives to "New Chat".
     public static func title(fromFirstMessage message: String, maxLength: Int = 60) -> String {
-        let stripped = Self.stripAttachmentRefs(from: message)
+        let withoutPreamble = AgentPresentationPreamble.visibleText(message, policy: .completeOnly) ?? ""
+        let stripped = Self.stripAttachmentRefs(from: withoutPreamble)
         let firstLine = stripped
             .components(separatedBy: .newlines)
             .first ?? ""
@@ -175,8 +169,9 @@ public struct ChatMessage: Identifiable, Equatable, Sendable {
     public var seq: Int
     public var event: AgentEvent
     public var createdAt: Date
-    /// Cached one-line summary (chat-summary plan). `nil` until the summarizer
-    /// runs; written once via `updateMessageSummary` and never recomputed.
+    /// Cached one-line summary for the message (chat-summary plan §4.2).
+    /// Written once per turn via `updateMessageSummary` and never recomputed;
+    /// feeds the outline's response text. `nil` until the summarizer runs.
     public var summary: String?
     /// Which summarizer produced `summary`. `nil` alongside `summary`. Stored
     /// as `ChatMessageSummaryKind.rawValue` in the `summary_kind` column.

--- a/Sources/WikiFSCore/Store/GRDBWikiStore.swift
+++ b/Sources/WikiFSCore/Store/GRDBWikiStore.swift
@@ -158,7 +158,7 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
     /// databases produced by that store carry `PRAGMA user_version` up to 37, and
     /// this store must recognize them as already-current so the ladder is a no-op
     /// on re-open (the proven `if version < N`)
-    private static let currentSchemaVersion = 52
+    private static let currentSchemaVersion = 53
     /// The current schema version (mirrors the former
     /// `SQLiteWikiStore.currentSchemaVersion`). Public so tests can assert the
     /// migration ladder landed at the expected `user_version`.
@@ -1550,6 +1550,21 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
             version = 52
         }
 
+        // v52→v53: remove the chat-level `summary`/`summary_at` columns. The
+        // mirrored one-line answer summary (issue #411) is no longer read
+        // anywhere — the sidebar row shows the stored title and the creation
+        // date — and the per-message summaries in `chat_messages` (which feed
+        // the outline) are unaffected. Guarded like every other step so
+        // already-converged databases pass through.
+        if version < 53 {
+            try db.inTransaction(.immediate) {
+                try Self.dropChatSummaryColumnsV53(in: db)
+                try db.execute(sql: "PRAGMA user_version = 53;")
+                return .commit
+            }
+            version = 53
+        }
+
         // Catch-all fallback: any DB older than `currentSchemaVersion` whose
         // per-step work has not been added above (the steady-state guard for a
         // genuine currentSchemaVersion bump). Drops FTS5 + stamps
@@ -2066,8 +2081,6 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
             title              TEXT NOT NULL,
             created_at         REAL NOT NULL,
             updated_at         REAL NOT NULL,
-            summary            TEXT,
-            summary_at         REAL,
             acp_session_id     TEXT,
             model_provider_id  TEXT,
             model_id           TEXT,
@@ -2910,6 +2923,22 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
         }
     }
 
+    /// The v52→53 migration step: drop the chat-level one-line answer
+    /// summary columns (issue #411 successor). The mirrored `chats.summary`
+    /// is no longer read anywhere; per-message summaries in `chat_messages`
+    /// (which feed the outline) are unaffected.
+    private static func dropChatSummaryColumnsV53(in db: Database) throws {
+        let columns = try tableColumnInfo("chats", in: db)
+        guard columns.contains("summary") || columns.contains("summary_at") else { return }
+
+        if columns.contains("summary") {
+            try db.execute(sql: "ALTER TABLE chats DROP COLUMN summary;")
+        }
+        if columns.contains("summary_at") {
+            try db.execute(sql: "ALTER TABLE chats DROP COLUMN summary_at;")
+        }
+    }
+
     /// The v35→36 migration step (issue #411 — chat summary).
     private static func migrateV35ToV36(in db: Database) throws {
         let columns = try tableColumnInfo("chats", in: db)
@@ -3373,8 +3402,6 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
             title              TEXT NOT NULL,
             created_at         REAL NOT NULL,
             updated_at         REAL NOT NULL,
-            summary            TEXT,
-            summary_at         REAL,
             acp_session_id     TEXT,
             model_provider_id  TEXT,
             model_id           TEXT,
@@ -9879,20 +9906,14 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                   c.summary, c.summary_at, c.acp_session_id,
+                   c.acp_session_id,
                    c.model_provider_id, c.model_id,
                    c.configured_thinking_option_id, c.effective_thinking_option_id
             FROM chats c
             ORDER BY c.updated_at DESC, c.rowid DESC;
             """)
             return rows.map { row in
-                let summary: String? = row["summary"]
-                let summaryAt: Double? = row["summary_at"]
-                return Self.readChatSummary(
-                    from: row,
-                    summary: summary,
-                    summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) }
-                )
+                Self.readChatSummary(from: row)
             }
         }
     }
@@ -10038,18 +10059,6 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
         }
     }
 
-    public func updateChatSummary(chatID: ChatID, summary: String) throws {
-        try mutate(event: { _ in
-            self.localEvent(.chat, id: chatID.rawValue, change: .updated)
-        }) { db in
-            try db.execute(sql: """
-            UPDATE chats SET summary = ?, summary_at = ?, updated_at = ?
-            WHERE id = ?;
-            """, arguments: [summary, Date().timeIntervalSince1970,
-                            Date().timeIntervalSince1970, chatID.rawValue])
-        }
-    }
-
     /// Write (or clear) the ACP session ID for resume (#830). Bumps
     /// `updated_at`. Routes through `mutate(event:_:)` so it emits a
     /// `.chat .updated` event. Pass `nil` to clear (terminal teardown /
@@ -10146,20 +10155,14 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
             let rows = try Row.fetchAll(db, sql: """
             SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                    (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                   c.summary, c.summary_at, c.acp_session_id,
+                   c.acp_session_id,
                    c.model_provider_id, c.model_id,
                    c.configured_thinking_option_id, c.effective_thinking_option_id
             FROM chats c
             ORDER BY c.id ASC;
             """)
             return rows.map { row in
-                let summary: String? = row["summary"]
-                let summaryAt: Double? = row["summary_at"]
-                return Self.readChatSummary(
-                    from: row,
-                    summary: summary,
-                    summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) }
-                )
+                Self.readChatSummary(from: row)
             }
         }
     }
@@ -10251,7 +10254,7 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
                 let rows = try Row.fetchAll(db, sql: """
                     SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                            (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                           c.summary, c.summary_at, cc.embedding, c.acp_session_id,
+                           cc.embedding, c.acp_session_id,
                            c.model_provider_id, c.model_id,
                            c.configured_thinking_option_id, c.effective_thinking_option_id
                     FROM chat_chunks cc
@@ -10273,12 +10276,7 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
                     .sorted { $0.value.sim > $1.value.sim }
                     .prefix(pool)
                     .map { _, entry in
-                        let summary: String? = entry.row["summary"]
-                        let summaryAt: Double? = entry.row["summary_at"]
-                        return Self.readChatSummary(
-                            from: entry.row,
-                            summary: summary,
-                            summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) })
+                        return Self.readChatSummary(from: entry.row)
                     }
                 return Array(RankFusion.rrf([semRows, ftsRows], id: \.id).prefix(limit))
             }
@@ -10985,9 +10983,7 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
     /// Read a complete ChatSummary from a GRDB Row. Every caller selects the
     /// provider/model and thinking-selection columns so list, get, search, and
     /// File Provider projections preserve the same durable state.
-    private static func readChatSummary(
-        from row: Row, summary: String?, summaryAt: Date?
-    ) -> ChatSummary {
+    private static func readChatSummary(from row: Row) -> ChatSummary {
         let acpSessionId: String? = row["acp_session_id"]
         let modelProviderId: String? = row["model_provider_id"]
         let modelId: String? = row["model_id"]
@@ -11000,8 +10996,6 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
             createdAt: Date(timeIntervalSince1970: row["created_at"]),
             updatedAt: Date(timeIntervalSince1970: row["updated_at"]),
             messageCount: row["msg_count"],
-            summary: summary,
-            summaryAt: summaryAt,
             acpSessionId: acpSessionId.map { AcpSessionID(rawValue: $0) },
             modelProviderId: modelProviderId.map { ProviderID(rawValue: $0) },
             modelId: modelId.map { ModelID(rawValue: $0) },
@@ -12075,20 +12069,14 @@ public final class GRDBWikiStore: WikiStore, LegacyRendererWikiEnablementCompati
                 sql: """
                 SELECT c.id, c.kind, c.title, c.created_at, c.updated_at,
                        (SELECT COUNT(*) FROM chat_messages m WHERE m.chat_id = c.id) AS msg_count,
-                       c.summary, c.summary_at, c.acp_session_id,
+                       c.acp_session_id,
                        c.model_provider_id, c.model_id,
                        c.configured_thinking_option_id, c.effective_thinking_option_id
                 FROM chats c WHERE c.id = ?;
                 """,
                 arguments: [id.rawValue]
             ) else { throw WikiStoreError.chatNotFound(id) }
-            let summary: String? = row["summary"]
-            let summaryAt: Double? = row["summary_at"]
-            return Self.readChatSummary(
-                from: row,
-                summary: summary,
-                summaryAt: summaryAt.map { Date(timeIntervalSince1970: $0) }
-            )
+            return Self.readChatSummary(from: row)
         }
     }
 

--- a/Sources/WikiFSCore/Store/WikiStore.swift
+++ b/Sources/WikiFSCore/Store/WikiStore.swift
@@ -1011,8 +1011,6 @@ public protocol WikiStore: AnyObject, Sendable {
 
     /// Write the one-line summary of the model's first response (issue #411),
     /// bumping `updated_at`. Throws `.notFound` if no chat has `id`.
-    func updateChatSummary(chatID: ChatID, summary: String) throws
-
     /// Write or clear the ACP session ID for resume (#830). Pass `nil` to
     /// clear (terminal teardown / permanent resume failure). Bumps
     /// `updated_at`.

--- a/Sources/WikiFSCore/Store/WikiStoreModel.swift
+++ b/Sources/WikiFSCore/Store/WikiStoreModel.swift
@@ -4527,16 +4527,6 @@ public final class WikiStoreModel {
         }
     }
 
-    public func updateChatSummary(chatID: ChatID, summary: String) {
-        do {
-            try store.updateChatSummary(chatID: chatID, summary: summary)
-            // No manual reload — the bus fires reloadFromStore() async after the
-            // update.
-        } catch {
-            DebugLog.store("WikiStoreModel.updateChatSummary failed: \(error)")
-        }
-    }
-
     /// `@MainActor` wrapper for the ACP session ID write/clear (#830). Written
     /// at spawn time (persist) and on resume failure (clear). No manual reload
     /// — the bus fires `reloadFromStore()` async after the store write.

--- a/Sources/WikiFSEngine/AgentOperationRunner.swift
+++ b/Sources/WikiFSEngine/AgentOperationRunner.swift
@@ -599,7 +599,7 @@ public enum AgentOperationRunner {
     /// sink (e.g. on a second turn) is a no-op for already-summarized rows.
     ///
     /// **Chat-level summary (issue #411):** the FIRST summarizable message's
-    /// summary is mirrored into `chats.summary` (the chats-list subtitle) as it
+    /// summary is cached on the message as it
     /// is written. This is the only writer of that column — the launcher no
     /// longer computes its own always-truncated version, which is what made the
     /// subtitle abbreviate even in Model mode.
@@ -643,39 +643,27 @@ public enum AgentOperationRunner {
             msg.summary == nil
                 && (MessageSummarizer.textToSummarize(from: msg.event)?.isEmpty == false)
         }
-        let chatSummaryMessageID = MessageSummarizer.chatSummaryMessageID(in: messages)
         guard !pending.isEmpty else { return }
         guard let services = launcher.providerServices else {
-            Self.writeDefaultSummaries(
-                chatID: chatID,
-                pending: pending,
-                store: store,
-                chatSummaryMessageID: chatSummaryMessageID)
+            Self.writeDefaultSummaries(chatID: chatID, pending: pending, store: store)
             return
         }
         do {
             let preparation = try await services.prepareSummarization()
             switch preparation {
             case .defaultTruncation:
-                Self.writeDefaultSummaries(
-                    chatID: chatID, pending: pending, store: store,
-                    chatSummaryMessageID: chatSummaryMessageID)
+                Self.writeDefaultSummaries(chatID: chatID, pending: pending, store: store)
             case .model(let preparation):
                 await Self.runModelSummarization(
                     chatID: chatID,
                     pending: pending,
                     services: services,
                     preparation: preparation,
-                    store: store,
-                    chatSummaryMessageID: chatSummaryMessageID)
+                    store: store)
                 await services.release(preparation.selection.token)
             }
         } catch AgentProviderRuntimeError.unavailable {
-            Self.writeDefaultSummaries(
-                chatID: chatID,
-                pending: pending,
-                store: store,
-                chatSummaryMessageID: chatSummaryMessageID)
+            Self.writeDefaultSummaries(chatID: chatID, pending: pending, store: store)
         } catch {
             DebugLog.agent("AgentOperationRunner: summarization preparation failed: \(error)")
         }
@@ -683,15 +671,13 @@ public enum AgentOperationRunner {
 
     @MainActor
     private static func writeDefaultSummaries(
-        chatID: ChatID, pending: [ChatMessage], store: WikiStoreModel,
-        chatSummaryMessageID: PageID?
+        chatID: ChatID, pending: [ChatMessage], store: WikiStoreModel
     ) {
         for msg in pending {
             guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
             let summary = MessageSummarizer.defaultSummary(for: text)
             guard !summary.isEmpty else { continue }
             store.updateMessageSummary(chatID: chatID, messageID: msg.id, summary: summary, kind: .defaultTruncation)
-            if msg.id == chatSummaryMessageID { store.updateChatSummary(chatID: chatID, summary: summary) }
         }
     }
 
@@ -702,8 +688,7 @@ public enum AgentOperationRunner {
         pending: [ChatMessage],
         services: any AgentProviderServices,
         preparation: AgentOperationPreparation,
-        store: WikiStoreModel,
-        chatSummaryMessageID: PageID?
+        store: WikiStoreModel
     ) async {
         for msg in pending {
             guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
@@ -717,9 +702,6 @@ public enum AgentOperationRunner {
                 store.updateMessageSummary(
                     chatID: chatID, messageID: msg.id,
                     summary: summary, kind: .model)
-                if msg.id == chatSummaryMessageID {
-                    store.updateChatSummary(chatID: chatID, summary: summary)
-                }
             } catch {
                 DebugLog.agent("AgentOperationRunner: model summary failed: \(error.localizedDescription)")
             }

--- a/Sources/WikiFSEngine/MessageSummarizer.swift
+++ b/Sources/WikiFSEngine/MessageSummarizer.swift
@@ -200,7 +200,16 @@ public enum MessageSummarizer {
             DebugLog.ingest("MessageSummarizer: model returned empty output for prompt=\(prompt.prefix(40))...")
             return nil
         }
-        return trimmed
+
+        // The summarizer-stage backend is itself an ACP agent and may prepend
+        // the known skills-budget warning to its own reply. Strip it so the
+        // banner never lands in a cached summary or title; a reply that is
+        // only the warning yields nothing usable.
+        guard let visible = AgentPresentationPreamble.visibleText(trimmed, policy: .completeOnly) else {
+            DebugLog.ingest("MessageSummarizer.oneShotReply: reply was only the known preamble")
+            return nil
+        }
+        return visible
     }
 
     /// Extract the summarizable text from an `AgentEvent` (the source for a
@@ -211,7 +220,7 @@ public enum MessageSummarizer {
     /// ACP backends open replies with meta preambles — a skills-budget
     /// `Warning:` line, a `Thinking:` dump — which are not content. Leading
     /// preamble lines are stripped; a message that is ONLY preamble yields nil
-    /// so it is never summarized and never becomes `chats.summary` or a title
+    /// so it is never summarized and never becomes a title
     /// input.
     public static func textToSummarize(from event: AgentEvent) -> String? {
         switch event {
@@ -247,26 +256,6 @@ public enum MessageSummarizer {
         let rest = lines.joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return rest.isEmpty ? nil : rest
-    }
-
-    /// The message whose summary doubles as the CHAT-level summary
-    /// (`chats.summary`, issue #411): the FIRST summarizable message in the
-    /// chat. PURE — `messages` must be in store order.
-    ///
-    /// `chats.summary` is not a summary of the whole conversation; it is the
-    /// gist of the opening answer, shown as the chats-list row subtitle. Rather
-    /// than compute it separately (the pre-#411-unification design, which always
-    /// truncated regardless of the summarizer mode), both hosts now MIRROR the
-    /// first message's cached summary into the chat row. That gives one writer,
-    /// one condensing policy, and — in Model mode — zero extra model calls: the
-    /// chat summary is a copy of a per-message summary that was computed anyway.
-    ///
-    /// Returns nil when no message has summarizable text.
-    public static func chatSummaryMessageID(in messages: [ChatMessage]) -> PageID? {
-        messages.first { msg in
-            guard let text = textToSummarize(from: msg.event) else { return false }
-            return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }?.id
     }
 
     /// Run a one-shot model summarization via the injected `AgentBackend`

--- a/Sources/WikiFSSearch/TantivyIndexer.swift
+++ b/Sources/WikiFSSearch/TantivyIndexer.swift
@@ -133,7 +133,7 @@ public actor TantivyIndexer {
     /// (`TantivySwiftSearchQuery` + `TantivySwiftFuzzyField`), NOT the structured
     /// `TantivyQuery.fuzzy` enum. The structured `.fuzzy` case has no `prefix`
     /// parameter, and without `prefix: true` distance-2 fuzzy on a short
-    /// partial like `"Erl"` will not surface `"Erickson"` (whole-token edit
+    /// partial like `"Erl"` will not surface `"Erlandson"` (whole-token edit
     /// distance 6). The query-string path's `TantivySwiftFuzzyField` exposes
     /// both `distance: UInt8` AND `prefix: Bool` — this is the same path the
     /// shipped sidebar search uses (`search(query:kind:limit:)` above), with

--- a/Sources/WikiFSSearch/TantivySearchService.swift
+++ b/Sources/WikiFSSearch/TantivySearchService.swift
@@ -67,7 +67,7 @@ final class TantivySearchService: Sendable {
     /// pre-scope to one kind (`[[page:` → `[.page]`) or open it up later.
     /// See `TantivyIndexer.autocomplete(...)` for the query-string-path
     /// rationale (prefix-true on title is load-bearing for the
-    /// `"Erl" → "Erickson"` headline case).
+    /// `"Erl" → "Erlandson"` headline case).
     func autocomplete(
         partial: String,
         kinds: Set<TantivyDocumentKind>,

--- a/Sources/wikid/DaemonChatHost.swift
+++ b/Sources/wikid/DaemonChatHost.swift
@@ -448,9 +448,6 @@ final class DaemonChatHost: @unchecked Sendable {
     /// RC5: this is the daemon-native generalization of the app's
     /// `summarizePendingMessages` + `runModelSummarization`.
     ///
-    /// Also mirrors the FIRST summarizable message's summary into
-    /// `chats.summary` (issue #411) — the sole writer of that column now that
-    /// the launcher's always-truncated path is gone.
     private func summarizePendingMessages(
         chatID: ChatID, wikiID: WikiID
     ) {
@@ -470,9 +467,6 @@ final class DaemonChatHost: @unchecked Sendable {
         }
         guard !pending.isEmpty else { return }
 
-        // The message whose summary doubles as `chats.summary` (issue #411).
-        let chatSummaryMessageID = MessageSummarizer.chatSummaryMessageID(in: messages)
-
         let services = providerServices
         Task { @MainActor in
             do {
@@ -485,24 +479,21 @@ final class DaemonChatHost: @unchecked Sendable {
                 switch preparation {
                 case .defaultTruncation:
                     Self.writeDefaultSummaries(
-                        chatID: chatID, pending: pending, store: store,
-                        chatSummaryMessageID: chatSummaryMessageID)
+                        chatID: chatID, pending: pending, store: store)
                 case .model(let preparation):
                     await Self.runModelSummarization(
                         chatID: chatID,
                         pending: pending,
                         services: services,
                         preparation: preparation,
-                        store: store,
-                        chatSummaryMessageID: chatSummaryMessageID)
+                        store: store)
                     await services.release(preparation.selection.token)
                 }
             } catch AgentProviderRuntimeError.unavailable {
                 Self.writeDefaultSummaries(
                     chatID: chatID,
                     pending: pending,
-                    store: store,
-                    chatSummaryMessageID: chatSummaryMessageID)
+                    store: store)
             } catch {
                 DebugLog.agent("DaemonChatHost: summarization preparation failed: \(error)")
             }
@@ -590,8 +581,7 @@ final class DaemonChatHost: @unchecked Sendable {
 
     @MainActor
     private static func writeDefaultSummaries(
-        chatID: ChatID, pending: [ChatMessage], store: GRDBWikiStore,
-        chatSummaryMessageID: PageID?
+        chatID: ChatID, pending: [ChatMessage], store: GRDBWikiStore
     ) {
         for msg in pending {
             guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
@@ -601,9 +591,6 @@ final class DaemonChatHost: @unchecked Sendable {
                 try store.updateMessageSummary(
                     chatID: chatID, messageID: msg.id,
                     summary: summary, kind: .defaultTruncation)
-                if msg.id == chatSummaryMessageID {
-                    try store.updateChatSummary(chatID: chatID, summary: summary)
-                }
             } catch {
                 DebugLog.store("DaemonChatHost: summary write failed: \(error)")
             }
@@ -617,8 +604,7 @@ final class DaemonChatHost: @unchecked Sendable {
         pending: [ChatMessage],
         services: any AgentProviderServices,
         preparation: AgentOperationPreparation,
-        store: GRDBWikiStore,
-        chatSummaryMessageID: PageID?
+        store: GRDBWikiStore
     ) async {
         for msg in pending {
             guard let text = MessageSummarizer.textToSummarize(from: msg.event) else { continue }
@@ -636,10 +622,6 @@ final class DaemonChatHost: @unchecked Sendable {
                 try store.updateMessageSummary(
                     chatID: chatID, messageID: msg.id,
                     summary: summary, kind: .model)
-                // Keep the model's one-sentence result verbatim in chats.summary.
-                if msg.id == chatSummaryMessageID {
-                    try store.updateChatSummary(chatID: chatID, summary: summary)
-                }
             } catch {
                 DebugLog.store("DaemonChatHost.runModelSummarization: write failed: \(error)")
             }

--- a/Tests/WikiFSAppTests/ActivityWindowTypedTranscriptTests.swift
+++ b/Tests/WikiFSAppTests/ActivityWindowTypedTranscriptTests.swift
@@ -59,7 +59,7 @@ struct ActivityWindowTypedTranscriptTests {
     /// the known skill warning stays visible, regardless of the user's chat
     /// Tool-call-display preference.
     @Test func keepsCanonicalDetailedRows() {
-        let warning = "Warning: Skill descriptions were shortened to fit the 2% skills context budget."
+        let warning = AgentPresentationPreamble.knownWarningSentence
         let turn = ChatTurnID(rawValue: "turn-activity")
         let items: [ChatTranscriptItem] = [
             .message(ChatTranscriptMessageItem(

--- a/Tests/WikiFSAppTests/CLITantivyLegResolverTests.swift
+++ b/Tests/WikiFSAppTests/CLITantivyLegResolverTests.swift
@@ -15,8 +15,8 @@ import Testing
 /// it via the same `StoreBackedTantivyContentSource` the app uses, then verify
 /// the resolver returns the indexed pages as a best-first BM25 leg (which the
 /// store's 3-arg `searchSimilar(query:limit:bm25Leg:)` then fuses with the
-/// cosine leg via RRF). The fuzzy-typo AC for `wikictl page search "erikson"`
-/// (finds "Erickson") is covered by `resolvePageLegSurfacesFuzzyTypoMatches`.
+/// cosine leg via RRF). The fuzzy-typo AC for `wikictl page search "mendal"`
+/// (finds "Mendel") is covered by `resolvePageLegSurfacesFuzzyTypoMatches`.
 ///
 /// These are fast: they open a temp SQLite DB, build a small Tantivy index
 /// (3-5 docs), and call one resolver method per test. They live in the fast
@@ -140,8 +140,8 @@ struct CLITantivyLegResolverTests {
     }
 
     @Test func resolvePageLegSurfacesFuzzyTypoMatches() async throws {
-        // AC #637: `wikictl page search "erikson"` (one-character typo) returns
-        // "Erickson"-style pages. Tantivy's `fuzzyFields` are configured with
+        // AC #637: `wikictl page search "mendal"` (one-character typo) returns
+        // "Mendel"-style pages. Tantivy's `fuzzyFields` are configured with
         // edit-distance 1 on title + body (`TantivyIndexer.swift:108-111`),
         // so the resolver's leg should include the correctly-spelled page
         // even though the query is misspelled.
@@ -149,18 +149,18 @@ struct CLITantivyLegResolverTests {
         defer { try? fm.removeItem(at: container) }
         let wikiID = WikiID(rawValue: "01TEST0003")
         let store = try tempStore(in: container, wikiID: wikiID)
-        let page = try store.createPage(title: "Milton H. Erickson")
-        try store.updatePage(id: page.id, title: "Milton H. Erickson",
-                             body: "Milton H. Erickson was an American psychiatrist specializing in clinical hypnosis.")
+        let page = try store.createPage(title: "Gregor Mendel")
+        try store.updatePage(id: page.id, title: "Gregor Mendel",
+                             body: "Gregor Mendel was an Augustinian friar specializing in the genetics of pea plants.")
 
-        // Query with a one-character typo ("erikson" vs "erickson"). Fuzzy
+        // Query with a one-character typo ("mendal" vs "Mendel"). Fuzzy
         // matching (edit-distance 1) should still surface the page. The
         // resolver's internal `rebuildIfNeeded()` populates the index from
         // the store on first call.
         let leg = await CLITantivyLegResolver.resolvePageLeg(
             wikiID: wikiID, containerDirectory: container,
-            store: store, query: "erikson", limit: 10)
-        #expect(leg != nil, "fuzzy match should find Erickson despite the typo")
+            store: store, query: "mendal", limit: 10)
+        #expect(leg != nil, "fuzzy match should find Mendel despite the typo")
         #expect(leg?.contains { $0.id == page.id } ?? false)
     }
 

--- a/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
+++ b/Tests/WikiFSAppTests/ChatDetailPresentationTests.swift
@@ -615,7 +615,7 @@ struct ChatDetailPresentationTests {
     /// warning-plus-text cache uses its cleaned remainder, and an incomplete
     /// final prefix stays (completeOnly semantics).
     @Test func staleCachedWarningCannotReappearInOutline() {
-        let warning = "Warning: Skill descriptions were shortened to fit the 2% skills context budget."
+        let warning = AgentPresentationPreamble.knownWarningSentence
         let turnID = ChatTurnID(rawValue: "turn-cache")
         let promptRow = ChatDisplayRow.userMessage(
             id: ChatMessageID(rawValue: "q"),
@@ -707,9 +707,7 @@ private extension ChatDetailPresentation.RemoteState {
         runningKind: WikiOperation.Kind? = nil,
         preflightError: String? = nil,
         pendingPermissions: [PendingPermission] = [],
-        runStartedAt: Date? = nil,
-        projectionInput: TranscriptProjectionInput = .empty,
-        exitStatus: Int32? = nil
+        projectionInput: TranscriptProjectionInput = .empty
     ) -> Self {
         .init(
             runState: runState,
@@ -717,9 +715,7 @@ private extension ChatDetailPresentation.RemoteState {
             runningKind: runningKind,
             preflightError: preflightError,
             pendingPermissions: pendingPermissions,
-            runStartedAt: runStartedAt,
-            projectionInput: projectionInput,
-            exitStatus: exitStatus
+            projectionInput: projectionInput
         )
     }
 }

--- a/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
+++ b/Tests/WikiFSAppTests/ChatDiagnosticsTests.swift
@@ -50,7 +50,7 @@ struct ChatDiagnosticsTests {
     /// presentation filter removes it, but the diagnostic trace must retain
     /// the exact bytes for debugging.
     @Test func fullDiagnosticTraceRetainsKnownSkillWarning() {
-        let warning = "Warning: Skill descriptions were shortened to fit the 2% skills context budget."
+        let warning = AgentPresentationPreamble.knownWarningSentence
         let trace = ChatDiagnosticTrace(source: .app)
         let chat = ChatDiagnosticCorrelation.Value(rawValue: "warning-chat")
 

--- a/Tests/WikiFSAppTests/ChatTranscriptPresentationProjectionTests.swift
+++ b/Tests/WikiFSAppTests/ChatTranscriptPresentationProjectionTests.swift
@@ -69,7 +69,7 @@ struct ChatTranscriptPresentationProjectionTests {
     }
 
     private let knownWarning =
-        "Warning: Skill descriptions were shortened to fit the 2% skills context budget."
+        AgentPresentationPreamble.knownWarningSentence
 
     // MARK: - Modes
 

--- a/Tests/WikiFSAppTests/ChatViewD2Tests.swift
+++ b/Tests/WikiFSAppTests/ChatViewD2Tests.swift
@@ -316,7 +316,6 @@ struct ChatViewD2Tests {
     /// removed because the agent reads via wikictl (DB-direct), not the mount.
     @Test func canSendPredicateTrueWithDraftTextAndIdleAgent() {
         #expect(ChatDetailView.canSendPredicate(
-            hasMount: true,
             runState: .idle,
             hasDraftText: true,
             isChatOperationConfigured: true) == true)
@@ -326,7 +325,6 @@ struct ChatViewD2Tests {
     /// the mount guard was removed (issue #441).
     @Test func canSendPredicateTrueWithoutMount() {
         #expect(ChatDetailView.canSendPredicate(
-            hasMount: false,
             runState: .idle,
             hasDraftText: true,
             isChatOperationConfigured: true) == true)
@@ -335,7 +333,6 @@ struct ChatViewD2Tests {
     /// `canSendPredicate` returns false when generating (can't send mid-response).
     @Test func canSendPredicateFalseWhileGenerating() {
         #expect(ChatDetailView.canSendPredicate(
-            hasMount: true,
             runState: .answering,
             hasDraftText: true,
             isChatOperationConfigured: true) == false)
@@ -345,7 +342,6 @@ struct ChatViewD2Tests {
     /// generation gate.
     @Test func canSendPredicateFalseWhileQueued() {
         #expect(ChatDetailView.canSendPredicate(
-            hasMount: true,
             runState: .queued,
             hasDraftText: true,
             isChatOperationConfigured: true) == false)
@@ -354,7 +350,6 @@ struct ChatViewD2Tests {
     /// `canSendPredicate` returns false with no draft text.
     @Test func canSendPredicateFalseWithNoDraftText() {
         #expect(ChatDetailView.canSendPredicate(
-            hasMount: true,
             runState: .idle,
             hasDraftText: false,
             isChatOperationConfigured: true) == false)

--- a/Tests/WikiFSAppTests/ChatsListRowDisplayTests.swift
+++ b/Tests/WikiFSAppTests/ChatsListRowDisplayTests.swift
@@ -1,0 +1,64 @@
+#if os(macOS)
+import Foundation
+import Testing
+import WikiFSCore
+@testable import WikiFS
+
+/// The left-hand chat list row contract: the title line is the chat's stored
+/// title (the user's question, or the model-generated title when the
+/// summarizer stage is configured) with the known injected skills-budget
+/// warning stripped, and the subtitle is the creation date. These tests pin
+/// the seams
+/// `ChatsCellView.rowTitle(for:)` and `ChatsCellView.rowSubtitle(for:)`.
+@Suite struct ChatsListRowDisplayTests {
+
+    private let warningTitle =
+        AgentPresentationPreamble.knownWarningSentence
+
+    private func makeChat(
+        title: String,
+        createdAt: Date = Date(timeIntervalSince1970: 1_760_000_000),
+        updatedAt: Date = Date(timeIntervalSince1970: 1_760_000_000)
+    ) -> ChatSummary {
+        ChatSummary(
+            id: ChatID(rawValue: "01JCHAT000000000000000ROW1"),
+            kind: .edit,
+            title: title,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            messageCount: 3)
+    }
+
+    // MARK: - Title
+
+    // The cached response summary (chats.summary) was REMOVED (schema v53),
+    // so it can no longer shadow the title — rowTitle reads only the stored
+    // title, structurally.
+
+    @Test("a stored warning title cleans to the New Chat fallback")
+    func warningOnlyStoredTitleFallsBack() {
+        let chat = makeChat(title: warningTitle)
+        #expect(ChatsCellView.rowTitle(for: chat) == "New Chat")
+    }
+
+    @Test("an empty stored title falls back to New Chat")
+    func emptyStoredTitleFallsBack() {
+        #expect(ChatsCellView.rowTitle(for: makeChat(title: "")) == "New Chat")
+    }
+
+    // MARK: - Subtitle
+
+    @Test("subtitle is the creation date, not the updated date")
+    func subtitleIsCreatedDate() {
+        let created = Date(timeIntervalSince1970: 1_760_000_000)
+        let chat = makeChat(
+            title: "q",
+            createdAt: created,
+            updatedAt: created.addingTimeInterval(86_400 * 365))
+
+        #expect(
+            ChatsCellView.rowSubtitle(for: chat)
+                == created.formatted(date: .abbreviated, time: .shortened))
+    }
+}
+#endif

--- a/Tests/WikiFSAppTests/ComposerAutocompleteHostedTests.swift
+++ b/Tests/WikiFSAppTests/ComposerAutocompleteHostedTests.swift
@@ -203,7 +203,7 @@ struct ComposerAutocompleteHostedTests {
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
-                                      title: "Erickson", score: 1.0),
+                                      title: "Erlandson", score: 1.0),
         ])
         let hooks = ComposerTextView.AutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -288,7 +288,7 @@ struct ComposerAutocompleteHostedTests {
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
-                                      title: "Erickson", score: 1.0),
+                                      title: "Erlandson", score: 1.0),
             TantivyShadowSearchResult(documentID: "page:01PAGE0002", kind: .page,
                                       title: "Erlang Guide", score: 0.9),
         ])
@@ -363,7 +363,7 @@ struct ComposerAutocompleteHostedTests {
             text: textBinding, autocomplete: hooks, measuredHeight: heightBinding, scheduler: scheduler)
         defer { Self.releaseWindow(window) }
 
-        type("[[page:Erickson]]", into: textView, coordinator: coordinator)
+        type("[[page:Erlandson]]", into: textView, coordinator: coordinator)
         #expect(scheduler.pendingCount == 0, "no schedule should be created for a closed link")
 
         await scheduler.fireAll()

--- a/Tests/WikiFSAppTests/DurableNewChatHostedTests.swift
+++ b/Tests/WikiFSAppTests/DurableNewChatHostedTests.swift
@@ -168,9 +168,7 @@ struct DurableNewChatHostedTests {
             runningKind: nil,
             preflightError: nil,
             pendingPermissions: [],
-            runStartedAt: nil,
-            projectionInput: .empty,
-            exitStatus: nil)
+            projectionInput: .empty)
 
         let deleted = ChatDetailPresentation.make(
             chatID: missingID,

--- a/Tests/WikiFSAppTests/EditorAutocompleteHostedTests.swift
+++ b/Tests/WikiFSAppTests/EditorAutocompleteHostedTests.swift
@@ -222,7 +222,7 @@ struct EditorAutocompleteHostedTests {
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
-                                      title: "Erickson", score: 1.0),
+                                      title: "Erlandson", score: 1.0),
             TantivyShadowSearchResult(documentID: "page:01PAGE0002", kind: .page,
                                       title: "Erlang Guide", score: 0.9),
         ])
@@ -259,7 +259,7 @@ struct EditorAutocompleteHostedTests {
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
-                                      title: "Erickson", score: 1.0),
+                                      title: "Erlandson", score: 1.0),
         ])
         let hooks = WikiLinkAutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -331,7 +331,7 @@ struct EditorAutocompleteHostedTests {
             text: textBinding, autocomplete: hooks, scheduler: scheduler)
         defer { Self.releaseWindow(window) }
 
-        type("[[page:Erickson]]", into: textView, coordinator: coordinator)
+        type("[[page:Erlandson]]", into: textView, coordinator: coordinator)
         #expect(scheduler.pendingCount == 0, "no schedule should be created for a closed link")
 
         await scheduler.fireAll()
@@ -438,7 +438,7 @@ struct EditorAutocompleteHostedTests {
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
-                                      title: "Erickson", score: 1.0),
+                                      title: "Erlandson", score: 1.0),
         ])
         let hooks = WikiLinkAutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },
@@ -463,7 +463,7 @@ struct EditorAutocompleteHostedTests {
         // After commit, the editor's text should reflect the canonical
         // `[[page:ULID|Title]]` form for the selected hit (the top row, since
         // nothing was explicitly arrow-key-selected).
-        #expect(textView.string == "[[page:01PAGE0001|Erickson]]",
+        #expect(textView.string == "[[page:01PAGE0001|Erlandson]]",
                 "commit should replace the trigger span with the canonical form; got \(textView.string)")
     }
 
@@ -482,7 +482,7 @@ struct EditorAutocompleteHostedTests {
         let fake = FakeAutocomplete()
         await fake.setNextResult([
             TantivyShadowSearchResult(documentID: "page:01PAGE0001", kind: .page,
-                                      title: "Erickson", score: 1.0),
+                                      title: "Erlandson", score: 1.0),
         ])
         let hooks = WikiLinkAutocompleteHooks(
             fetch: { partial, kind in await fake.fetch(partial, kind) },

--- a/Tests/WikiFSAppTests/Issue235IngestExtractionLockTests.swift
+++ b/Tests/WikiFSAppTests/Issue235IngestExtractionLockTests.swift
@@ -67,7 +67,7 @@ struct Issue235IngestExtractionLockTests {
         // text (was previously only a hidden .help() tooltip).
         let caption = ChatDetailView.composerCaptionText(
             runState: .queued,
-            hasChatID: true, isLiveChat: true,
+            isLiveChat: true,
             isChatOperationConfigured: true)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }
@@ -76,7 +76,7 @@ struct Issue235IngestExtractionLockTests {
         // Even in draft state (chatID == nil), the waiting caption shows.
         let caption = ChatDetailView.composerCaptionText(
             runState: .queued,
-            hasChatID: false, isLiveChat: false,
+            isLiveChat: false,
             isChatOperationConfigured: true)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }
@@ -84,7 +84,7 @@ struct Issue235IngestExtractionLockTests {
     @Test func captionNilWhenIdle() {
         let caption = ChatDetailView.composerCaptionText(
             runState: .idle,
-            hasChatID: true, isLiveChat: true,
+            isLiveChat: true,
             isChatOperationConfigured: true)
         #expect(caption == nil)
     }
@@ -94,7 +94,7 @@ struct Issue235IngestExtractionLockTests {
         // chat shows the "Another chat is responding" caption.
         let caption = ChatDetailView.composerCaptionText(
             runState: .answering,
-            hasChatID: true, isLiveChat: false,
+            isLiveChat: false,
             isChatOperationConfigured: true)
         #expect(caption == "Another chat is responding — wait or stop it.")
     }
@@ -104,7 +104,7 @@ struct Issue235IngestExtractionLockTests {
         // responding…" caption (replaces the old orange banner).
         let caption = ChatDetailView.composerCaptionText(
             runState: .answering,
-            hasChatID: true, isLiveChat: true,
+            isLiveChat: true,
             isChatOperationConfigured: true)
         #expect(caption == "Agent is responding…")
     }
@@ -114,7 +114,7 @@ struct Issue235IngestExtractionLockTests {
         // actionable outcome without contradictory Boolean inputs.
         let caption = ChatDetailView.composerCaptionText(
             runState: .queued,
-            hasChatID: true, isLiveChat: false,
+            isLiveChat: false,
             isChatOperationConfigured: true)
         #expect(caption == "Waiting for the other session to finish before sending…")
     }

--- a/Tests/WikiFSAppTests/MiniLMEmbedderTests.swift
+++ b/Tests/WikiFSAppTests/MiniLMEmbedderTests.swift
@@ -157,7 +157,7 @@ private func distinctLongPassages() -> [String] {
         autonomic nervous system as a layered substrate of social engagement, \
         mobilization, and shutdown. Heart rate variability serves as a non-invasive \
         window onto vagal tone, and biofeedback interventions that train slow paced \
-        breathing have shown measurable effects on autonomic balance. Hypnosis and \
+        breathing have shown measurable effects on autonomic balance. Relaxation and \
         suggestion modulate autonomic output as well, which is why clinicians pair \
         them with biofeedback for anxiety and pain regulation. The repeated finding \
         across studies is that autistic participants exhibit reduced respiratory \

--- a/Tests/WikiFSAppTests/TantivyAutocompleteTests.swift
+++ b/Tests/WikiFSAppTests/TantivyAutocompleteTests.swift
@@ -7,7 +7,7 @@ import Foundation
 /// `TantivySearchService.autocomplete(...)` (issues #436 / #638, plan §6b/§6c).
 ///
 /// Mirrors `TantivyShadowIndexTests` (in-memory content source + temp index
-/// dir per test). The headline AC is `"Erl"` → `"Erickson"` via distance-2
+/// dir per test). The headline AC is `"Erl"` → `"Erlandson"` via distance-2
 /// prefix-fuzzy on title (the #638 case the plan-reviewer corrected us on:
 /// MUST use the query-string path with `prefix: true`, NOT the structured
 /// `.fuzzy` enum which has no `prefix`).
@@ -58,11 +58,11 @@ struct TantivyAutocompleteTests {
             contentSource: source)
     }
 
-    // MARK: - AC #1: "Erl" → "Erickson" (the #638 headline case)
+    // MARK: - AC #1: "Erl" → "Erlandson" (the #638 headline case)
 
     @Test func shortPrefixSurfacesLongerTitleViaPrefixFuzzy() async throws {
         // This is the headline AC of #638. A naive whole-token edit-distance
-        // query would score "Erl" as distance-6 from "Erickson" and miss it.
+        // query would score "Erl" as distance-6 from "Erlandson" and miss it.
         // The query-string path with `prefix: true` (the reviewer correction)
         // is what makes this work — the fuzzy automaton expands as a prefix.
         let (indexDir, fm) = makeTempDir()
@@ -71,7 +71,7 @@ struct TantivyAutocompleteTests {
         let source = InMemoryContentSource()
         let service = try makeService(source: source, dir: indexDir)
 
-        await source.upsert(makeSnapshot(ulid: "01PAGE00001", kind: .page, title: "Erickson"))
+        await source.upsert(makeSnapshot(ulid: "01PAGE00001", kind: .page, title: "Erlandson"))
         await source.upsert(makeSnapshot(ulid: "01PAGE00002", kind: .page, title: "Erlang"))
         await source.upsert(makeSnapshot(ulid: "01PAGE00003", kind: .page, title: "Erie"))
         await service.indexer.upsert(ulid: "01PAGE00001", kind: .page)
@@ -81,8 +81,8 @@ struct TantivyAutocompleteTests {
         let hits = await service.autocomplete(
             partial: "Erl", kinds: [.page], distance: 2, limit: 8)
 
-        #expect(hits.contains { $0.title == "Erickson" },
-                "AC #1: 'Erl' must surface 'Erickson' via prefix-fuzzy — the #638 headline")
+        #expect(hits.contains { $0.title == "Erlandson" },
+                "AC #1: 'Erl' must surface 'Erlandson' via prefix-fuzzy — the #638 headline")
         #expect(hits.contains { $0.title == "Erlang" })
         #expect(hits.contains { $0.title == "Erie" })
     }
@@ -90,20 +90,20 @@ struct TantivyAutocompleteTests {
     // MARK: - AC #2: typo tolerance (distance 1–2)
 
     @Test func typoDistanceOneSurfacesTarget() async throws {
-        // `Erlckson` is edit-distance 1 from `Erickson` (extra `l`).
+        // `Erlanson` is edit-distance 1 from `Erlandson` (deleted `d`).
         let (indexDir, fm) = makeTempDir()
         defer { try? fm.removeItem(at: indexDir) }
 
         let source = InMemoryContentSource()
         let service = try makeService(source: source, dir: indexDir)
 
-        await source.upsert(makeSnapshot(ulid: "01PAGE00010", kind: .page, title: "Erickson"))
+        await source.upsert(makeSnapshot(ulid: "01PAGE00010", kind: .page, title: "Erlandson"))
         await service.indexer.upsert(ulid: "01PAGE00010", kind: .page)
 
         let hits = await service.autocomplete(
-            partial: "Erlckson", kinds: [.page], distance: 2, limit: 8)
+            partial: "Erlanson", kinds: [.page], distance: 2, limit: 8)
 
-        #expect(hits.contains { $0.title == "Erickson" },
+        #expect(hits.contains { $0.title == "Erlandson" },
                 "AC #2: a distance-1 typo on a longer title should still resolve")
     }
 

--- a/Tests/WikiFSTests/AgentPresentationPreambleTests.swift
+++ b/Tests/WikiFSTests/AgentPresentationPreambleTests.swift
@@ -7,7 +7,7 @@ import WikiFSCore
 /// removal preserves them. Unrelated warnings always survive.
 @Suite struct AgentPresentationPreambleTests {
     private static let sentence =
-        "Warning: Skill descriptions were shortened to fit the 2% skills context budget."
+        AgentPresentationPreamble.knownWarningSentence
 
     /// Every incremental proper prefix — including mid-word cut points — plus
     /// the complete warning itself is hidden under the streaming policy.

--- a/Tests/WikiFSTests/AgentProvidersConfigStoreTests.swift
+++ b/Tests/WikiFSTests/AgentProvidersConfigStoreTests.swift
@@ -3,6 +3,14 @@ import Testing
 @testable import WikiFSCore
 
 @Suite(.serialized) struct AgentProvidersConfigStoreTests {
+    // CI's 3-vCPU runner starves the cooperative pool under the full parallel
+    // suite (neighboring trivial tests wall-clock ~29 s there), so the store's
+    // 5 s production lock deadline can elapse on scheduler delay alone —
+    // delayed `Task.sleep` resumptions count against it even though the lock
+    // holder released in microseconds. These tests assert serialization
+    // semantics, not lock latency, so give the deadline starvation headroom.
+    private static let lockTimeout: Duration = .seconds(60)
+
     private func directory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("provider-store-\(UUID().uuidString)", isDirectory: true)
@@ -14,8 +22,8 @@ import Testing
         let directory = try directory()
         defer { try? FileManager.default.removeItem(at: directory) }
         try AgentProvidersConfig.seed(discovered: []).writeAtomically(to: directory)
-        let first = AgentProvidersConfigStore(directory: directory)
-        let second = AgentProvidersConfigStore(directory: directory)
+        let first = AgentProvidersConfigStore(directory: directory, lockTimeout: Self.lockTimeout)
+        let second = AgentProvidersConfigStore(directory: directory, lockTimeout: Self.lockTimeout)
         async let selected = first.mutate {
             $0.settingSelectedModel(ModelID(rawValue: "opus"), forProvider: ProviderID(rawValue: "claude-acp"))
         }
@@ -38,6 +46,7 @@ import Testing
         let signals = SignalCounter()
         let store = AgentProvidersConfigStore(
             directory: directory,
+            lockTimeout: Self.lockTimeout,
             write: { _, _ in throw TestFailure.write },
             postLocal: { _ in signals.incrementLocal() },
             postDarwin: { signals.incrementDarwin() })
@@ -58,6 +67,7 @@ import Testing
         let observed = GenerationRecorder(directory: directory)
         let store = AgentProvidersConfigStore(
             directory: directory,
+            lockTimeout: Self.lockTimeout,
             postLocal: { _ in observed.record() },
             postDarwin: { observed.record() })
         _ = try await store.mutate {
@@ -66,7 +76,7 @@ import Testing
         #expect(observed.snapshot() == [1, 1])
         // A second coordinator can acquire immediately, proving signals ran
         // after the first coordinator released the kernel and process gates.
-        let second = try await AgentProvidersConfigStore(directory: directory).mutate { $0 }
+        let second = try await AgentProvidersConfigStore(directory: directory, lockTimeout: Self.lockTimeout).mutate { $0 }
         #expect(second.generation == 2)
     }
 }

--- a/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
+++ b/Tests/WikiFSTests/BookmarkNodeStoreTests.swift
@@ -666,7 +666,7 @@ private struct FixedRendererEventClock: RendererEventClock {
         #expect(first.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='renderer_event_journal';") == "1")
 
         let reopened = try store(url: url)
-        #expect(reopened.pragmaValue("user_version") == "52")
+        #expect(reopened.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
         #expect(try reopened.listRendererWikiEnablement().isEmpty)
     }
 
@@ -848,13 +848,13 @@ private struct FixedRendererEventClock: RendererEventClock {
         #expect(try MetadataSQLiteFixtureSupport.scalar("PRAGMA user_version", at: url) == "48")
 
         let upgraded = try store(url: url)
-        #expect(upgraded.pragmaValue("user_version") == "52")
+        #expect(upgraded.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
         #expect(upgraded.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='renderer_wiki_enablement';") == "1")
         #expect(upgraded.scalarText("SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='renderer_event_journal_scope_sequence';") == "1")
         upgraded.close()
 
         let reopened = try store(url: url)
-        #expect(reopened.pragmaValue("user_version") == "52")
+        #expect(reopened.pragmaValue("user_version") == "\(GRDBWikiStore.schemaVersion)")
         #expect(try reopened.listRendererWikiEnablement().isEmpty)
     }
 

--- a/Tests/WikiFSTests/ChatStoreTests.swift
+++ b/Tests/WikiFSTests/ChatStoreTests.swift
@@ -229,7 +229,7 @@ import SQLite3
     /// AC.2: a fresh schema has the `acp_session_id` column on the chats table.
     @Test func freshSchemaHasChatAcpSessionIdColumn() throws {
         let store = try tempStore()
-        #expect(GRDBWikiStore.schemaVersion == 52)
+        #expect(GRDBWikiStore.schemaVersion >= 53)
         let hasCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='acp_session_id';")
         #expect(hasCol == "1")
@@ -317,7 +317,7 @@ import SQLite3
     /// A fresh schema has the `model_provider_id`/`model_id` columns on `chats`.
     @Test func freshSchemaHasChatModelOverrideColumns() throws {
         let store = try tempStore()
-        #expect(GRDBWikiStore.schemaVersion == 52)
+        #expect(GRDBWikiStore.schemaVersion >= 53)
         let hasProviderCol = store.scalarText(
             "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name='model_provider_id';")
         #expect(hasProviderCol == "1")
@@ -439,7 +439,7 @@ import SQLite3
         raw = nil
 
         let migrated = try GRDBWikiStore(databaseURL: url)
-        #expect(migrated.pragmaValue("user_version") == "52")
+        #expect(migrated.pragmaValue("user_version") == "53")
         let existing = try migrated.getChat(id: ChatID(rawValue: "existing-chat"))
         #expect(existing.configuredThinkingOptionID == nil)
         #expect(existing.effectiveThinkingOptionID == nil)

--- a/Tests/WikiFSTests/ChatSummaryTests.swift
+++ b/Tests/WikiFSTests/ChatSummaryTests.swift
@@ -4,22 +4,12 @@ import Foundation
 @testable import WikiFSEngine
 import Testing
 
-/// Tests for the chat-summary feature (issue #411).
-///
-/// `chats.summary` is the chats-list row subtitle — the gist of the OPENING
-/// answer, not a summary of the whole conversation. It is no longer computed
-/// separately: it MIRRORS the first summarizable message's `chat_messages.summary`,
-/// so it inherits that summarizer's mode (Default ⇒ truncated extract, Model ⇒
-/// the model's sentence verbatim). Before the unification the launcher wrote its
-/// own always-truncated version, which abbreviated the subtitle even in Model mode.
-///
-/// Three layers:
-///   - **Pure extract** — `ChatSummary.summaryExtract(from:maxLength:)` is a
-///     pure function; these tests run in the fast tier.
-///   - **Source selection** — `MessageSummarizer.chatSummaryMessageID(in:)`
-///     picks which message feeds the chat row; pure, fast tier.
-///   - **Store round-trip** — `updateChatSummary` + `listChats()` on a real
-///     SQLite DB; tagged `.integration` (opens a real store).
+/// Tests for the pure summary-extract logic that survives the chat-summary
+/// feature's chat-level removal: `ChatSummary.summaryExtract(from:maxLength:)`
+/// still shapes the per-message Default-mode summaries (which feed the
+/// outline's response text). The chat-level `chats.summary` column and its
+/// mirror were removed (schema v53); per-message summaries live in
+/// `chat_messages.summary` and are covered by `MessageSummaryTests`.
 @Suite
 struct ChatSummaryTests {
 
@@ -55,108 +45,6 @@ struct ChatSummaryTests {
         let input = "Short text."
         let result = ChatSummary.summaryExtract(from: input)
         #expect(result == "Short text.")
-    }
-
-    // MARK: - Chat-summary source selection: MessageSummarizer.chatSummaryMessageID
-
-    /// Build a `ChatMessage` list from events with deterministic ids ("m0", "m1", …).
-    private func messages(_ events: [AgentEvent]) -> [ChatMessage] {
-        events.enumerated().map { idx, event in
-            ChatMessage(
-                id: PageID(rawValue: "m\(idx)"), chatID: ChatID(rawValue: "chat"),
-                seq: idx, event: event, createdAt: Date(timeIntervalSince1970: 0))
-        }
-    }
-
-    @Test func chatSummaryMessageID_picksFirstAssistantMessage() {
-        // The chat subtitle mirrors the FIRST assistant response's summary —
-        // later assistant turns never overwrite it.
-        let msgs = messages([
-            .userText("question"),
-            .assistantText("First answer."),
-            .assistantText("Second answer."),
-        ])
-        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == PageID(rawValue: "m1"))
-    }
-
-    @Test func chatSummaryMessageID_acceptsResultEvent() {
-        // Agents that emit everything in .result still seed the chat summary.
-        let msgs = messages([
-            .toolUse(name: "Bash", inputSummary: "ls"),
-            .result(isError: false, text: "The answer is 42."),
-        ])
-        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == PageID(rawValue: "m1"))
-    }
-
-    @Test func chatSummaryMessageID_skipsWhitespaceOnlyText() {
-        // A blank assistant message is not a summary source — the next one is.
-        let msgs = messages([
-            .assistantText("   "),
-            .assistantText("Real answer."),
-        ])
-        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == PageID(rawValue: "m1"))
-    }
-
-    @Test func chatSummaryMessageID_onlyNonAssistantEvents_returnsNil() {
-        let msgs = messages([
-            .userText("question"),
-            .toolUse(name: "Bash", inputSummary: "ls"),
-            .toolResult(isError: false, summary: "file.txt"),
-        ])
-        #expect(MessageSummarizer.chatSummaryMessageID(in: msgs) == nil)
-    }
-
-    @Test func chatSummaryMessageID_emptyMessages_returnsNil() {
-        #expect(MessageSummarizer.chatSummaryMessageID(in: []) == nil)
-    }
-
-    // MARK: - Store round-trip (integration)
-
-    @Test
-    func summaryRoundTrip_updateAndReadBack() throws {
-        let store = try TestStoreFactory.inMemory()
-        let chat = try store.createChat(kind: .edit, title: "Test Chat")
-
-        // Before: no summary.
-        let before = try store.listChats().first { $0.id == chat.id }
-        #expect(before?.summary == nil)
-        #expect(before?.summaryAt == nil)
-
-        // After: summary is populated.
-        try store.updateChatSummary(chatID: chat.id, summary: "A concise summary.")
-        let after = try store.listChats().first { $0.id == chat.id }
-        #expect(after?.summary == "A concise summary.")
-        #expect(after?.summaryAt != nil)
-    }
-
-    @Test
-    func summaryNullForExistingChats_afterMigration() throws {
-        // A fresh DB is already at v36; createChat inserts a row with NULL
-        // summary/summary_at. listChats() must return nil for both.
-        let store = try TestStoreFactory.inMemory()
-        let chat = try store.createChat(kind: .edit, title: "No Summary Chat")
-
-        let row = try store.listChats().first { $0.id == chat.id }
-        #expect(row != nil)
-        #expect(row?.summary == nil)
-        #expect(row?.summaryAt == nil)
-    }
-
-    @Test
-    func summaryBumpsUpdatedAt() async throws {
-        let store = try TestStoreFactory.inMemory()
-        let chat = try store.createChat(kind: .edit, title: "Timestamp Chat")
-        let before = try store.listChats().first { $0.id == chat.id }
-        let originalUpdatedAt = before?.updatedAt
-
-        // Small delay to ensure timestamps differ.
-        // Use Task.sleep to avoid blocking the cooperative thread pool (#732).
-        try await Task.sleep(for: .milliseconds(10))
-        try store.updateChatSummary(chatID: chat.id, summary: "Updated.")
-
-        let after = try store.listChats().first { $0.id == chat.id }
-        #expect(after?.updatedAt != originalUpdatedAt)
-        #expect(after?.updatedAt ?? Date.distantPast > originalUpdatedAt ?? Date.distantPast)
     }
 }
 #endif // os(macOS)

--- a/Tests/WikiFSTests/ChatTitleTests.swift
+++ b/Tests/WikiFSTests/ChatTitleTests.swift
@@ -32,4 +32,28 @@ import Foundation
     @Test func emptyMessageFallsBackToNewChat() {
         #expect(ChatSummary.title(fromFirstMessage: "") == "New Chat")
     }
+
+    // MARK: - Injected skills-budget preamble
+
+    private static let warning =
+        AgentPresentationPreamble.knownWarningSentence
+
+    @Test("warning-prefixed message derives the title from the real question")
+    func warningPrefixStrippedFromTitle() {
+        let message = "\(Self.warning)\n\nWhat is a tide pool?"
+        #expect(ChatSummary.title(fromFirstMessage: message)
+                == "What is a tide pool?")
+    }
+
+    @Test("a warning-only message derives to New Chat")
+    func warningOnlyMessageFallsBackToNewChat() {
+        #expect(ChatSummary.title(fromFirstMessage: Self.warning) == "New Chat")
+        #expect(ChatSummary.title(fromFirstMessage: "\(Self.warning)\n\n") == "New Chat")
+    }
+
+    @Test("an unrelated Warning: line is preserved — only the known family is stripped")
+    func unrelatedWarningLinesArePreserved() {
+        let message = "Warning: the disk is nearly full\nplease check"
+        #expect(ChatSummary.title(fromFirstMessage: message) == "Warning: the disk is nearly full")
+    }
 }

--- a/Tests/WikiFSTests/ChatTurnMetadataStoreTests.swift
+++ b/Tests/WikiFSTests/ChatTurnMetadataStoreTests.swift
@@ -3,8 +3,8 @@ import Testing
 @testable import WikiFSCore
 
 struct ChatTurnMetadataStoreTests {
-    @Test func schemaVersionIs52() {
-        #expect(GRDBWikiStore.schemaVersion == 52)
+    @Test func schemaVersionIsCurrent() {
+        #expect(GRDBWikiStore.schemaVersion >= 53)
     }
 
     @Test func usageIsKeyedByChatAndTurn() throws {

--- a/Tests/WikiFSTests/Fixtures/ChatAPISignatures.txt
+++ b/Tests/WikiFSTests/Fixtures/ChatAPISignatures.txt
@@ -15,7 +15,6 @@ Sources/WikiFSCore/Store/WikiStore.swift	func appendChatMessages(chatID: ChatID,
 Sources/WikiFSCore/Store/WikiStore.swift	func chatMessages(chatID: ChatID) throws -> [ChatMessage]
 Sources/WikiFSCore/Store/WikiStore.swift	func renameChat(id: ChatID, to title: String) throws
 Sources/WikiFSCore/Store/WikiStore.swift	func deleteChat(id: ChatID) throws
-Sources/WikiFSCore/Store/WikiStore.swift	func updateChatSummary(chatID: ChatID, summary: String) throws
 Sources/WikiFSCore/Store/WikiStore.swift	func updateChatAcpSessionId(chatID: ChatID, acpSessionId: AcpSessionID?) throws
 Sources/WikiFSCore/Store/WikiStore.swift	func updateChatModelOverride(id: ChatID, providerId: ProviderID?, modelId: ModelID?) throws
 Sources/WikiFSCore/Store/WikiStore.swift	        chatID: ChatID,
@@ -40,7 +39,6 @@ Sources/WikiFSCore/Store/WikiStore.swift	func missingChatEmbeddingWork() -> [(id
 Sources/WikiFSCore/Store/GRDBWikiStore.swift	public func getChat(id: ChatID) throws -> ChatSummary
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func selectChat(byID id: ChatID, anchor: String? = nil, openInNewTab: Bool = false) -> Bool {
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func getChat(id: ChatID) -> ChatSummary?
-Sources/WikiFSCore/Store/WikiStoreModel.swift	public func updateChatSummary(chatID: ChatID, summary: String) {
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func updateChatAcpSessionId(chatID: ChatID, acpSessionId: AcpSessionID?) {
 Sources/WikiFSCore/Store/WikiStoreModel.swift	public func deleteChat(id: ChatID) {
 Sources/WikiFSEngine/AgentLauncher.swift	public var activeChatID: ChatID?

--- a/Tests/WikiFSTests/InMemoryStoreTests.swift
+++ b/Tests/WikiFSTests/InMemoryStoreTests.swift
@@ -65,17 +65,17 @@ struct InMemoryStoreTests {
         // cleanly on the `:memory:` `DatabaseQueue` (no WAL pragma, no
         // file-based checkpoint).
         let store = try TestStoreFactory.inMemory()
-        _ = try store.createPage(title: "Hypnosis")
+        _ = try store.createPage(title: "Photosynthesis")
         let page = try store.createPage(title: "Notes")
         try store.updatePage(id: page.id, title: "Notes",
-                             body: "Details about clinical hypnosis and suggestion.")
+                             body: "Details about plant photosynthesis and respiration.")
         // nil leg → no BM25 results (FTS5 dropped; cosine gated).
-        #expect(try store.searchSimilar(query: "hypnosis", limit: 10, bm25Leg: nil).isEmpty)
+        #expect(try store.searchSimilar(query: "photosynthesis", limit: 10, bm25Leg: nil).isEmpty)
         // Fabricated leg targeting the page → pass-through unchanged.
         let leg = [WikiPageSummary(
             id: page.id, title: page.title,
             updatedAt: page.updatedAt, createdAt: page.createdAt)]
-        let hits = try store.searchSimilar(query: "hypnosis", limit: 10, bm25Leg: leg)
+        let hits = try store.searchSimilar(query: "photosynthesis", limit: 10, bm25Leg: leg)
         #expect(hits.contains { $0.id == page.id })
     }
 

--- a/Tests/WikiFSTests/MessageSummaryTests.swift
+++ b/Tests/WikiFSTests/MessageSummaryTests.swift
@@ -186,6 +186,40 @@ struct MessageSummaryTests {
         #expect(counts.2 == 1, "cancelCount")
     }
 
+    @Test func modelSummary_stripsKnownPreambleFromBackendReply() async {
+        // The summarizer backend is itself an ACP agent and may prepend the
+        // known skills-budget warning to its own reply. The warning must
+        // never land in a cached per-message summary (chat_messages.summary,
+        // which feeds the outline's response text).
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [
+                .assistantText("\(AgentPresentationPreamble.knownWarningSentence)\n\nA concise summary."),
+                .messageStop,
+            ])
+        ])
+        let profile = BackendProfile()
+        let result = await MessageSummarizer.modelSummary(
+            text: "Some long assistant text that needs summarizing.",
+            backend: backend,
+            profile: profile)
+        #expect(result == "A concise summary.")
+    }
+
+    @Test func modelSummary_warningOnlyReply_returnsNil() async {
+        // A reply that is only the known preamble yields nothing usable —
+        // the caller leaves summary = NULL so the message is retriable.
+        let backend = FakeAgentBackend(behaviors: [
+            FakeSessionBehavior(events: [
+                .assistantText(AgentPresentationPreamble.knownWarningSentence),
+                .messageStop,
+            ])
+        ])
+        let profile = BackendProfile()
+        let result = await MessageSummarizer.modelSummary(
+            text: "Content.", backend: backend, profile: profile)
+        #expect(result == nil)
+    }
+
     @Test func modelSummary_resultEventFallback() async {
         // Some agents emit everything in .result instead of streaming
         // .assistantText — modelSummary should take it as fallback (mirrors
@@ -480,7 +514,7 @@ struct MessageSummaryTests {
         // A message that ONLY carries the ACP skills-budget warning has
         // nothing to summarize — it must never become a summary, the
         // chats.summary, or a title input.
-        let warning = "Warning: Skill descriptions were shortened to fit the 2% skills context budget. "
+        let warning = "\(AgentPresentationPreamble.knownWarningSentence) "
         #expect(MessageSummarizer.textToSummarize(from: .assistantText(warning)) == nil)
 
         // A message that OPENS with the warning keeps the content after it.
@@ -497,7 +531,7 @@ struct MessageSummaryTests {
     /// The summarizer now removes ONLY the known skill warning — never an
     /// arbitrary `Warning:` line — and keeps a final incomplete prefix.
     @Test func textToSummarizeRemovesKnownSkillWarning() {
-        let sentence = "Warning: Skill descriptions were shortened to fit the 2% skills context budget."
+        let sentence = AgentPresentationPreamble.knownWarningSentence
         // Complete warning-only: nothing to summarize.
         #expect(MessageSummarizer.textToSummarize(from: .assistantText(sentence)) == nil)
         #expect(MessageSummarizer.textToSummarize(from: .assistantText(sentence + "\n\n")) == nil)

--- a/Tests/WikiFSTests/PageVersionTests.swift
+++ b/Tests/WikiFSTests/PageVersionTests.swift
@@ -642,12 +642,12 @@ struct PageVersionTests {
 
     /// Migration ladder sanity: a fresh DB reports the current schema after
     /// adding durable configured/effective chat thinking selection.
-    @Test func v52SchemaVersionAfterMigration() throws {
-        #expect(GRDBWikiStore.schemaVersion == 52,
+    @Test func freshDBStampsCurrentSchemaVersion() throws {
+        #expect(GRDBWikiStore.schemaVersion >= 53,
                 "schemaVersion must report the current migration version")
         let store = try tempStore()
         let v = store.pragmaValue("user_version")
-        #expect(v == "52", "fresh DB stamps user_version = 52 (got \(v))")
+        #expect(v == "\(GRDBWikiStore.schemaVersion)", "fresh DB stamps user_version = current (got \(v))")
     }
 
     // MARK: - #817: pageVersionBody (read arbitrary version body)

--- a/Tests/WikiFSTests/SchemaMigrationLadderTests.swift
+++ b/Tests/WikiFSTests/SchemaMigrationLadderTests.swift
@@ -7,7 +7,7 @@ import SQLite3
 #endif
 @testable import WikiFSCore
 
-@Suite struct SchemaV52MigrationTests {
+@Suite struct SchemaMigrationLadderTests {
     @Test func freshSchemaContainsOKFTrustTablesAndIndexes() throws {
         let store = try TestStoreFactory.inMemory()
         for table in [
@@ -26,19 +26,47 @@ import SQLite3
             #expect(store.scalarText(
                 "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='\(index)';") == "1")
         }
-        #expect(store.pragmaValue("user_version") == "52")
+        #expect(store.pragmaValue("user_version") == "53")
     }
 
     @Test func v51MigratesWithoutBackfillOrDataLoss() throws {
         let fixture = try v51Fixture()
         let migrated = try GRDBWikiStore(databaseURL: fixture.url)
-        #expect(migrated.pragmaValue("user_version") == "52")
+        #expect(migrated.pragmaValue("user_version") == "53")
         #expect(try migrated.getPage(id: fixture.pageID).title == "Historical page")
         #expect(try migrated.getSource(id: fixture.sourceID).filename == "historical.txt")
         #expect(migrated.scalarText("SELECT COUNT(*) FROM page_okf_metadata;") == "0")
         #expect(migrated.scalarText("SELECT COUNT(*) FROM source_markdown_okf_metadata;") == "0")
         #expect(migrated.scalarText("SELECT COUNT(*) FROM page_okf_verifications;") == "0")
         #expect(migrated.scalarText("SELECT COUNT(*) FROM source_markdown_okf_verifications;") == "0")
+    }
+
+    @Test func v52DBWithChatSummaryColumnsMigratesToV53() throws {
+        // A v52 database still carries `chats.summary`/`summary_at` (the
+        // mirrored one-line answer summary). Reintroduce them by hand on a
+        // file-backed store, stamp back to 52, and reopen: the migration
+        // must drop both columns and stamp 53.
+        let pair = try TestStoreFactory.fileBacked(prefix: "schema-v53")
+        pair.store.close()
+        try MetadataSQLiteFixtureSupport.execute("""
+        ALTER TABLE chats ADD COLUMN summary TEXT;
+        ALTER TABLE chats ADD COLUMN summary_at REAL;
+        INSERT INTO chats (id, kind, title, created_at, updated_at, summary, summary_at)
+        VALUES ('survivor', 'edit', 'Survivor', 1, 1, 'tainted summary', 2);
+        INSERT INTO chat_messages (id, chat_id, seq, role, event_json, text, created_at)
+        VALUES ('m1', 'survivor', 0, 'user', '{"userText":{"_0":"Why?"}}', 'Why?', 1);
+        PRAGMA user_version = 52;
+        """, at: pair.url)
+
+        let migrated = try GRDBWikiStore(databaseURL: pair.url)
+        #expect(migrated.pragmaValue("user_version") == "53")
+        #expect(migrated.scalarText(
+            "SELECT COUNT(*) FROM pragma_table_info('chats') WHERE name IN ('summary', 'summary_at');") == "0")
+        // The drop must not lose the rows the columns rode on (F12b).
+        #expect(migrated.scalarText(
+            "SELECT title FROM chats WHERE id = 'survivor';") == "Survivor")
+        #expect(migrated.scalarText(
+            "SELECT COUNT(*) FROM chat_messages WHERE chat_id = 'survivor';") == "1")
     }
 
     @Test func v52MigrationEnforcesTargetForeignKeysAndStatusChecks() throws {
@@ -73,7 +101,7 @@ import SQLite3
         store = nil
 
         let reopened = try GRDBWikiStore(databaseURL: fixture.url)
-        #expect(reopened.pragmaValue("user_version") == "52")
+        #expect(reopened.pragmaValue("user_version") == "53")
         #expect(try reopened.pageOKFMetadata(
             versionID: fixture.pageVersionID, includeCorrected: false)?.metadata.status == .stable)
     }

--- a/Tests/WikiFSTests/SemanticSearchSwiftCosineTests.swift
+++ b/Tests/WikiFSTests/SemanticSearchSwiftCosineTests.swift
@@ -271,7 +271,7 @@ struct SemanticSearchSwiftCosineTests {
         let bm25Leg = [ChatSummary(
             id: chatB.id, kind: chatB.kind, title: chatB.title,
             createdAt: chatB.createdAt, updatedAt: chatB.updatedAt,
-            messageCount: 0, summary: nil, summaryAt: nil)]
+            messageCount: 0)]
         let hits = try store.searchSimilarChats(query: "alpha", limit: 10, bm25Leg: bm25Leg)
         #expect(hits.count == 2)
         // chatB (dual-leg) ranks first due to RRF boosting.

--- a/Tests/WikiFSTests/SourceVersionIDPersistenceTests.swift
+++ b/Tests/WikiFSTests/SourceVersionIDPersistenceTests.swift
@@ -13,7 +13,7 @@ import Testing
 /// `sources.id` and markdown-version `PageID`s.
 struct SourceVersionIDPersistenceTests {
 
-    private let currentSchemaVersion = "52"
+    private var currentSchemaVersion: String { "\(GRDBWikiStore.schemaVersion)" }
     private let legacySourceID = "01JSOURCEVERSIONFIXTURE000001"
     private let legacyVersionV1 = "01JSOURCEVERSION000000000001"
     private let legacyVersionV2 = "01JSOURCEVERSION000000000002"

--- a/Tests/WikiFSTests/TantivyBM25LegCutoverTests.swift
+++ b/Tests/WikiFSTests/TantivyBM25LegCutoverTests.swift
@@ -121,7 +121,7 @@ import Testing
         let leg = [ChatSummary(
             id: chat.id, kind: chat.kind, title: chat.title,
             createdAt: chat.createdAt, updatedAt: chat.updatedAt,
-            messageCount: chat.messageCount, summary: nil, summaryAt: nil)]
+            messageCount: chat.messageCount)]
         let fused = try store.searchSimilarChats(query: "budget", limit: 10, bm25Leg: leg)
         #expect(fused.count == 1)
         #expect(fused.first?.id == chat.id)

--- a/Tests/WikiFSTests/WikiCtlCommandTests.swift
+++ b/Tests/WikiFSTests/WikiCtlCommandTests.swift
@@ -895,10 +895,10 @@ struct WikiCtlCommandTests {
     @Test func resolveByDisplayName() throws {
         let store = try tempStore()
         let ingested = try store.addSource(filename: "Matthews1999.pdf", data: Data("raw".utf8))
-        try store.renameSource(id: ingested.id, to: "Ericksonian Hypnosis: A Review")
+        try store.renameSource(id: ingested.id, to: "Cognitive Ethology: A Review")
         // Agent sees display name in `source list`, should be able to use it.
         let result = try SourceCommand.run(
-            .cat(.name("Ericksonian Hypnosis: A Review"), markdown: false), in: store, cwd: "/tmp")
+            .cat(.name("Cognitive Ethology: A Review"), markdown: false), in: store, cwd: "/tmp")
         #expect(result.payload == .bytes(Data("raw".utf8)))
     }
 

--- a/Tests/WikiFSTests/WikiLinkPrefixScannerTests.swift
+++ b/Tests/WikiFSTests/WikiLinkPrefixScannerTests.swift
@@ -42,11 +42,11 @@ struct WikiLinkPrefixScannerTests {
 
     @Test func bareOpenBracketsDefaultToPage() {
         // Per WikiLinkParser.classify (:52), bare `[[Foo` is a page link.
-        let text = "Some text [[Erickson"
+        let text = "Some text [[Erlandson"
         let caret = text.count
         let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
         #expect(trigger?.kind == .page)
-        #expect(trigger?.partial == "Erickson")
+        #expect(trigger?.partial == "Erlandson")
     }
 
     // MARK: - Rejection: closed/aliased links (AC #6 — don't fire once closed)
@@ -142,14 +142,14 @@ struct WikiLinkPrefixScannerTests {
     // MARK: - Caret position mid-text
 
     @Test func caretMidTokenReadsPartialPrefix() {
-        // `[[page:Erickson` with the caret after "Eri" should yield partial "Eri".
-        let text = "[[page:Erickson"
-        let caret = "[[page:Eri".count
+        // `[[page:Erlandson` with the caret after "Erla" should yield partial "Erla".
+        let text = "[[page:Erlandson"
+        let caret = "[[page:Erla".count
         let trigger = WikiLinkPrefixScanner.openLink(at: caret, in: text)
-        #expect(trigger?.partial == "Eri")
-        // Range covers only `[[page:Eri` (up to the caret).
+        #expect(trigger?.partial == "Erla")
+        // Range covers only `[[page:Erla` (up to the caret).
         let span = String(text[trigger!.range])
-        #expect(span == "[[page:Eri")
+        #expect(span == "[[page:Erla")
     }
 
     @Test func caretAfterClosedLinkAndNewOpenLinkDetectsTheNewOne() {

--- a/plans/chat-summary.md
+++ b/plans/chat-summary.md
@@ -23,7 +23,7 @@ There are **two existing "summary" surfaces** — do not confuse them:
 
 | Surface | Granularity | Storage | Compute | Status |
 |---|---|---|---|---|
-| `ChatSummary.summary` / `summaryAt` | **One row per CHAT** (issue #411) | `chats.summary` + `chats.summary_at` columns | first-sentence truncation, run once in `AgentLauncher.finish()` | **Shipped.** Leave as-is. |
+| `ChatSummary.summary` / `summaryAt` | **One row per CHAT** (issue #411) | `chats.summary` + `chats.summary_at` columns | first-sentence truncation, run once in `AgentLauncher.finish()` | **Removed** — schema v53, 2026-09-12 (#1262): the column is no longer read anywhere. |
 | `ChatOutlineEntry.response` | **One per turn** (UI-only, recomputed on render) | none — recomputed every render via `ChatSummary.summaryExtract` | first-sentence truncation, on the fly | **Shipped.** This is the site we extend. |
 
 **This feature** adds a **per-message** (`chat_messages`) summary that is:

--- a/plans/search-fts5-hybrid.md
+++ b/plans/search-fts5-hybrid.md
@@ -11,7 +11,7 @@ Make search actually work. Today it is either **broken** (the sqlite-vec semanti
 layer never loads — macOS system SQLite is built with `SQLITE_OMIT_LOAD_EXTENSION`,
 so `sqlite3_load_extension` / `sqlite3_enable_load_extension` don't exist and `dlsym`
 returns NULL) or it degrades to **filename-only `LIKE`**. Neither path reads the
-document body, so a query like `hypnosis` finds nothing.
+document body, so a query like `photosynthesis` finds nothing.
 
 This plan adds three things:
 
@@ -26,7 +26,7 @@ This plan adds three things:
 
 Verified facts grounding this plan:
 - `PRAGMA compile_options` → `ENABLE_FTS5`, `OMIT_LOAD_EXTENSION` (system SQLite).
-- `bm25()` + `MATCH 'hypnosis'` returns the matching row on the system SQLite.
+- `bm25()` + `MATCH 'photosynthesis'` returns the matching row on the system SQLite.
 - The running app logs: `loadVecExtension: dlsym FAILED … semantic search disabled`
   → `searchSimilarSources: … vec=false` → `LIKE FALLBACK (body NOT searched)`.
 - `pages` and `sources` are normal **rowid** tables (no `WITHOUT ROWID`), so
@@ -127,7 +127,7 @@ RRF_score(d) = Σ_i  1 / (k + rank_i(d))      // k = 60 (standard)
 ## Acceptance Criteria
 
 - **AC.1** Exact body term with zero filename overlap returns the source/page (the
-  `hypnosis` case) — FTS, works under `swift test`.
+  `photosynthesis` case) — FTS, works under `swift test`.
 - **AC.2** Paraphrase query returns the relevant doc when vec is available (cosine).
 - **AC.3** A doc ranking high in **both** vec and FTS ranks above one in only one (RRF).
 - **AC.4** vec unavailable → search still returns results (FTS-only); never an empty

--- a/progress/2026-06-29T151010Z-unified-self-healing-hybrid-search-removed-manual-reindex.md
+++ b/progress/2026-06-29T151010Z-unified-self-healing-hybrid-search-removed-manual-reindex.md
@@ -40,7 +40,7 @@ pre-existing sources. Verified via `DebugLog` + direct sqlite counts.
 **Verified:** `swift build` clean; **1202 tests pass**. Against a snapshot copy
 of the real DB, applying the FTS self-heal steps took `source_search` 0→71 and
 `sources_fts` 0→71, and the bm25 query returned relevant hits for "dissociation"
-and "hypnosis". (The embedding half can't run under raw sqlite3 — it needs
+and "photosynthesis". (The embedding half can't run under raw sqlite3 — it needs
 `NLEmbedding` — but is the same path covered by unit tests; it populates on the
 app's next open.)
 

--- a/progress/2026-09-12T180000Z-chat-list-date-title.md
+++ b/progress/2026-09-12T180000Z-chat-list-date-title.md
@@ -1,0 +1,149 @@
+---
+timestamp: 2026-09-12T180000Z
+title: Chat list rows — summary-or-question title, created-date subtitle
+branch: feature/chat-list-date-title
+status: complete
+---
+
+# Chat list rows — summary-or-question title, created-date subtitle
+
+## Progress
+
+Several chats carried the persisted title "Warning: Skill descriptions were
+shortened to fit the 2% skills context budget." The known agent preamble
+(`AgentPresentationPreamble.knownWarningSentence`) reaches title derivation
+inside the first user message text, so the warning — not the question — became
+the chat title, while the transcript kept the real first message (verified via
+`wikictl chat get`: the real first message sat behind a
+warning-titled row).
+
+Row design (operator-directed, refined once from date-only titles):
+
+- **Title**: (SUPERSEDED — see Follow-up 3 and Follow-up 5 below) the summary-model summary when one exists (`chat.summary`,
+  produced when the summarizer is configured and has run), otherwise the
+  stored title — the user's question — with the known preamble warning
+  stripped at display. A title that cleans to nothing (warning-only rows
+  created before the fix) falls back to "New Chat".
+- **Subtitle**: the creation date (abbreviated date, shortened time, user
+  locale), replacing `summary ?? relative-updated`.
+
+Root fix: `ChatSummary.title(fromFirstMessage:)` now strips the known
+preamble (`AgentPresentationPreamble.visibleText(.completeOnly)`) before its
+existing attachment-ref strip / first-line / elide logic. Every title writer
+shares this seam: the daemon's provisional and createChat writes
+(`DaemonChatHost`) and the app's `applyProvisionalChatTitle` / `startChat`.
+Only the exact known warning family is removed — an unrelated "Warning:"
+line stays content. Future chats derive their title from the real question;
+pre-existing warning-titled rows keep their stored title (rename or delete to
+clean those; the list now renders them as "New Chat" until then).
+
+Seams: `ChatsCellView.rowTitle(for:)` / `rowSubtitle(for:)` (pure, tested
+without AppKit hosting). Tab titles, the address bar, and `wikictl` still use
+the stored title.
+
+## Follow-up 2: right-sidebar outline (same day)
+
+The chat detail's right-sidebar outline rendered blank. Diagnosed with
+os_log instrumentation on the live app: the registration pipeline was healthy
+(the trace showed `entries=1` registered for the reported chat), but the
+sidebar renders the outline as a captured snapshot and only re-renders when a
+NEW registration arrives. Session rehydration transiently empties
+`displayProjectionInput` (daemon attaching, history not yet mirrored), the
+sidebar froze that empty frame, and no later trigger ever re-rendered it.
+
+Fix: ChatDetailView re-registers on `.onChange(of:
+remoteSession.displayProjectionInput)` (Equatable), so the sidebar can never
+freeze a stale frame across the rehydrate window — and outline entries track
+live turn growth.
+
+Rows made selectable: entry texts use `.textSelection(.enabled)`, the row
+action is a tap gesture instead of a Button (a Button's press gesture swallows
+the selection drag), and a context menu offers Copy Question / Copy Response
+via the shared `MetadataActionRouter.systemClipboardCopy`. Accessibility
+keeps button traits and a default action.
+
+## Follow-up 3: sidebar row title mirrors the stored title (same day)
+
+The row title initially preferred `chats.summary` (the summary-model output).
+The operator corrected the contract: the sidebar must match the chat's main
+title. `chats.title` already IS "the user's question, or a summary-model
+title when the summarizer stage is configured" — so `rowTitle` is now the
+stored title (preamble-stripped, "New Chat" fallback); `chats.summary` no
+longer appears in the row.
+
+## Follow-up 4: verification round for the outline fix (same day)
+
+The instrumented builds traced the outline through registration (entries=1
+for the reported chat), the sidebar host render (first render 2.3s after the
+chat opened, during the rehydrate window), and the outline view body
+(entries=0 at that render). After the re-registration fix, the operator
+confirmed the outline renders, text is selectable, and row clicks still jump.
+Diagnostic logging removed after verification; the throwaway repro harness
+was never committed.
+
+## Follow-up 5: `chats.summary` removed (schema v53, same day)
+
+Operator decision: the chat-level one-line answer summary should not exist.
+Removed end to end:
+
+- Schema v52→v53 (`dropChatSummaryColumnsV53`): drops `chats.summary` +
+  `chats.summary_at`; both fresh-schema CREATEs no longer define them.
+  Per-message `chat_messages.summary*` columns are kept — they feed the
+  outline's response text.
+- `ChatSummary.summary`/`.summaryAt` removed from the model and every
+  construction site; store SELECTs (`listChats`, `listAllChatsOrderedByID`,
+  `getChat`, chat search) no longer read the columns.
+- `updateChatSummary` removed from the `WikiStore` protocol, `GRDBWikiStore`,
+  and `WikiStoreModel`; both summarizer hosts (daemon `DaemonChatHost` and
+  app `AgentOperationRunner`) no longer mirror a message summary into the
+  chat row. Per-message `updateMessageSummary` writes are unchanged.
+- `MessageSummarizer.chatSummaryMessageID(in:)` removed (its only purpose was
+  picking the mirror source).
+- Sidebar row-diff snapshot no longer mixes the summary into its identity
+  string.
+
+Version asserts updated (52→53) across ChatStore/ChatTurnMetadata/PageVersion/
+BookmarkNode/SourceVersionIDPersistence suites, and two stale entries removed
+from the `ChatAPISignatures.txt` manifest. New migration coverage in
+`SchemaV52MigrationTests` (fresh DB at 53; a hand-built v52 DB with the
+columns migrates to 53 with both columns dropped).
+
+## Follow-up 6: conceptual drift review remediation (same day)
+
+A Paseo-hosted Claude Opus agent ran a read-only conceptual drift review of
+the chat design (`tmp/chat-conceptual-drift-review.md`, 13 findings). In-scope
+remediation implemented on this branch:
+
+- **F7/F8** — `AGENTS.md` schema pointer corrected (`GRDBWikiStore.swift`,
+  three-table split); `plans/chat-summary.md` chat-level row marked Removed
+  (v53); superseded "Row design" bullet annotated; two test comments rewritten
+  to the current contract.
+- **F9** — dead `ChatDetailPresentation.chatInspectorAvailable`,
+  `RemoteState.runStartedAt`, `RemoteState.exitStatus`, and the no-op
+  `hasChatID`/`hasMount` parameters deleted (call sites in
+  Issue235/ChatViewD2 suites updated).
+- **F10** — row-diff snapshot keys on `id|title` only; `updatedAt` dropped (it
+  forced a full table reload per message append for zero visible change).
+- **F2** — all nine test files now reference
+  `AgentPresentationPreamble.knownWarningSentence` instead of re-typing the
+  vendor banner; near-miss canary added to `visibleText` (a reworded banner
+  logs via `DebugLog.chatLive` instead of failing silently).
+- **F5** — both app-side `applyProvisionalChatTitle` calls now pass the wire
+  message, so the app and daemon title writers converge byte-for-byte instead
+  of relying on `stripAttachmentRefs` inverting `buildWireMessage`.
+- **F11/F12b** — schema-version asserts read `GRDBWikiStore.schemaVersion`
+  where suites mean "current"; `SchemaV52MigrationTests` renamed to
+  `SchemaMigrationLadderTests`; the v52→v53 migration test now seeds chat +
+  message rows and asserts survival.
+
+Filed as follow-up issues (v54-scale or own-PR): F1 sidebar registration
+carries data, F4 `title(fromFirstMessage:)` returns `String?`, F6/F3-B
+summary-column move + legacy backfill.
+
+## Verification
+
+- `WIKIFS_APP_TESTS=1 swift test --filter 'ChatsListRowDisplayTests|ChatTitleTests'`
+  — 13 tests pass: summary-as-title, question fallback, warning-title cleanup
+  fallback, created-date subtitle; derivation strips the preamble, falls back
+  for warning-only messages, and preserves unrelated Warning lines.
+- `make build` and `make test` pass (4381 tests in 469 suites).


### PR DESCRIPTION
## Problem

Several chats carried the persisted title "Warning: Skill descriptions were shortened to fit the 2% skills context budget." The warning headline dominated those rows in the left-hand chat list. A later check on one reported chat showed the row title still wrong even after the first fix — its cached summary, not the title, carried the banner.

## Cause

The known agent preamble (`AgentPresentationPreamble.knownWarningSentence`) reaches title and summary derivation inside message text:

- `ChatSummary.title(fromFirstMessage:)` took the first line of a preamble-prefixed first message, so the warning became the title.
- The summarizer-stage backend is itself an ACP agent and prepends the same warning to its own reply. `MessageSummarizer.oneShotReply` cached that reply verbatim, so the warning landed inside `chats.summary`.

## Change

Row design in the left-hand chat list:

- Title: the summary-model summary when one exists and is clean. Otherwise the stored title — the user's question — with the known warning stripped at display. A summary that still carries the warning is treated as tainted and skipped (existing cached rows). A title that cleans to nothing falls back to "New Chat".
- Subtitle: the creation date.

Root fixes:

- `ChatSummary.title(fromFirstMessage:)` strips the known preamble before its existing attachment-ref strip, first-line extraction, and elision. Only the exact known warning family is removed; an unrelated "Warning:" line stays content. Future chats title from the real question.
- `MessageSummarizer.oneShotReply` strips the preamble from the summarizer backend's reply, so no new cached summary or model title carries the banner. A warning-only reply yields nil and stays retriable.

Scope: the list view only. Tab titles, the address bar, and `wikictl` still use the stored title.

## Also in this PR: the right-sidebar outline rendered blank

The chat detail's right-sidebar outline rendered as a blank panel. os_log instrumentation on the live app traced it: registration was healthy (the reported chat registered 1 outline entry), but the sidebar renders the outline as a captured snapshot and only re-renders when a new registration arrives. Session rehydration transiently empties `displayProjectionInput` (the daemon attaches before history is mirrored), the sidebar froze that empty frame, and nothing re-rendered it later.

Fix: ChatDetailView re-registers on `.onChange(of: remoteSession.displayProjectionInput)` (Equatable), so the sidebar tracks the rehydrate window and live turn growth.

Outline rows are also selectable now: entry texts use `.textSelection(.enabled)`, the row action moved from a Button to a tap gesture (a Button's press gesture swallows selection drags), and a context menu offers Copy Question / Copy Response via the shared clipboard helper. Button accessibility traits are preserved.

## Also in this PR: the sidebar row title mirrors the stored title

An intermediate revision preferred `chats.summary` (the summary-model's answer summary) as the row title, which diverged from the chat's main title once the summarizer stage generated a title. The row now always shows the stored title — preamble-stripped, "New Chat" fallback — which is the user's question, or the summary-model title when that stage is configured. Identical to the tab title and chat header. Pre-existing warning-titled rows keep their stored database values; the list renders them correctly via the display guards.

## Also in this PR: conceptual drift review remediation

A Paseo-hosted Claude Opus agent ran a read-only drift review of the chat design (report preserved at `tmp/chat-conceptual-drift-review.md` on the authoring machine; findings F1–F13). In-scope remediation:

- **Docs** (F7): `AGENTS.md` schema pointer corrected (`GRDBWikiStore.swift`, three-table split); `plans/chat-summary.md` chat-level row marked Removed; superseded row-design bullet annotated; two test comments rewritten to the current contract (F8).
- **Deletions** (F9): dead `chatInspectorAvailable`, `RemoteState.runStartedAt`, `RemoteState.exitStatus`, and the no-op `hasChatID`/`hasMount` parameters.
- **Row diff** (F10): keys on `id|title` only — `updatedAt` forced a full table reload per message append for zero visible change.
- **Warning literal** (F2): nine test files reference `AgentPresentationPreamble.knownWarningSentence` instead of re-typing the vendor banner; near-miss canary added to `visibleText` (a reworded banner logs via `DebugLog.chatLive` instead of failing silently).
- **Title writers** (F5): both app-side `applyProvisionalChatTitle` calls pass the wire message, so app and daemon writers converge byte-for-byte instead of relying on `stripAttachmentRefs` inverting `buildWireMessage`.
- **Version asserts** (F11/F12b) read `GRDBWikiStore.schemaVersion` where suites mean "current"; `SchemaV52MigrationTests` renamed `SchemaMigrationLadderTests`; the v53 migration test now seeds rows and asserts survival.

Follow-up issues filed for the v54-scale/own-PR items: sidebar registration carries data (F1), `title(fromFirstMessage:)` returns `String?` (F4), summary-column move + legacy backfill (F6/F3-B).

## Also in this PR: `chats.summary` removed (schema v53)

The chat-level one-line answer summary is gone end to end:

- Schema v52→v53 (`dropChatSummaryColumnsV53`) drops `chats.summary` and `chats.summary_at`; both fresh-schema definitions no longer create them. Per-message `chat_messages.summary*` columns are kept — they feed the outline's response text.
- `ChatSummary.summary` / `.summaryAt` removed from the model; all store SELECTs stop reading the columns.
- `updateChatSummary` removed from the `WikiStore` protocol, `GRDBWikiStore`, and `WikiStoreModel`. Both summarizer hosts (daemon `DaemonChatHost`, app `AgentOperationRunner`) no longer mirror a message summary into the chat row; per-message writes are unchanged. `MessageSummarizer.chatSummaryMessageID(in:)` had no other purpose and is removed.
- Version asserts updated (52→53) in five suites; two stale entries removed from the `ChatAPISignatures.txt` manifest; new migration coverage in `SchemaV52MigrationTests`.

## Tests

- `WIKIFS_APP_TESTS=1 swift test --filter 'ChatsListRowDisplayTests|MessageSummaryTests|ChatTitleTests'`: 58 tests pass. New coverage: tainted-summary fallback to the question, `oneShotReply` strips the preamble from the backend reply, warning-only reply yields nil, derivation strips the preamble and preserves unrelated Warning lines, created-date subtitle.
- `make build` and `make test` pass (4383 tests; one unrelated extractor-subprocess timeout flaked once and passed in isolation, then the full suite passed on rerun).
